### PR TITLE
feature2

### DIFF
--- a/dot_config/ccmanager/config.json
+++ b/dot_config/ccmanager/config.json
@@ -31,16 +31,16 @@
     "presets": [
       {
         "id": "1",
-        "name": "Claude A1 (resume)",
+        "name": "Claude A1",
         "command": "claude",
-        "args": ["--resume"],
+        "args": ["--dangerously-skip-permissions"],
         "fallbackArgs": []
       },
       {
         "id": "2",
         "name": "Claude A2 (resume)",
         "command": "claude2",
-        "args": ["--resume"],
+        "args": ["--dangerously-skip-permissions"],
         "fallbackArgs": [],
         "detectionStrategy": "claude"
       },
@@ -48,14 +48,14 @@
         "id": "3",
         "name": "Claude A1 (no resume)",
         "command": "claude",
-        "args": [""],
+        "args": ["--dangerously-skip-permissions"],
         "detectionStrategy": "claude"
       },
       {
         "id": "4",
         "name": "Claude A2 (no resume)",
         "command": "claude2",
-        "args": [""],
+        "args": ["--dangerously-skip-permissions"],
         "detectionStrategy": "claude"
       },
       {
@@ -69,7 +69,7 @@
         "id": "codex",
         "name": "Codex",
         "command": "codex",
-        "args": ["resume", "--yolo"],
+        "args": ["--yolo"],
         "detectionStrategy": "codex",
         "fallbackArgs": ["--yolo"]
       },
@@ -78,7 +78,7 @@
         "name": "Copilot",
         "command": "copilot",
         "detectionStrategy": "github-copilot",
-        "args": ["--resume", "--yolo"],
+        "args": ["--yolo"],
         "fallbackArgs": ["--yolo"]
       }
     ],

--- a/dot_config/devcontainer/mise.toml
+++ b/dot_config/devcontainer/mise.toml
@@ -8,7 +8,7 @@
 "aqua:openai/codex"              = "0.110.0"
 bun                              = "1.3.11"
 "github:github/copilot-cli"      = "1.0.18"
-"github:philschmid/mcp-cli"      = "0.3.0"
+"github:philschmid/mcp-cli"      = { version = "0.3.0", asset_pattern = "mcp-cli-linux-x64" }
 go                               = "1.26.1"
 node                             = "22.19.0"
 "npm:@google/gemini-cli"         = "0.36.0"

--- a/dot_config/zabrze/ai.toml
+++ b/dot_config/zabrze/ai.toml
@@ -4,11 +4,9 @@ snippet = "ccmanager"
 trigger = "ccm"
 
 [[snippets]]
-cursor          = "👇"
-evaluate        = true
-name            = "ccmanager devcontainer(claude account1)"
-snippet         = "ccmanager --devc-up-command \"devc-up-wrapper devcontainer up --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json\" --devc-exec-command \"devcontainer exec --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json claude --dangerously-skip-permissions\""
-trigger-pattern = "(^ccmc$|ccmcc)"
+name    = "ccmanager devcontainer"
+snippet = "ccmanager --devc-up-command \"devc-up-wrapper devcontainer up --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json\" --devc-exec-command \"devcontainer exec --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json\""
+trigger = "ccmc"
 
 [[snippets]]
 cursor          = "👇"
@@ -16,26 +14,6 @@ evaluate        = true
 name            = "ccmanager devcontainer(claude account2)"
 snippet         = "ccmanager --devc-up-command \"devc-up-wrapper devcontainer up --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json\" --devc-exec-command \"devcontainer exec --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json env CLAUDE_CONFIG_DIR=/home/vscode/.claude-account2 claude --dangerously-skip-permissions\""
 trigger-pattern = "(^ccmc2$|ccmcc2)"
-
-[[snippets]]
-name    = "ccmanager devcontainer(gemini)"
-snippet = "ccmanager --devc-up-command \"devc-up-wrapper devcontainer up --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json\" --devc-exec-command \"devcontainer exec --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json gemini --yolo\""
-trigger = "ccmcg"
-
-[[snippets]]
-name    = "ccmanager devcontainer(codex)"
-snippet = "ccmanager --devc-up-command \"devc-up-wrapper devcontainer up --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json\" --devc-exec-command \"devcontainer exec --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json codex --yolo\""
-trigger = "ccmcx"
-
-[[snippets]]
-name    = "ccmanager devcontainer(opencode)"
-snippet = "ccmanager --devc-up-command \"devc-up-wrapper devcontainer up --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json\" --devc-exec-command \"devcontainer exec --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json opencode\""
-trigger = "ccmco"
-
-[[snippets]]
-name    = "ccmanager devcontainer(copilot)"
-snippet = "ccmanager --devc-up-command \"devc-up-wrapper devcontainer up --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json\" --devc-exec-command \"devcontainer exec --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json copilot --yolo\""
-trigger = "ccmcp"
 
 [[snippets]]
 name    = "devcontainer up"

--- a/dot_config/zsh/lazy/function.zsh
+++ b/dot_config/zsh/lazy/function.zsh
@@ -164,33 +164,6 @@ zsh-profiler() {
   ZSHRC_PROFILE=1 zsh -i -c zprof
 }
 
-_claude_prepare_account2_dir() {
-  local config_dir="${HOME}/.claude-account2"
-  local shared_entry
-  mkdir -p "$config_dir"
-
-  for shared_entry in projects settings.json agents skills plugins; do
-    if [[ ! -e "$config_dir/$shared_entry" && ! -L "$config_dir/$shared_entry" && -e "${HOME}/.claude/$shared_entry" ]]; then
-      ln -s "../.claude/$shared_entry" "$config_dir/$shared_entry"
-    fi
-  done
-}
-
-claude1() {
-  CLAUDE_CONFIG_DIR="${HOME}/.claude" command claude "$@"
-}
-
-claude2() {
-  _claude_prepare_account2_dir
-  CLAUDE_CONFIG_DIR="${HOME}/.claude-account2" command claude "$@"
-}
-
-claude-clear-cache() {
-  local config_dir="${1:-${CLAUDE_CONFIG_DIR:-${HOME}/.claude}}"
-  rm -rf "${config_dir}/statsig"
-  echo "Claude statsig cache cleared: ${config_dir}/statsig"
-}
-
 # historyの定期バックアップを起動
 zsh-history-backup
 

--- a/dot_local/bin/executable_claude2
+++ b/dot_local/bin/executable_claude2
@@ -1,7 +1,18 @@
 #!/bin/sh
 set -eu
 
-config_dir="${HOME}/.claude-account2"
-mkdir -p "${config_dir}"
+_claude_prepare_account2_dir() {
+  local config_dir="${HOME}/.claude-account2"
+  local shared_entry
+  mkdir -p "$config_dir"
 
-exec env CLAUDE_CONFIG_DIR="${config_dir}" claude "$@"
+  for shared_entry in projects settings.json agents skills plugins; do
+    if [[ ! -e "$config_dir/$shared_entry" && ! -L "$config_dir/$shared_entry" && -e "${HOME}/.claude/$shared_entry" ]]; then
+      ln -s "../.claude/$shared_entry" "$config_dir/$shared_entry"
+    fi
+  done
+}
+
+_claude_prepare_account2_dir
+exec env CLAUDE_CONFIG_DIR="${HOME}/.claude-account2" claude "$@"
+


### PR DESCRIPTION
- **fix: mcp-cli for devcontainer**
- **chore: update ccmanger**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更内容概要

- devcontainer 環境向けに mcp-cli のインストール指定を厳密化（mise.toml の github:philschmid/mcp-cli を asset_pattern を含む構成に変更）。
- ccmanager のプリセット設定を整理（Claude A1/A2 のプリセット名と args を更新して `--dangerously-skip-permissions` を使用、Codex/Copilot から `--resume` を削除など）。  
- ccmanager 用スニペットを統合・簡素化（ai.toml の複数モデル別スニペットを削除し、単一の `ccmanager devcontainer` スニペットに置き換え）。
- Claude 関連の古い Zsh ヘルパー関数を削除し、代わりに実行ファイル側でアカウント2用ディレクトリ準備を行う helper を追加（dot_local/bin/executable_claude2）。

## 変更理由

- devcontainer 内で正しい mcp-cli バイナリを確実に取得するためにアセットパターンを指定する必要があったため。  
- 権限周りの実行フローを統一し安全性・保守性を高めるために、ccmanager のコマンド引数とスニペットを簡素化・統合したため。  
- Zsh 側のアカウント切替処理をスクリプト側で扱うことでシェル設定を軽量化・整理するため。

## 確認した項目

- mise.toml の mcp-cli エントリが version を維持しつつ asset_pattern を追加していること。  
- ccmanager のプリセット（名前・args）と Codex/Copilot の args 変更を反映していること。  
- ai.toml の複数スニペットが削除され、単一の統合スニペット `ccmanager devcontainer` に置き換わっていること。  
- Zsh の Claude 関連関数が削除され、実行ファイルにアカウント2準備ロジックが追加されていること。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->