### PR TITLE
feature2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,14 +24,14 @@
     "brew-formula": {
       "defaultRegistryUrlTemplate": "https://formulae.brew.sh/api/formula/{{{packageName}}}.json",
       "transformTemplates": [
-        "{ \"releases\": [ { \"version\": versions.stable, \"isDeprecated\": deprecated, \"releaseTimestamp\": generated_date & 'T00:00:00Z', \"digest\": urls.stable.checksum } ], \"homepage\": homepage, \"sourceUrl\": (urls.head.url ? urls.head.url : homepage) }"
+        "{ \"releases\": [ { \"version\": versions.stable, \"isDeprecated\": deprecated, \"digest\": urls.stable.checksum } ], \"homepage\": homepage, \"sourceUrl\": (urls.head.url ? urls.head.url : homepage), \"changelogUrl\": ($contains($string(urls.head.url ? urls.head.url : homepage), 'github.com') ? $join([$replace((urls.head.url ? urls.head.url : homepage), /\\.git$/, ''), '/releases'], '') : '') }"
       ],
       "format": "json"
     },
     "brew-cask": {
       "defaultRegistryUrlTemplate": "https://formulae.brew.sh/api/cask/{{{packageName}}}.json",
       "transformTemplates": [
-        "{ \"releases\": [ { \"version\": version, \"isDeprecated\": deprecated, \"releaseTimestamp\": generated_date & 'T00:00:00Z', \"digest\": sha256 } ], \"homepage\": homepage, \"sourceUrl\": homepage }"
+        "{ \"releases\": [ { \"version\": version, \"isDeprecated\": deprecated, \"digest\": sha256 } ], \"homepage\": homepage, \"sourceUrl\": homepage, \"changelogUrl\": ($contains($string(homepage), 'github.com') ? $join([$replace((homepage), /\\.git$/, ''), '/releases'], '') : '') }"
       ],
       "format": "json"
     }


### PR DESCRIPTION
- **chore(renovate): transformTemplatesを変更**
- **fix(renovate): templateの調整**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renovate の設定を更新し、brew-formula と brew-cask のカスタムデータソース用テンプレートを調整。
  * releaseTimestamp を削除し、GitHub の場合に自動生成される changelogUrl を追加。
  * digest / sourceUrl / homepage は維持しつつ出力構造を整理。
  * 影響: Renovate の依存更新PRで変更履歴リンクが表示されやすくなり、タイムスタンプは出力されなくなります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->