### PR TITLE
feat(zsh): install zsh-halfpipe and bind to ctrl+s

### DIFF
--- a/dot_config/zsh/lazy/bindkey.zsh
+++ b/dot_config/zsh/lazy/bindkey.zsh
@@ -61,7 +61,7 @@ else
   bindkey -M viins -r "^Q^X"
   bindkey -M viins -r "^Q^Z"
   bindkey -M viins -r "^R"
-  bindkey -M viins -r "^S"
+#   bindkey -M viins -r "^S"
   bindkey -M viins -r "^T"
   bindkey -M viins -r "^U"
   bindkey -M viins -r "^V"
@@ -104,3 +104,7 @@ else
   bindkey "^[N" history-search-forward
   bindkey "^[P" history-search-backward
 fi
+
+# ctrl + sでhalfpipe起動
+bindkey "^S" halfpipe
+bindkey -M viins "^S" halfpipe

--- a/dot_config/zsh/lazy/plugin.zsh
+++ b/dot_config/zsh/lazy/plugin.zsh
@@ -80,6 +80,8 @@ zinit wait lucid light-mode blockf for \
 zinit wait lucid light-mode blockf for \
     @'azu/ni.zsh'
 
+zinit wait lucid light-mode for @'raimo/zsh-halfpipe'
+
 ### completion ###
 zinit wait lucid light-mode blockf for \
     as"completion" \

--- a/dot_config/zsh/main.zsh
+++ b/dot_config/zsh/main.zsh
@@ -23,13 +23,13 @@ setopt APPEND_HISTORY
 # コマンド実行のたびにすぐ履歴ファイルに書き込む
 setopt INC_APPEND_HISTORY
 
+# ctrl + sは無効
+stty stop undef
 if [ "$(uname)" = "Darwin" ]; then
   # ctrl + dは無効
   stty eof undef
   # ctrl + qは無効
   stty start undef
-  # ctrl + sは無効
-  stty stop undef
   # ctrl + zはsuspend
   stty susp ^Z
   # NOTE:sttyを変更するのは要注意


### PR DESCRIPTION
Installs the raimo/zsh-halfpipe plugin via Zinit and configures Ctrl+S as the trigger key. This includes disabling terminal flow control (stty stop undef) globally to ensure Ctrl+S is available in the shell.

---
*PR created automatically by Jules for task [12127882745287353182](https://jules.google.com/task/12127882745287353182) started by @ryo246912*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

zsh-halfpipeプラグイン（raimo/zsh-halfpipe）のインストール、および Ctrl+S キーバインディングの設定を行いました。以下の3つのファイルを変更：

- **plugin.zsh**：zsh-halfpipeプラグインをzinit経由でlazy-loadするよう追加
- **bindkey.zsh**：Ctrl+S（^S）をhalfpipeウィジェットにバインド（デフォルトキーマップとviinsキーマップの両方）
- **main.zsh**：Ctrl+Sをシェルで利用可能にするため、`stty stop undef`コマンドを全プラットフォーム対応に変更（従来はDarwin限定）

## 変更理由

raimo/zsh-halfpipeはCtrl+Sでシェルコマンド入力を補助するプラグインです。ターミナルのフロー制御によってCtrl+Sがデフォルトで無効化されているため、全プラットフォームで`stty stop undef`を実行することで、このキーを利用可能にしました。

## 確認した項目

- zsh-halfpipeプラグインのzinit設定は正しく追加されている
- キーバインディングはデフォルトキーマップとvi-insert モードの両方に設定されている
- `stty stop undef`の設定が全プラットフォーム共通化されている

<!-- end of auto-generated comment: release notes by coderabbit.ai -->