### PR TITLE
Introduce secretlint and lefthook for pre-push checks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -77,3 +77,17 @@ jobs:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       - name: taplo
         run: taplo format --check
+
+  lint-secret:
+    if: ${{ ! endsWith(github.actor, '[bot]')}}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: secretlint/secretlint-github-action@e89104082260773d2a71536b3602f37c768a1835 # v0.8.0
+        with:
+          secretlintrc: .secretlintrc.json

--- a/.secretlintrc.json
+++ b/.secretlintrc.json
@@ -1,0 +1,7 @@
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-preset-recommend"
+    }
+  ]
+}

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -21,6 +21,7 @@ ASDF_FFMPEG_ENABLE = "gpl libx264"
 "aqua:dlvhdr/diffnav"                                       = "0.11.0"
 "aqua:dlvhdr/gh-dash"                                       = "4.23.2"
 "aqua:docker/cli"                                           = "29.3.0"
+"aqua:evilmartians/lefthook"                                = "2.1.4"
 "aqua:gitui-org/gitui"                                      = "0.22.1"
 "aqua:golangci/golangci-lint"                               = "2.11.3"
 "aqua:hadolint/hadolint"                                    = "2.14.0"
@@ -36,6 +37,7 @@ ASDF_FFMPEG_ENABLE = "gpl libx264"
 "aqua:pnpm/pnpm"                                            = "10.32.1"
 "aqua:rhysd/actionlint"                                     = "1.7.11"
 "aqua:samwho/spacer"                                        = "0.5.0"
+"aqua:secretlint/secretlint"                                = "11.4.1"
 "aqua:sharkdp/bat"                                          = "0.26.1"
 "aqua:sinclairtarget/git-who"                               = "1.3"
 "aqua:skanehira/rtty"                                       = "0.4.0"
@@ -129,6 +131,7 @@ description = "Run all action linters"
 [tasks.lint-other]
 depends = [
     "lint-json",
+    "lint-secret",
     "lint-toml",
     "lint-yaml",
 ]
@@ -213,3 +216,8 @@ run         = "prettier --check '**/*.json'"
 [tasks.fix-json]
 description = "Run fix json files"
 run         = "prettier --write '**/*.json'"
+
+# secret
+[tasks.lint-secret]
+description = "Run secretlint"
+run         = "secretlint '**/*'"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,4 @@
+pre-push:
+  commands:
+    lint-secret:
+      run: mise run lint-secret

--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,7 @@ description = "Run all action linters"
 [tasks.lint-other]
 depends = [
     "lint-json",
+    "lint-secret",
     "lint-toml",
     "lint-yaml",
 ]
@@ -77,6 +78,12 @@ description = "Run fix json files"
 hide        = true
 run         = "prettier --write --list-different '**/*.json'"
 
+# secret
+[tasks.lint-secret]
+description = "Run secretlint"
+hide        = true
+run         = "secretlint '**/*'"
+
 [tasks.karabiner-apply]
 description = "build and apply karabiner.ts configuration"
 run = [
@@ -93,6 +100,8 @@ run = [
 
 [tools]
 actionlint                     = "1.7.7"
+"aqua:evilmartians/lefthook"   = "2.1.4"
+"aqua:secretlint/secretlint"   = "11.4.1"
 "aqua:suzuki-shunsuke/ghalint" = "1.5.5"
 "npm:@taplo/cli"               = "0.7.0"
 "npm:prettier"                 = "3.8.1"


### PR DESCRIPTION
This PR introduces `secretlint` for secret detection and `lefthook` for Git hook management. A `pre-push` hook is configured to ensure that no secrets are pushed to the repository. The setup is integrated into the existing `mise` task runner and GitHub Actions CI.

---
*PR created automatically by Jules for task [1706749756852746625](https://jules.google.com/task/1706749756852746625) started by @ryo246912*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

秘密情報（API キーなど）の漏洩防止を目的とした `secretlint` と Git フック管理ツール `lefthook` を導入しました。以下のファイルが追加・変更されました：

- `.secretlintrc.json`：推奨ルールセットを使用した secretlint 設定
- `lefthook.yml`：pre-push フックで `mise run lint-secret` を実行
- `.github/workflows/lint.yaml`：`lint-secret` ジョブを追加（`secretlint/secretlint-github-action` を実行）
- `mise.toml` および `dot_config/mise/config.toml`：`aqua:evilmartians/lefthook` (v2.1.4) と `aqua:secretlint/secretlint` (v11.4.1) ツールを追加、`lint-secret` タスク（`secretlint '**/*'` を実行）を定義

## 変更理由

秘密情報の誤コミットを防ぐために、Git push 前の段階で secretlint によるスキャンを自動実行する仕組みを整備しました。CI パイプラインにも統合することで、リポジトリ全体の検査体制を強化しています。

## 確認した項目

- secretlint の推奨ルールセットが正しく設定されている
- pre-push フックが mise タスクを経由して lint-secret を実行する構成
- GitHub Actions ワークフローが秘密検出ジョブを含む（タイムアウト 1 分、最小権限の原則に従った権限設定）
- 両方の mise 設定ファイル（`mise.toml` と `dot_config/mise/config.toml`）に一貫してツールとタスクが定義されている

<!-- end of auto-generated comment: release notes by coderabbit.ai -->