### PR TITLE
docs: add opensessions agent support and principles memo

### DIFF
--- a/dot_config/ccmanager/config.json
+++ b/dot_config/ccmanager/config.json
@@ -10,11 +10,11 @@
   },
   "statusHooks": {
     "idle": {
-      "command": "if [ -n \"$TMUX\" ]; then macos-notify-cli --title \"CCManager - Idle\" --message \"${CCMANAGER_WORKTREE_PATH}の${CCMANAGER_WORKTREE_BRANCH}がIdle状態です\" --sound Hero --current-tmux; else macos-notify-cli --title \"CCManager - Idle\" --message \"${CCMANAGER_WORKTREE_PATH}の${CCMANAGER_WORKTREE_BRANCH}がIdle状態です\" --sound Hero; fi",
+      "command": "if [ -n \"$TMUX\" ]; then macos-notify-cli --title \"CCManager - Idle\" --message \"${CCMANAGER_WORKTREE_PATH}の${CCMANAGER_WORKTREE_BRANCH}がIdle状態です\" --sound Hero --current-tmux; curl -s -X POST http://127.0.0.1:7391/set-status -H 'content-type: application/json' -d \"{\\\"session\\\":\\\"$(tmux display -p '#S')\\\", \\\"text\\\":\\\"Idle\\\", \\\"tone\\\":\\\"success\\\"}\"; else macos-notify-cli --title \"CCManager - Idle\" --message \"${CCMANAGER_WORKTREE_PATH}の${CCMANAGER_WORKTREE_BRANCH}がIdle状態です\" --sound Hero; fi",
       "enabled": true
     },
     "waiting_input": {
-      "command": "if [ -n \"$TMUX\" ]; then macos-notify-cli --title \"CCManager - 入力待ち\" --message \"${CCMANAGER_WORKTREE_PATH}の${CCMANAGER_WORKTREE_BRANCH}が入力待ちです\" --sound Glass --current-tmux; else macos-notify-cli --title \"CCManager - 入力待ち\" --message \"${CCMANAGER_WORKTREE_PATH}の${CCMANAGER_WORKTREE_BRANCH}が入力待ちです\" --sound Glass; fi",
+      "command": "if [ -n \"$TMUX\" ]; then macos-notify-cli --title \"CCManager - 入力待ち\" --message \"${CCMANAGER_WORKTREE_PATH}の${CCMANAGER_WORKTREE_BRANCH}が入力待ちです\" --sound Glass --current-tmux; curl -s -X POST http://127.0.0.1:7391/set-status -H 'content-type: application/json' -d \"{\\\"session\\\":\\\"$(tmux display -p '#S')\\\", \\\"text\\\":\\\"Input\\\", \\\"tone\\\":\\\"warn\\\"}\"; else macos-notify-cli --title \"CCManager - 入力待ち\" --message \"${CCMANAGER_WORKTREE_PATH}の${CCMANAGER_WORKTREE_BRANCH}が入力待ちです\" --sound Glass; fi",
       "enabled": true
     }
   },

--- a/dot_config/opensessions/config.json
+++ b/dot_config/opensessions/config.json
@@ -1,0 +1,7 @@
+{
+  "theme": "default",
+  "sidebarWidth": 40,
+  "sidebarPosition": "right",
+  "mux": "tmux",
+  "plugins": []
+}

--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -240,6 +240,7 @@ bind C-v run-shell ' \
 # plugin追加したら、prefix + Iでロードする
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-yank'
+set -g @plugin 'Ataraxy-Labs/opensessions'
 
 # tmux-resurrect/tmux-continuum
 set -g @plugin 'ryo246912/tmux-resurrect'

--- a/not_config/memo/opensessions.md
+++ b/not_config/memo/opensessions.md
@@ -1,0 +1,18 @@
+# opensessions AI Agent Support and Mechanism
+
+## Supported AI Agents
+opensessions standardly monitors the following agents:
+- **Claude Code**: Watches JSONL logs in `~/.claude/projects/`.
+- **Codex (Symphony)**: Watches session files in `~/.codex/sessions/`.
+- **Amp**: Watches `~/.local/share/amp/threads/*.json`.
+- **OpenCode**: Monitors SQLite database `opencode.db`.
+- **Pi**: Internal watcher implementation.
+
+## Principles of Operation
+The core mechanism is based on **Passive Watching**:
+1. **Filesystem Watch**: It uses OS features (like `fs.watch`) to monitor agent log directories.
+2. **State Analysis**: It parses logs to determine states like `running`, `waiting`, `done`, or `error`.
+3. **CWD Mapping**: It extracts the working directory from logs and maps it to tmux sessions to show status icons in the correct place.
+
+## Compatibility with ccmanager
+It is fully compatible with `ccmanager`. Since `opensessions` watches the files produced by the agents rather than managing the agent processes themselves, it doesn't matter how the agent was started (directly or via a manager like `ccmanager`).


### PR DESCRIPTION
This PR adds a technical memo explaining the AI agent support and working principles of opensessions.
It covers:
- List of supported agents (Claude Code, Codex, etc.)
- The passive filesystem watching and CWD mapping mechanism
- Compatibility with ccmanager and other agent managers

---
*PR created automatically by Jules for task [8584107266161451003](https://jules.google.com/task/8584107266161451003) started by @ryo246912*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 1. 変更内容概要

opensessions と ccmanager の統合に関連する以下の3つの変更を実施：

- **技術メモの追加**：opensessions がサポートするAIエージェント（Claude Code、Codex、Amp、OpenCode、Pi）と、ファイルシステム監視による状態検出、tmux セッションへのCWDマッピング機構を説明するメモを追加

- **ccmanager 設定の拡張**：ステータスフック（idle、waiting_input）で、TMUX環境下時に HTTP POST で opensessions のエンドポイント（`http://127.0.0.1:7391/set-status`）にセッション情報とステータスを送信する機能を追加

- **opensessions の統合**：新たな設定ファイルでテーマ・サイドバー配置を指定し、tmux プラグインマネージャー（TPM）の管理対象に `Ataraxy-Labs/opensessions` プラグインを追加

## 2. 変更理由

複数のAIエージェント間での状態監視と通知を統一的に管理し、ccmanager を介した操作環境と opensessions による監視機能を連携させるための実装

## 3. 確認した項目

- opensessions が複数のAIエージェント形式に対応し、パッシブなファイルウォッチング機構で状態を検出する仕様
- ccmanager との互換性が保証される（エージェント起動方法に依存しない）
- 設定ファイルの追加と既存設定の拡張により、tmux 環境での統合が実現される

<!-- end of auto-generated comment: release notes by coderabbit.ai -->