### PR TITLE
Add Playwright and desktop-lite for browser automation in DevContainer

### DIFF
--- a/dot_config/devcontainer/devcontainer.json
+++ b/dot_config/devcontainer/devcontainer.json
@@ -2,50 +2,52 @@
   // https://containers.dev/implementors/json_reference/
   "name": "Devcontainer for AI Agent",
   "build": {
-    "dockerfile": "${localEnv:HOME}/.config/devcontainer/Dockerfile"
+    "dockerfile": "\${localEnv:HOME}/.config/devcontainer/Dockerfile"
   },
   // https://github.com/devcontainers/features/tree/main/src
   "features": {
     // "ghcr.io/devcontainers/features/docker-in-docker:2.13.0": {}
+    "ghcr.io/devcontainers/features/desktop-lite:1": {}
   },
+  "forwardPorts": [6080],
   "remoteEnv": {
-    "GH_TOKEN": "${localEnv:GH_TOKEN}",
+    "GH_TOKEN": "\${localEnv:GH_TOKEN}",
     // claudeがxterm-256colorを必要とするため、TERMを設定
     "TERM": "xterm-256color",
     // ホストのユーザー名（SSH接続用）
-    "HOST_USER": "${localEnv:USER}"
+    "HOST_USER": "\${localEnv:USER}"
   },
   // localWorkspaceFolder: ホスト側の作業ディレクトリ(.git/wk/{project}-{branch})を指す
-  // "workspaceFolder": "${localWorkspaceFolder}",
+  // "workspaceFolder": "\${localWorkspaceFolder}",
   "mounts": [
     // .config
-    "type=bind,source=${localEnv:HOME}/.config/git/config,target=/tmp/gitconfig-host,readonly",
-    "type=bind,source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,readonly",
-    "type=bind,source=${localEnv:HOME}/.config/ccusage,target=/home/vscode/.config/ccusage,readonly",
-    "type=bind,source=${localEnv:HOME}/.config/mise,target=/home/vscode/.config/mise,readonly",
+    "type=bind,source=\${localEnv:HOME}/.config/git/config,target=/tmp/gitconfig-host,readonly",
+    "type=bind,source=\${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,readonly",
+    "type=bind,source=\${localEnv:HOME}/.config/ccusage,target=/home/vscode/.config/ccusage,readonly",
+    "type=bind,source=\${localEnv:HOME}/.config/mise,target=/home/vscode/.config/mise,readonly",
     // .ssh
-    "type=bind,source=${localEnv:HOME}/.ssh/known_hosts,target=/home/vscode/.ssh/known_hosts,readonly",
+    "type=bind,source=\${localEnv:HOME}/.ssh/known_hosts,target=/home/vscode/.ssh/known_hosts,readonly",
     // devcontainer専用のSSH鍵（ホスト通知用）
-    "type=bind,source=${localEnv:HOME}/.ssh/id_docker_devcontainer,target=/home/vscode/.ssh/id_ed25519,readonly",
+    "type=bind,source=\${localEnv:HOME}/.ssh/id_docker_devcontainer,target=/home/vscode/.ssh/id_ed25519,readonly",
     // devcontainer scripts
-    "type=bind,source=${localEnv:HOME}/.config/devcontainer/scripts,target=/home/vscode/.config/devcontainer/scripts,readonly",
+    "type=bind,source=\${localEnv:HOME}/.config/devcontainer/scripts,target=/home/vscode/.config/devcontainer/scripts,readonly",
     // git - parent directory of workspace
     // 本体の .git (2つ上の階層) を、ホストと同じ絶対パスにマウント
-    "source=${localWorkspaceFolder}/../..,target=${localWorkspaceFolder}/../..,type=bind",
-    "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
+    "source=\${localWorkspaceFolder}/../..,target=\${localWorkspaceFolder}/../..,type=bind",
+    "source=\${localWorkspaceFolder},target=\${localWorkspaceFolder},type=bind",
     // AI agent configs
-    "type=bind,source=${localEnv:HOME}/.claude,target=/home/vscode/.claude",
-    "type=bind,source=${localEnv:HOME}/.claude/settings.json,target=/home/vscode/.claude/settings.json,readonly",
+    "type=bind,source=\${localEnv:HOME}/.claude,target=/home/vscode/.claude",
+    "type=bind,source=\${localEnv:HOME}/.claude/settings.json,target=/home/vscode/.claude/settings.json,readonly",
     // Claude account2 config for independent quota/auth
-    "type=bind,source=${localEnv:HOME}/.claude-account2,target=/home/vscode/.claude-account2",
+    "type=bind,source=\${localEnv:HOME}/.claude-account2,target=/home/vscode/.claude-account2",
     // .claude.jsonは一時的に読み取り専用でマウント(コピー用)
-    "type=bind,source=${localEnv:HOME}/.claude.json,target=/tmp/claude-config-host.json,readonly",
-    "type=bind,source=${localEnv:HOME}/.gemini,target=/home/vscode/.gemini",
-    "type=bind,source=${localEnv:HOME}/.codex,target=/home/vscode/.codex",
-    "type=bind,source=${localEnv:HOME}/.copilot,target=/home/vscode/.copilot",
-    "type=bind,source=${localEnv:HOME}/.local/share/opencode,target=/home/vscode/.local/share/opencode",
-    "type=bind,source=${localEnv:HOME}/.config/opencode,target=/home/vscode/.config/opencode",
-    "type=bind,source=${localEnv:HOME}/.coderabbit,target=/home/vscode/.coderabbit"
+    "type=bind,source=\${localEnv:HOME}/.claude.json,target=/tmp/claude-config-host.json,readonly",
+    "type=bind,source=\${localEnv:HOME}/.gemini,target=/home/vscode/.gemini",
+    "type=bind,source=\${localEnv:HOME}/.codex,target=/home/vscode/.codex",
+    "type=bind,source=\${localEnv:HOME}/.copilot,target=/home/vscode/.copilot",
+    "type=bind,source=\${localEnv:HOME}/.local/share/opencode,target=/home/vscode/.local/share/opencode",
+    "type=bind,source=\${localEnv:HOME}/.config/opencode,target=/home/vscode/.config/opencode",
+    "type=bind,source=\${localEnv:HOME}/.coderabbit,target=/home/vscode/.coderabbit"
   ],
   "postCreateCommand": "bash /home/vscode/.config/devcontainer/scripts/post-create.sh",
   "postStartCommand": "bash /home/vscode/.config/devcontainer/scripts/post-start.sh"

--- a/dot_config/devcontainer/scripts/executable_post-create.sh
+++ b/dot_config/devcontainer/scripts/executable_post-create.sh
@@ -38,3 +38,21 @@ for shared_entry in projects settings.json agents skills plugins; do
 		echo "ℹ️ .claude-account2/${shared_entry} の共有はスキップしました"
 	fi
 done
+
+# Playwright のインストール（ブラウザ操作自動化用）
+if ! command -v playwright &> /dev/null; then
+	echo "🚀 Playwright をインストールしています..."
+	npx playwright install --with-deps chromium
+	echo "✓ Playwright のインストールが完了しました"
+else
+	echo "ℹ️ Playwright は既にインストールされています"
+fi
+
+# Playwright MCP の設定（Claude Code 用）
+if ! claude mcp list | grep -q "playwright"; then
+	echo "🚀 Playwright MCP を Claude に追加しています..."
+	claude mcp add playwright npx @playwright/mcp@latest
+	echo "✓ Playwright MCP が追加されました"
+else
+	echo "ℹ️ Playwright MCP は既に設定されています"
+fi


### PR DESCRIPTION
This PR adds the necessary configuration to enable browser automation using Claude Code and Playwright within the DevContainer. It includes the desktop-lite feature for VNC access via port 6080 and automates Playwright setup in the post-create script.

---
*PR created automatically by Jules for task [17108663408523739829](https://jules.google.com/task/17108663408523739829) started by @ryo246912*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 1. 変更内容概要

DevContainer 設定ファイル (`devcontainer.json`) に `desktop-lite` フィーチャーを追加し、ポート 6080 をフォワードして VNC アクセスを有効化しました。

ポスト作成スクリプト (`post-create.sh`) に Playwright のインストール処理と Claude Code への MCP 登録処理を追加しました。Playwright Chromium が未インストールの場合は `npx playwright install --with-deps chromium` でインストール、未登録の場合は `claude mcp add playwright npx @playwright/mcp@latest` で MCP を登録します。

## 2. 変更理由

Claude Code でブラウザ自動化機能（Playwright）を利用可能にし、DevContainer 環境でブラウザ操作を自動化できるようにするため。デスクトップ環境（VNC）を提供することで、ビジュアルな確認やデバッグが容易になります。

## 3. 確認した項目

- Playwright インストール処理は既にインストール済みの場合はスキップ
- Playwright MCP 登録処理は既に登録済みの場合はスキップ
- 既存の post-create.sh の処理（.claude.json のコピー、.gitconfig の生成など）との競合なし

<!-- end of auto-generated comment: release notes by coderabbit.ai -->