### PR TITLE
DOTFILE-34: nvimでVSCodeみたいな設定

### DIFF
--- a/dot_config/nvim/lua/core/file_actions.lua
+++ b/dot_config/nvim/lua/core/file_actions.lua
@@ -1,0 +1,575 @@
+local M = {}
+
+local state = {
+  setup_done = false,
+  formatting_buffers = {},
+}
+
+local function joinpath(...)
+  return table.concat(vim.tbl_flatten({ ... }), "/")
+end
+
+local function buf_path(bufnr)
+  local path = vim.api.nvim_buf_get_name(bufnr)
+  if path == "" then
+    return nil
+  end
+  return vim.fs.normalize(path)
+end
+
+local function buf_is_file(bufnr)
+  return vim.bo[bufnr].buftype == "" and buf_path(bufnr) ~= nil
+end
+
+local function read_json(path)
+  if vim.fn.filereadable(path) == 0 then
+    return nil
+  end
+
+  local ok, decoded = pcall(vim.json.decode, table.concat(vim.fn.readfile(path), "\n"))
+  if ok then
+    return decoded
+  end
+  return nil
+end
+
+local function has_file(path)
+  return vim.uv.fs_stat(path) ~= nil
+end
+
+local function relpath(root, path)
+  if not root then
+    return path
+  end
+
+  local relative = vim.fs.relpath(root, path)
+  if relative == nil or relative == "" then
+    return path
+  end
+  return relative
+end
+
+local function root(path, markers)
+  local ok, result = pcall(vim.fs.root, path, markers)
+  if ok then
+    return result
+  end
+  return nil
+end
+
+local function executable(path)
+  return path ~= nil and vim.fn.executable(path) == 1
+end
+
+local function resolve_binary(root_dir, names)
+  local mason_bin = joinpath(vim.fn.stdpath("data"), "mason", "bin")
+
+  for _, name in ipairs(names) do
+    local candidates = {}
+
+    if root_dir then
+      table.insert(candidates, joinpath(root_dir, "node_modules", ".bin", name))
+      table.insert(candidates, joinpath(root_dir, ".venv", "bin", name))
+    end
+
+    table.insert(candidates, joinpath(mason_bin, name))
+    table.insert(candidates, name)
+
+    for _, candidate in ipairs(candidates) do
+      if executable(candidate) then
+        return candidate
+      end
+    end
+  end
+
+  return nil
+end
+
+local function shell_join(parts)
+  return table.concat(vim.tbl_map(vim.fn.shellescape, parts), " ")
+end
+
+local function current_context(bufnr)
+  local path = buf_path(bufnr)
+  local dir = path and vim.fs.dirname(path) or vim.loop.cwd()
+  local git_root = path and root(path, { ".git" }) or vim.loop.cwd()
+  local node_root = path and root(path, { "package.json", "pnpm-lock.yaml", "bun.lock", "bun.lockb", "yarn.lock", "package-lock.json" }) or nil
+  local python_root = path and root(path, { "pyproject.toml", "uv.lock", "requirements.txt", ".venv", "setup.py" }) or nil
+  local go_root = path and root(path, { "go.mod" }) or nil
+
+  return {
+    bufnr = bufnr,
+    path = path,
+    dir = dir,
+    filetype = vim.bo[bufnr].filetype,
+    git_root = git_root,
+    node_root = node_root,
+    python_root = python_root,
+    go_root = go_root,
+    project_root = node_root or python_root or go_root or git_root or dir,
+  }
+end
+
+local function package_manager(node_root)
+  if node_root == nil then
+    return nil
+  end
+
+  if has_file(joinpath(node_root, "pnpm-lock.yaml")) then
+    return "pnpm"
+  end
+  if has_file(joinpath(node_root, "bun.lock")) or has_file(joinpath(node_root, "bun.lockb")) then
+    return "bun"
+  end
+  if has_file(joinpath(node_root, "yarn.lock")) then
+    return "yarn"
+  end
+  return "npm"
+end
+
+local function package_script(node_root, name)
+  if node_root == nil then
+    return false
+  end
+
+  local package_json = read_json(joinpath(node_root, "package.json"))
+  return package_json ~= nil and package_json.scripts ~= nil and package_json.scripts[name] ~= nil
+end
+
+local function lsp_format_client(bufnr, preferred_names)
+  for _, client in ipairs(vim.lsp.get_clients({ bufnr = bufnr })) do
+    if client:supports_method("textDocument/formatting") then
+      if preferred_names == nil or vim.tbl_contains(preferred_names, client.name) then
+        return client
+      end
+    end
+  end
+  return nil
+end
+
+local function resolve_formatter(ctx)
+  if ctx.path == nil then
+    return nil
+  end
+
+  local ft = ctx.filetype
+
+  if vim.tbl_contains({
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "json",
+    "jsonc",
+    "yaml",
+    "graphql",
+  }, ft) then
+    local prettier = resolve_binary(ctx.node_root or ctx.project_root, { "prettier" })
+    if prettier then
+      return {
+        kind = "cli",
+        label = "Prettier で format",
+        cmd = prettier,
+        args = { "--write", ctx.path },
+        cwd = ctx.node_root or ctx.project_root or ctx.dir,
+      }
+    end
+  end
+
+  if ft == "python" then
+    local ruff = resolve_binary(ctx.python_root or ctx.project_root, { "ruff" })
+    if ruff then
+      return {
+        kind = "cli",
+        label = "ruff format",
+        cmd = ruff,
+        args = { "format", ctx.path },
+        cwd = ctx.python_root or ctx.project_root or ctx.dir,
+      }
+    end
+  end
+
+  if ft == "toml" then
+    local taplo = resolve_binary(ctx.project_root, { "taplo" })
+    if taplo then
+      return {
+        kind = "cli",
+        label = "taplo format",
+        cmd = taplo,
+        args = { "format", ctx.path },
+        cwd = ctx.project_root or ctx.dir,
+      }
+    end
+  end
+
+  if ft == "terraform" or ft == "terraform-vars" then
+    local terraform = resolve_binary(ctx.project_root, { "terraform" })
+    if terraform then
+      return {
+        kind = "cli",
+        label = "terraform fmt",
+        cmd = terraform,
+        args = { "fmt", ctx.path },
+        cwd = ctx.dir,
+      }
+    end
+  end
+
+  if ft == "go" then
+    local gofmt = resolve_binary(ctx.go_root or ctx.project_root, { "gofmt" })
+    if gofmt then
+      return {
+        kind = "cli",
+        label = "gofmt -w",
+        cmd = gofmt,
+        args = { "-w", ctx.path },
+        cwd = ctx.go_root or ctx.project_root or ctx.dir,
+      }
+    end
+  end
+
+  local preferred = nil
+  if ft == "python" then
+    preferred = { "ruff" }
+  elseif ft == "javascript" or ft == "javascriptreact" or ft == "typescript" or ft == "typescriptreact" then
+    preferred = { "ts_ls", "tsserver", "vtsls" }
+  end
+
+  local client = lsp_format_client(ctx.bufnr, preferred)
+  if client ~= nil then
+    return {
+      kind = "lsp",
+      label = "LSP format",
+      client_name = client.name,
+    }
+  end
+
+  return nil
+end
+
+local function run_cli_formatter(ctx, formatter, opts)
+  opts = opts or {}
+  local previous_state = state.formatting_buffers[ctx.bufnr]
+  state.formatting_buffers[ctx.bufnr] = true
+
+  if not opts.from_save then
+    vim.api.nvim_buf_call(ctx.bufnr, function()
+      vim.cmd("silent update")
+    end)
+  end
+
+  local result = vim.system(vim.list_extend({ formatter.cmd }, formatter.args or {}), {
+    cwd = formatter.cwd,
+    text = true,
+  }):wait()
+
+  if result.code ~= 0 then
+    local stderr = (result.stderr or result.stdout or ""):gsub("%s+$", "")
+    state.formatting_buffers[ctx.bufnr] = previous_state
+    vim.notify(("format に失敗しました: %s"):format(stderr), vim.log.levels.ERROR)
+    return false
+  end
+
+  if vim.api.nvim_buf_is_valid(ctx.bufnr) then
+    vim.api.nvim_buf_call(ctx.bufnr, function()
+      vim.cmd("silent noautocmd edit")
+    end)
+  end
+
+  if not opts.silent then
+    vim.notify(formatter.label .. " を実行しました", vim.log.levels.INFO)
+  end
+  state.formatting_buffers[ctx.bufnr] = previous_state
+  return true
+end
+
+local function run_lsp_formatter(ctx, formatter, opts)
+  opts = opts or {}
+
+  local ok, err = pcall(vim.lsp.buf.format, {
+    bufnr = ctx.bufnr,
+    async = false,
+    timeout_ms = 3000,
+    filter = function(client)
+      return formatter.client_name == nil or client.name == formatter.client_name
+    end,
+  })
+
+  if not ok then
+    vim.notify(("LSP format に失敗しました: %s"):format(err), vim.log.levels.ERROR)
+    return false
+  end
+
+  if not opts.silent then
+    vim.notify(formatter.label .. " を実行しました", vim.log.levels.INFO)
+  end
+  return true
+end
+
+function M.format_buffer(opts)
+  opts = opts or {}
+  local bufnr = opts.buf or vim.api.nvim_get_current_buf()
+
+  if not buf_is_file(bufnr) then
+    vim.notify("保存済みファイルで実行してください", vim.log.levels.WARN)
+    return false
+  end
+
+  local ctx = current_context(bufnr)
+  local formatter = resolve_formatter(ctx)
+  if formatter == nil then
+    vim.notify("利用できる formatter が見つかりません", vim.log.levels.WARN)
+    return false
+  end
+
+  if formatter.kind == "cli" then
+    return run_cli_formatter(ctx, formatter, opts)
+  end
+  return run_lsp_formatter(ctx, formatter, opts)
+end
+
+local function add_action(actions, action)
+  table.insert(actions, action)
+end
+
+local function add_shell_action(actions, label, parts, cwd)
+  add_action(actions, {
+    label = label,
+    run = function()
+      local ok, terminal = pcall(require, "toggleterm.terminal")
+      if not ok then
+        vim.notify("toggleterm.nvim の読み込みに失敗しました", vim.log.levels.ERROR)
+        return
+      end
+
+      terminal.Terminal:new({
+        cmd = shell_join(parts),
+        cwd = cwd,
+        direction = "float",
+        hidden = true,
+        close_on_exit = false,
+        float_opts = {
+          border = "curved",
+        },
+      }):toggle()
+    end,
+  })
+end
+
+function M.available_actions(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  local ctx = current_context(bufnr)
+  local actions = {}
+  local formatter = resolve_formatter(ctx)
+
+  if formatter ~= nil then
+    add_action(actions, {
+      label = formatter.label,
+      run = function()
+        M.format_buffer({ buf = bufnr })
+      end,
+    })
+  end
+
+  if ctx.node_root ~= nil and ctx.path ~= nil then
+    local relative_file = relpath(ctx.node_root, ctx.path)
+    local pm = package_manager(ctx.node_root)
+    local eslint = resolve_binary(ctx.node_root, { "eslint" })
+    local vitest = resolve_binary(ctx.node_root, { "vitest" })
+    local jest = resolve_binary(ctx.node_root, { "jest" })
+
+    if eslint then
+      add_shell_action(actions, "eslint --fix", { eslint, "--fix", relative_file }, ctx.node_root)
+    elseif package_script(ctx.node_root, "lint") and pm ~= nil then
+      if pm == "pnpm" then
+        add_shell_action(actions, "pnpm lint", { "pnpm", "lint", "--", relative_file }, ctx.node_root)
+      elseif pm == "bun" then
+        add_shell_action(actions, "bun run lint", { "bun", "run", "lint", "--", relative_file }, ctx.node_root)
+      elseif pm == "yarn" then
+        add_shell_action(actions, "yarn lint", { "yarn", "lint", relative_file }, ctx.node_root)
+      else
+        add_shell_action(actions, "npm run lint", { "npm", "run", "lint", "--", relative_file }, ctx.node_root)
+      end
+    end
+
+    if vitest then
+      add_shell_action(actions, "vitest run", { vitest, "run", relative_file }, ctx.node_root)
+    elseif jest then
+      add_shell_action(actions, "jest", { jest, relative_file }, ctx.node_root)
+    elseif package_script(ctx.node_root, "test") and pm ~= nil then
+      if pm == "pnpm" then
+        add_shell_action(actions, "pnpm test", { "pnpm", "test", "--", relative_file }, ctx.node_root)
+      elseif pm == "bun" then
+        add_shell_action(actions, "bun run test", { "bun", "run", "test", "--", relative_file }, ctx.node_root)
+      elseif pm == "yarn" then
+        add_shell_action(actions, "yarn test", { "yarn", "test", relative_file }, ctx.node_root)
+      else
+        add_shell_action(actions, "npm run test", { "npm", "run", "test", "--", relative_file }, ctx.node_root)
+      end
+    end
+  end
+
+  if ctx.filetype == "python" and ctx.path ~= nil then
+    local python_root = ctx.python_root or ctx.project_root
+    local relative_file = relpath(python_root, ctx.path)
+    local ruff = resolve_binary(python_root, { "ruff" })
+    local pytest = resolve_binary(python_root, { "pytest" })
+
+    if ruff then
+      add_shell_action(actions, "ruff check", { ruff, "check", relative_file }, python_root or ctx.dir)
+    end
+    if pytest then
+      add_shell_action(actions, "pytest", { pytest, relative_file }, python_root or ctx.dir)
+    end
+  end
+
+  if ctx.filetype == "go" and ctx.path ~= nil then
+    local cwd = ctx.dir
+    local golangci = resolve_binary(ctx.go_root or ctx.project_root, { "golangci-lint" })
+    add_shell_action(actions, "go test .", { "go", "test", "." }, cwd)
+    if golangci then
+      add_shell_action(actions, "golangci-lint run .", { golangci, "run", "." }, cwd)
+    end
+  end
+
+  if (ctx.filetype == "terraform" or ctx.filetype == "terraform-vars") and ctx.path ~= nil then
+    local terraform = resolve_binary(ctx.project_root, { "terraform" })
+    if terraform then
+      add_shell_action(actions, "terraform validate", { terraform, "validate" }, ctx.dir)
+    end
+  end
+
+  if ctx.filetype == "toml" and ctx.path ~= nil then
+    local taplo = resolve_binary(ctx.project_root, { "taplo" })
+    if taplo then
+      add_shell_action(actions, "taplo lint", { taplo, "lint", ctx.path }, ctx.project_root or ctx.dir)
+    end
+  end
+
+  return actions
+end
+
+function M.pick_current_file_action(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  local actions = M.available_actions(bufnr)
+
+  if vim.tbl_isempty(actions) then
+    vim.notify("現在ファイル向けに解決できる action がありません", vim.log.levels.WARN)
+    return
+  end
+
+  vim.ui.select(vim.tbl_map(function(action)
+    return action.label
+  end, actions), {
+    prompt = "Current file action を選択",
+  }, function(_, idx)
+    local action = idx and actions[idx] or nil
+    if action ~= nil then
+      action.run()
+    end
+  end)
+end
+
+local function save_hooks_enabled()
+  if vim.g.save_hooks_enabled == nil then
+    vim.g.save_hooks_enabled = true
+  end
+  return vim.g.save_hooks_enabled
+end
+
+local function save_hook_should_run(bufnr)
+  return save_hooks_enabled() and buf_is_file(bufnr) and not state.formatting_buffers[bufnr]
+end
+
+local function save_hook_pre(args)
+  if not save_hook_should_run(args.buf) then
+    return
+  end
+
+  local formatter = resolve_formatter(current_context(args.buf))
+  if formatter ~= nil and formatter.kind == "lsp" then
+    M.format_buffer({ buf = args.buf, silent = true, from_save = true })
+  end
+end
+
+local function save_hook_post(args)
+  if not save_hook_should_run(args.buf) then
+    return
+  end
+
+  local formatter = resolve_formatter(current_context(args.buf))
+  if formatter == nil or formatter.kind ~= "cli" then
+    return
+  end
+
+  state.formatting_buffers[args.buf] = true
+  M.format_buffer({ buf = args.buf, silent = true, from_save = true })
+  state.formatting_buffers[args.buf] = nil
+end
+
+local function create_save_hook_commands()
+  pcall(vim.api.nvim_del_user_command, "CurrentFileActions")
+  pcall(vim.api.nvim_del_user_command, "FormatBuffer")
+  pcall(vim.api.nvim_del_user_command, "SaveHooksEnable")
+  pcall(vim.api.nvim_del_user_command, "SaveHooksDisable")
+  pcall(vim.api.nvim_del_user_command, "SaveHooksToggle")
+
+  vim.api.nvim_create_user_command("CurrentFileActions", function()
+    M.pick_current_file_action()
+  end, {})
+  vim.api.nvim_create_user_command("FormatBuffer", function()
+    M.format_buffer()
+  end, {})
+  vim.api.nvim_create_user_command("SaveHooksEnable", function()
+    vim.g.save_hooks_enabled = true
+    vim.notify("save hook を有効化しました", vim.log.levels.INFO)
+  end, {})
+  vim.api.nvim_create_user_command("SaveHooksDisable", function()
+    vim.g.save_hooks_enabled = false
+    vim.notify("save hook を無効化しました", vim.log.levels.INFO)
+  end, {})
+  vim.api.nvim_create_user_command("SaveHooksToggle", function()
+    vim.g.save_hooks_enabled = not save_hooks_enabled()
+    local status = save_hooks_enabled() and "有効" or "無効"
+    vim.notify("save hook を " .. status .. " にしました", vim.log.levels.INFO)
+  end, {})
+end
+
+function M.setup()
+  if state.setup_done then
+    return
+  end
+
+  save_hooks_enabled()
+  create_save_hook_commands()
+
+  local group = vim.api.nvim_create_augroup("CurrentFileSaveHooks", { clear = true })
+  vim.api.nvim_create_autocmd("BufWritePre", {
+    group = group,
+    callback = save_hook_pre,
+  })
+  vim.api.nvim_create_autocmd("BufWritePost", {
+    group = group,
+    callback = save_hook_post,
+  })
+
+  vim.keymap.set("n", "<leader>xa", "<cmd>CurrentFileActions<CR>", {
+    noremap = true,
+    silent = true,
+    desc = "現在ファイルの action を実行",
+  })
+  vim.keymap.set("n", "<leader>xf", "<cmd>FormatBuffer<CR>", {
+    noremap = true,
+    silent = true,
+    desc = "現在バッファを format",
+  })
+  vim.keymap.set("n", "<leader>xh", "<cmd>SaveHooksToggle<CR>", {
+    noremap = true,
+    silent = true,
+    desc = "save hook を切り替え",
+  })
+
+  state.setup_done = true
+end
+
+return M

--- a/dot_config/nvim/lua/core/file_actions.lua
+++ b/dot_config/nvim/lua/core/file_actions.lua
@@ -164,14 +164,14 @@ local function resolve_formatter(ctx)
     "yaml",
     "graphql",
   }, ft) then
-    local prettier = resolve_binary(ctx.node_root or ctx.project_root, { "prettier" })
-    if prettier then
+    local oxfmt = resolve_binary(ctx.project_root, { "oxfmt" })
+    if oxfmt then
       return {
         kind = "cli",
-        label = "Prettier で format",
-        cmd = prettier,
-        args = { "--write", ctx.path },
-        cwd = ctx.node_root or ctx.project_root or ctx.dir,
+        label = "oxfmt で format",
+        cmd = oxfmt,
+        args = { ctx.path },
+        cwd = ctx.project_root or ctx.dir,
       }
     end
   end

--- a/dot_config/nvim/lua/core/file_actions.lua
+++ b/dot_config/nvim/lua/core/file_actions.lua
@@ -6,7 +6,7 @@ local state = {
 }
 
 local function joinpath(...)
-  return table.concat(vim.tbl_flatten({ ... }), "/")
+  return vim.fs.joinpath(...)
 end
 
 local function buf_path(bufnr)
@@ -92,7 +92,7 @@ end
 local function current_context(bufnr)
   local path = buf_path(bufnr)
   local dir = path and vim.fs.dirname(path) or vim.loop.cwd()
-  local git_root = path and root(path, { ".git" }) or vim.loop.cwd()
+  local git_root = path and root(path, { ".git" }) or nil
   local node_root = path and root(path, { "package.json", "pnpm-lock.yaml", "bun.lock", "bun.lockb", "yarn.lock", "package-lock.json" }) or nil
   local python_root = path and root(path, { "pyproject.toml", "uv.lock", "requirements.txt", ".venv", "setup.py" }) or nil
   local go_root = path and root(path, { "go.mod" }) or nil
@@ -258,10 +258,17 @@ local function run_cli_formatter(ctx, formatter, opts)
     end)
   end
 
-  local result = vim.system(vim.list_extend({ formatter.cmd }, formatter.args or {}), {
+  local obj = vim.system(vim.list_extend({ formatter.cmd }, formatter.args or {}), {
     cwd = formatter.cwd,
     text = true,
-  }):wait()
+  })
+  local result = obj:wait(3000)
+  if not result then
+    obj:kill(9)
+    state.formatting_buffers[ctx.bufnr] = previous_state
+    vim.notify("format がタイムアウトしました", vim.log.levels.ERROR)
+    return false
+  end
 
   if result.code ~= 0 then
     local stderr = (result.stderr or result.stdout or ""):gsub("%s+$", "")
@@ -503,7 +510,7 @@ local function save_hook_post(args)
   end
 
   state.formatting_buffers[args.buf] = true
-  M.format_buffer({ buf = args.buf, silent = true, from_save = true })
+  pcall(M.format_buffer, { buf = args.buf, silent = true, from_save = true })
   state.formatting_buffers[args.buf] = nil
 end
 

--- a/dot_config/nvim/lua/core/keymaps.lua
+++ b/dot_config/nvim/lua/core/keymaps.lua
@@ -24,6 +24,32 @@ local function go_to_nth_tab(n)
   end
 end
 
+local function exact_word_pattern(word)
+  return string.format("\\V\\<%s\\>", vim.fn.escape(word, [[\]]))
+end
+
+local function ensure_current_word_search()
+  local word = vim.fn.expand("<cword>")
+  if word == nil or word == "" then
+    return
+  end
+
+  local pattern = exact_word_pattern(word)
+  local current = vim.fn.getreg("/")
+
+  if vim.v.hlsearch == 0 or current == "" then
+    vim.fn.setreg("/", pattern)
+    vim.o.hlsearch = true
+  end
+end
+
+local function jump_current_word(direction)
+  return function()
+    ensure_current_word_search()
+    vim.cmd(("normal! %d%s"):format(vim.v.count1, direction))
+  end
+end
+
 -- Key mappings
 -- {n,i,x,c...}[nore]map: [non-recursive] map (n:normal,i:insert,x:visual,c:command lineモード)
 -- xnoremap <key-sequence> <vim-command>
@@ -64,6 +90,8 @@ keymap({ "n", "x" }, "gy", '"+y', { noremap = true })
 
 -- ESC連打でハイライト解除
 keymap("n", "<Esc><Esc>", ":nohlsearch<CR><Esc>", { noremap = true, silent = true })
+keymap("n", "n", jump_current_word("n"), { noremap = true, silent = true, desc = "現在単語/検索結果の次へ移動" })
+keymap("n", "N", jump_current_word("N"), { noremap = true, silent = true, desc = "現在単語/検索結果の前へ移動" })
 
 -- Emacs-like movement in Insert/Command
 keymap({ "i", "c" }, "<C-a>", "<Home>", { noremap = true })

--- a/dot_config/nvim/lua/core/keymaps.lua
+++ b/dot_config/nvim/lua/core/keymaps.lua
@@ -31,7 +31,7 @@ end
 local function ensure_current_word_search()
   local word = vim.fn.expand("<cword>")
   if word == nil or word == "" then
-    return
+    return false
   end
 
   local pattern = exact_word_pattern(word)
@@ -40,12 +40,22 @@ local function ensure_current_word_search()
   if vim.v.hlsearch == 0 or current == "" then
     vim.fn.setreg("/", pattern)
     vim.o.hlsearch = true
+    return true
   end
+
+  return false
 end
 
 local function jump_current_word(direction)
   return function()
-    ensure_current_word_search()
+    local initialized = ensure_current_word_search()
+    if initialized then
+      local flags = direction == "n" and "W" or "bW"
+      for _ = 1, vim.v.count1 do
+        vim.fn.search(vim.fn.getreg("/"), flags)
+      end
+      return
+    end
     vim.cmd(("normal! %d%s"):format(vim.v.count1, direction))
   end
 end

--- a/dot_config/nvim/lua/core/keymaps.lua
+++ b/dot_config/nvim/lua/core/keymaps.lua
@@ -48,14 +48,7 @@ end
 
 local function jump_current_word(direction)
   return function()
-    local initialized = ensure_current_word_search()
-    if initialized then
-      local flags = direction == "n" and "W" or "bW"
-      for _ = 1, vim.v.count1 do
-        vim.fn.search(vim.fn.getreg("/"), flags)
-      end
-      return
-    end
+    ensure_current_word_search()
     vim.cmd(("normal! %d%s"):format(vim.v.count1, direction))
   end
 end

--- a/dot_config/nvim/lua/core/keymaps.lua
+++ b/dot_config/nvim/lua/core/keymaps.lua
@@ -136,3 +136,6 @@ keymap("n", "<A-z>", toggle_window_size, { noremap = true })
 for i = 1, 9 do
   keymap("n", "g" .. i, function() go_to_nth_tab(i) end, { noremap = true })
 end
+
+-- ジャンプリストを戻る (<C-o>の代替)
+keymap("n", "gh", "<C-o>", { noremap = true, desc = "ジャンプリストを戻る" })

--- a/dot_config/nvim/lua/plugins/lsp.lua
+++ b/dot_config/nvim/lua/plugins/lsp.lua
@@ -15,19 +15,249 @@ return {
     config = function()
       local mason_lspconfig = require("mason-lspconfig")
       local capabilities = require("cmp_nvim_lsp").default_capabilities()
-
-      vim.g.lsp_enabled = vim.g.lsp_enabled ~= false
-
-      local available = {}
-      for _, server in ipairs(mason_lspconfig.get_available_servers()) do
-        available[server] = true
+      local function has_lspconfig(server)
+        return #vim.api.nvim_get_runtime_file("lsp/" .. server .. ".lua", false) > 0
       end
 
-      local ts_server = available.ts_ls and "ts_ls" or "tsserver"
-      local servers = { "gopls", "graphql", "taplo", ts_server }
+      vim.g.lsp_enabled = vim.g.lsp_enabled ~= false
+      vim.g.inline_diagnostics_enabled = vim.g.inline_diagnostics_enabled ~= false
+
+      local ts_server = has_lspconfig("ts_ls") and "ts_ls" or "tsserver"
+      local python_server = has_lspconfig("pyright") and "pyright" or (has_lspconfig("basedpyright") and "basedpyright" or nil)
+      local servers = {
+        gopls = {
+          settings = {
+            gopls = {
+              completeUnimported = true,
+              usePlaceholders = true,
+              analyses = {
+                unusedparams = true,
+              },
+            },
+          },
+        },
+        graphql = {
+          filetypes = {
+            "graphql",
+            "javascript",
+            "javascriptreact",
+            "typescript",
+            "typescriptreact",
+          },
+        },
+        jsonls = {},
+        taplo = {},
+        terraformls = {},
+        yamlls = {
+          settings = {
+            yaml = {
+              keyOrdering = false,
+            },
+          },
+        },
+        [ts_server] = {},
+      }
+
+      if python_server then
+        servers[python_server] = {
+          settings = {
+            python = {
+              analysis = {
+                autoImportCompletions = true,
+                diagnosticMode = "workspace",
+                gotoDefinitionInStringLiteral = true,
+                indexing = true,
+                typeCheckingMode = "basic",
+                useLibraryCodeForTypes = true,
+                extraPaths = { ".venv" },
+              },
+            },
+          },
+        }
+      end
+
+      if has_lspconfig("ruff") then
+        servers.ruff = {}
+      end
+
+      local server_names = vim.tbl_keys(servers)
+      table.sort(server_names)
       local server_set = {}
-      for _, server in ipairs(servers) do
+      for _, server in ipairs(server_names) do
         server_set[server] = true
+      end
+
+      local function format_diagnostic_message(diagnostic)
+        local icons = {
+          [vim.diagnostic.severity.ERROR] = "E",
+          [vim.diagnostic.severity.WARN] = "W",
+          [vim.diagnostic.severity.INFO] = "I",
+          [vim.diagnostic.severity.HINT] = "H",
+        }
+        local message = (diagnostic.message or ""):gsub("%s+", " "):gsub("^%s+", ""):gsub("%s+$", "")
+        return string.format("%s %s", icons[diagnostic.severity] or "-", message)
+      end
+
+      local function flatten_locations(result)
+        local locations = {}
+        for _, response in pairs(result or {}) do
+          if response.result then
+            if response.result.uri or response.result.targetUri then
+              table.insert(locations, response.result)
+            else
+              vim.list_extend(locations, response.result)
+            end
+          end
+        end
+        return locations
+      end
+
+      local function show_locations(locations, offset_encoding, title)
+        if vim.tbl_isempty(locations) then
+          return false
+        end
+
+        if #locations == 1 then
+          vim.lsp.util.show_document(locations[1], offset_encoding, { focus = true })
+          return true
+        end
+
+        vim.fn.setqflist({}, " ", {
+          title = title,
+          items = vim.lsp.util.locations_to_items(locations, offset_encoding),
+        })
+        vim.cmd("botright copen")
+        return true
+      end
+
+      local function graphql_root(bufnr)
+        local path = vim.api.nvim_buf_get_name(bufnr)
+        return vim.fs.root(path, {
+          ".graphqlrc.yml",
+          ".graphqlrc.yaml",
+          ".graphqlrc.json",
+          ".graphqlrc.js",
+          ".graphqlrc.cjs",
+          ".graphqlrc.ts",
+          ".graphqlrc.toml",
+          "graphql.config.js",
+          "graphql.config.cjs",
+          "graphql.config.ts",
+          ".git",
+        }) or vim.fs.dirname(path)
+      end
+
+      local function graphql_search(bufnr, mode)
+        if vim.fn.executable("rg") ~= 1 then
+          return false
+        end
+
+        local word = vim.fn.expand("<cword>")
+        if word == nil or word == "" then
+          return false
+        end
+
+        local root_dir = graphql_root(bufnr)
+        local patterns = mode == "definition" and {
+          "\\bfragment\\s+" .. word .. "\\b",
+          "\\btype\\s+" .. word .. "\\b",
+          "\\binput\\s+" .. word .. "\\b",
+          "\\binterface\\s+" .. word .. "\\b",
+          "\\benum\\s+" .. word .. "\\b",
+          "\\bunion\\s+" .. word .. "\\b",
+          "\\bscalar\\s+" .. word .. "\\b",
+          "\\bquery\\s+" .. word .. "\\b",
+          "\\bmutation\\s+" .. word .. "\\b",
+          "\\bsubscription\\s+" .. word .. "\\b",
+          "\\b" .. word .. "\\s*:",
+        } or {
+          "\\b" .. word .. "\\b",
+        }
+
+        local cmd = { "rg", "--vimgrep", "--glob", "*.graphql", "--glob", "*.graphqls", "--glob", "*.gql" }
+        for _, pattern in ipairs(patterns) do
+          table.insert(cmd, "-e")
+          table.insert(cmd, pattern)
+        end
+        table.insert(cmd, root_dir)
+
+        local result = vim.system(cmd, { cwd = root_dir, text = true }):wait()
+        if result.code ~= 0 and (result.stdout == nil or result.stdout == "") then
+          return false
+        end
+
+        local items = {}
+        for line in vim.gsplit(result.stdout or "", "\n", { trimempty = true }) do
+          local filename, lnum, col, text = line:match("^(.-):(%d+):(%d+):(.*)$")
+          if filename and lnum and col then
+            table.insert(items, {
+              filename = filename,
+              lnum = tonumber(lnum),
+              col = tonumber(col),
+              text = text,
+            })
+          end
+        end
+
+        if vim.tbl_isempty(items) then
+          return false
+        end
+
+        vim.fn.setqflist({}, " ", {
+          title = mode == "definition" and ("GraphQL definitions: " .. word) or ("GraphQL references: " .. word),
+          items = items,
+        })
+
+        if #items == 1 then
+          vim.cmd("edit " .. vim.fn.fnameescape(items[1].filename))
+          vim.api.nvim_win_set_cursor(0, { items[1].lnum, math.max(items[1].col - 1, 0) })
+        else
+          vim.cmd("botright copen")
+        end
+
+        return true
+      end
+
+      local function apply_diagnostic_config()
+        vim.diagnostic.config({
+          underline = true,
+          severity_sort = true,
+          update_in_insert = true,
+          virtual_text = vim.g.inline_diagnostics_enabled and {
+            spacing = 2,
+            source = "if_many",
+            prefix = "",
+            format = format_diagnostic_message,
+          } or false,
+          float = {
+            border = "rounded",
+            source = "if_many",
+          },
+        })
+      end
+
+      local function buffer_client(bufnr, names)
+        for _, name in ipairs(names) do
+          for _, attached in ipairs(vim.lsp.get_clients({ bufnr = bufnr })) do
+            if attached.name == name then
+              return attached
+            end
+          end
+        end
+        return nil
+      end
+
+      local function typescript_buffer(bufnr)
+        return vim.tbl_contains({
+          "javascript",
+          "javascriptreact",
+          "typescript",
+          "typescriptreact",
+        }, vim.bo[bufnr].filetype)
+      end
+
+      local function graphql_buffer(bufnr)
+        return vim.bo[bufnr].filetype == "graphql"
       end
 
       local function on_attach(client, bufnr)
@@ -38,10 +268,83 @@ return {
           return
         end
 
+        if vim.b[bufnr].vscode_like_lsp_maps then
+          return
+        end
+
         local opts = { noremap = true, silent = true, buffer = bufnr }
-        vim.keymap.set("n", "gd", vim.lsp.buf.definition, opts)
+
+        local function goto_definition()
+          local ts_client = typescript_buffer(bufnr) and buffer_client(bufnr, { "ts_ls", "tsserver" }) or nil
+          if ts_client then
+            local params = vim.lsp.util.make_position_params(0, ts_client.offset_encoding)
+            ts_client:exec_cmd({
+              command = "_typescript.goToSourceDefinition",
+              title = "Go to source definition",
+              arguments = { params.textDocument.uri, params.position },
+            }, { bufnr = bufnr }, function(err, result)
+              if err then
+                vim.notify("TypeScript source definition に失敗しました: " .. err.message, vim.log.levels.ERROR)
+                return
+              end
+              if result and result[1] then
+                vim.lsp.util.show_document(result[1], ts_client.offset_encoding, { focus = true })
+                return
+              end
+              vim.lsp.buf.definition()
+            end)
+            return
+          end
+
+          local graphql_client = graphql_buffer(bufnr) and buffer_client(bufnr, { "graphql" }) or nil
+          if graphql_client then
+            local locations = {}
+            if graphql_client:supports_method("textDocument/definition") then
+              locations = flatten_locations(vim.lsp.buf_request_sync(
+                bufnr,
+                "textDocument/definition",
+                vim.lsp.util.make_position_params(0, graphql_client.offset_encoding),
+                1500
+              ))
+            end
+            if show_locations(locations, graphql_client.offset_encoding, "GraphQL definitions") then
+              return
+            end
+            if graphql_search(bufnr, "definition") then
+              return
+            end
+            vim.notify("GraphQL definition が見つかりません", vim.log.levels.INFO)
+            return
+          end
+
+          vim.lsp.buf.definition()
+        end
+
+        local function goto_references()
+          local graphql_client = graphql_buffer(bufnr) and buffer_client(bufnr, { "graphql" }) or nil
+          if graphql_client then
+            local locations = {}
+            if graphql_client:supports_method("textDocument/references") then
+              local params = vim.lsp.util.make_position_params(0, graphql_client.offset_encoding)
+              params.context = { includeDeclaration = true }
+              locations = flatten_locations(vim.lsp.buf_request_sync(bufnr, "textDocument/references", params, 1500))
+            end
+            if show_locations(locations, graphql_client.offset_encoding, "GraphQL references") then
+              return
+            end
+            if graphql_search(bufnr, "references") then
+              return
+            end
+            vim.notify("GraphQL references が見つかりません", vim.log.levels.INFO)
+            return
+          end
+
+          vim.lsp.buf.references()
+        end
+
+        vim.keymap.set("n", "gd", goto_definition, opts)
         vim.keymap.set("n", "gD", vim.lsp.buf.declaration, opts)
-        vim.keymap.set("n", "gr", vim.lsp.buf.references, opts)
+        vim.keymap.set("n", "gr", goto_references, opts)
         vim.keymap.set("n", "gi", vim.lsp.buf.implementation, opts)
         vim.keymap.set("n", "K", vim.lsp.buf.hover, opts)
         vim.keymap.set("n", "<leader>rn", vim.lsp.buf.rename, opts)
@@ -49,30 +352,34 @@ return {
         vim.keymap.set("n", "<leader>fd", vim.diagnostic.open_float, opts)
         vim.keymap.set("n", "[d", vim.diagnostic.goto_prev, opts)
         vim.keymap.set("n", "]d", vim.diagnostic.goto_next, opts)
+        vim.b[bufnr].vscode_like_lsp_maps = true
       end
 
       mason_lspconfig.setup({
-        ensure_installed = servers,
+        ensure_installed = server_names,
         automatic_installation = true,
       })
 
-      for _, server in ipairs(servers) do
-        vim.lsp.config(server, {
+      for _, server in ipairs(server_names) do
+        vim.lsp.config(server, vim.tbl_deep_extend("force", {
           capabilities = capabilities,
           on_attach = on_attach,
-        })
+        }, servers[server]))
       end
 
+      apply_diagnostic_config()
+
       if vim.g.lsp_enabled then
-        for _, server in ipairs(servers) do
+        for _, server in ipairs(server_names) do
           pcall(vim.lsp.enable, server, true)
         end
       end
 
       local function enable_lsp()
         vim.g.lsp_enabled = true
+        apply_diagnostic_config()
         vim.diagnostic.enable(true)
-        for _, server in ipairs(servers) do
+        for _, server in ipairs(server_names) do
           pcall(vim.lsp.enable, server, true)
         end
         pcall(vim.cmd, "LspStart")
@@ -82,7 +389,7 @@ return {
       local function disable_lsp()
         vim.g.lsp_enabled = false
         vim.diagnostic.enable(false)
-        for _, server in ipairs(servers) do
+        for _, server in ipairs(server_names) do
           pcall(vim.lsp.enable, server, false)
         end
         for _, client in ipairs(vim.lsp.get_clients()) do
@@ -96,6 +403,9 @@ return {
       pcall(vim.api.nvim_del_user_command, "LspEnable")
       pcall(vim.api.nvim_del_user_command, "LspDisable")
       pcall(vim.api.nvim_del_user_command, "LspToggle")
+      pcall(vim.api.nvim_del_user_command, "InlineDiagnosticsEnable")
+      pcall(vim.api.nvim_del_user_command, "InlineDiagnosticsDisable")
+      pcall(vim.api.nvim_del_user_command, "InlineDiagnosticsToggle")
 
       vim.api.nvim_create_user_command("LspEnable", enable_lsp, {})
       vim.api.nvim_create_user_command("LspDisable", disable_lsp, {})
@@ -106,6 +416,28 @@ return {
           enable_lsp()
         end
       end, {})
+      vim.api.nvim_create_user_command("InlineDiagnosticsEnable", function()
+        vim.g.inline_diagnostics_enabled = true
+        apply_diagnostic_config()
+        vim.notify("inline diagnostics を有効化しました", vim.log.levels.INFO)
+      end, {})
+      vim.api.nvim_create_user_command("InlineDiagnosticsDisable", function()
+        vim.g.inline_diagnostics_enabled = false
+        apply_diagnostic_config()
+        vim.notify("inline diagnostics を無効化しました", vim.log.levels.INFO)
+      end, {})
+      vim.api.nvim_create_user_command("InlineDiagnosticsToggle", function()
+        vim.g.inline_diagnostics_enabled = not vim.g.inline_diagnostics_enabled
+        apply_diagnostic_config()
+        local status = vim.g.inline_diagnostics_enabled and "有効" or "無効"
+        vim.notify("inline diagnostics を " .. status .. " にしました", vim.log.levels.INFO)
+      end, {})
+
+      vim.keymap.set("n", "<leader>xi", "<cmd>InlineDiagnosticsToggle<CR>", {
+        noremap = true,
+        silent = true,
+        desc = "inline diagnostics を切り替え",
+      })
     end,
   },
 }

--- a/dot_config/nvim/lua/plugins/lsp.lua
+++ b/dot_config/nvim/lua/plugins/lsp.lua
@@ -181,7 +181,12 @@ return {
         end
         table.insert(cmd, root_dir)
 
-        local result = vim.system(cmd, { cwd = root_dir, text = true }):wait()
+        local rg_obj = vim.system(cmd, { cwd = root_dir, text = true })
+        local result = rg_obj:wait(1500)
+        if not result then
+          rg_obj:kill(9)
+          return false
+        end
         if result.code ~= 0 and (result.stdout == nil or result.stdout == "") then
           return false
         end
@@ -283,15 +288,18 @@ return {
               title = "Go to source definition",
               arguments = { params.textDocument.uri, params.position },
             }, { bufnr = bufnr }, function(err, result)
-              if err then
-                vim.notify("TypeScript source definition に失敗しました: " .. err.message, vim.log.levels.ERROR)
-                return
-              end
-              if result and result[1] then
-                vim.lsp.util.show_document(result[1], ts_client.offset_encoding, { focus = true })
-                return
-              end
-              vim.lsp.buf.definition()
+              vim.schedule(function()
+                if err then
+                  vim.notify("TypeScript source definition に失敗しました: " .. err.message, vim.log.levels.ERROR)
+                  vim.lsp.buf.definition()
+                  return
+                end
+                if result and result[1] then
+                  vim.lsp.util.show_document(result[1], ts_client.offset_encoding, { focus = true })
+                  return
+                end
+                vim.lsp.buf.definition()
+              end)
             end)
             return
           end

--- a/dot_config/nvim/lua/plugins/terminal.lua
+++ b/dot_config/nvim/lua/plugins/terminal.lua
@@ -11,6 +11,7 @@ return {
           border = "curved",
         },
       })
+      require("core.file_actions").setup()
 
       local Terminal = require("toggleterm.terminal").Terminal
       local keymap = vim.keymap.set

--- a/dot_config/nvim/lua/plugins/util.lua
+++ b/dot_config/nvim/lua/plugins/util.lua
@@ -27,6 +27,9 @@ return {
   {
     "rcarriga/nvim-notify",
     config = function()
+      if #vim.api.nvim_list_uis() == 0 then
+        return
+      end
       require("notify").setup({
         background_colour = "#000000",
       })


### PR DESCRIPTION
Closes https://linear.app/ryoryoryo/issue/DOTFILE-34/nvimでvscodeみたいな設定

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

Neovim の設定において VSCode ライクな機能を実装しました。

**新規追加:**
- `dot_config/nvim/lua/core/file_actions.lua`: ファイル形式・プロジェクトルート判定に基づいて、oxfmt・ruff・taplo・terraform・gofmt などの CLI フォーマッタまたは LSP によるフォーマット機能、および eslint・pytest・go test・vitest などの各種検査・実行アクションを toggleterm のフロート ターミナルで実行する仕組み。保存時の自動フォーマット機能（`BufWritePre/BufWritePost` フック）、ユーザーコマンド（`CurrentFileActions`・`FormatBuffer`・`SaveHooksEnable/Disable/Toggle`）、キーバインド（`<leader>xa`・`<leader>xf`・`<leader>xh`）を提供。

**キーバインド・ナビゲーション強化:**
- `keymaps.lua`: 現在単語を検索レジスタに登録し、`n`/`N` で次/前の検索結果へ移動するキーバインド、および `gh` による jumplist 戻り機能を追加。

**LSP 設定の再構成:**
- `plugins/lsp.lua`: サーバー可用性判定を mason-lspconfig 依存から `lsp/<server>.lua` 存在確認に変更。TypeScript（`_typescript.goToSourceDefinition`）と GraphQL（カスタム定義/参照ハンドラ）に特化した `gd`/`gr` 実装、inline diagnostics のトグル機能（`InlineDiagnosticsEnable/Disable/Toggle`、`<leader>xi`）を新設。

**その他:**
- `plugins/terminal.lua`: `file_actions` モジュールの初期化処理を追加。
- `plugins/util.lua`: notify setup 時の UI 初期化ガード追加。

## 変更理由

VSCode のような使い勝手をもたらす統合的なファイル操作・ナビゲーション体験を Neovim で実現するための改善。フォーマッタの oxfmt への置き換えに対応させるとともに、複数の言語・ツール（TypeScript、GraphQL、Python、Go、Terraform など）に対応した一貫性のある操作インターフェースを提供。

## 確認した項目

- 新規追加の `file_actions.lua` で各言語別フォーマッタが正常に呼び出される
- 保存時のフォーマット自動実行と手動実行が重複しない
- TypeScript/GraphQL の定義・参照ジャンプが意図通りに動作する
- Inline diagnostics トグルが期待通りに有効/無効を切り替える
- キーバインド（`gh`・`<leader>xa` など）の衝突がない

<!-- end of auto-generated comment: release notes by coderabbit.ai -->