### PR TITLE
Group Atuin CLI and Docker image updates in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,16 @@
   "devcontainer": {
     "managerFilePatterns": ["dot_config/devcontainer/**/devcontainer.json"]
   },
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "atuinsh/atuin",
+        "aqua:atuinsh/atuin",
+        "ghcr.io/atuinsh/atuin"
+      ],
+      "groupName": "atuin"
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Updated `.github/renovate.json` to group Atuin-related updates (CLI and Docker image) into a single Pull Request by adding a `packageRules` entry with a common `groupName`.

---
*PR created automatically by Jules for task [11824963166249144486](https://jules.google.com/task/11824963166249144486) started by @ryo246912*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

`.github/renovate.json` に `packageRules` 設定を追加し、Atuin 関連の3つのパッケージ（`atuinsh/atuin`、`aqua:atuinsh/atuin`、`ghcr.io/atuinsh/atuin`）を同じグループ名 `"atuin"` でグループ化しました。これにより、Renovate はこれらのパッケージの更新を1つのプルリクエストにまとめるようになります。

## 変更理由

Atuin の CLI バージョンと Docker イメージ、aqua 経由でのバージョン管理が異なるパッケージとして認識されるため、それぞれの更新が複数の PR に分散していました。これを一つの PR にまとめることで、関連する更新を同時に確認・管理し、レビュープロセスを効率化します。

## 確認した項目

- `.github/renovate.json` の構文は正常で、既存の設定（`prHourlyLimit`、`reviewers`、`minimumReleaseAge` など）に影響なし
- `matchPackageNames` に指定された3つのパッケージは、実際に利用されているバージョン定義ファイルで確認できる Atuin パッケージ
- `groupName` の設定により、Renovate の PR グループ化ロジックに正しく統合される

<!-- end of auto-generated comment: release notes by coderabbit.ai -->