### PR TITLE
Enable auto-resolve for Gemini Code Assist code reviews

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -3,6 +3,7 @@ have_fun: false
 code_review:
   disable: false
   comment_severity_threshold: MEDIUM
+  auto_resolve_conversations: true
   max_review_comments: 20
   pull_request_opened:
     help: false

--- a/dot_config/vscode/settings.json
+++ b/dot_config/vscode/settings.json
@@ -203,6 +203,8 @@
   "bookmarks.saveBookmarksInProject": true,
   // (Gemini Code Assist)
   // trusted workspace で Agent mode の操作確認を自動承認する
+  // 指摘内容に対してコード編集して解決している場合に自動で会話を解決する
+  "geminicodeassist.codeReview.autoResolveConversations": true,
   "geminicodeassist.agentYoloMode": true,
   // (CommitMessageEditor)
   "commit-message-editor.view.defaultView": "form",


### PR DESCRIPTION
Enabled automatic conversation resolution for Gemini Code Assist in both VS Code and the review bot configuration. This ensures that review threads are automatically resolved once the corresponding feedback is addressed via code edits.

---
*PR created automatically by Jules for task [14803028450990888265](https://jules.google.com/task/14803028450990888265) started by @ryo246912*