### PR TITLE
Change runner to ubuntu-slim

### DIFF
--- a/.github/workflows/lint-action.yaml
+++ b/.github/workflows/lint-action.yaml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint:
     if: ${{ ! endsWith(github.actor, '[bot]')}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   lint:
     if: ${{ ! endsWith(github.actor, '[bot]')}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       pull-requests: read

--- a/dot_config/act/actrc
+++ b/dot_config/act/actrc
@@ -1,4 +1,4 @@
 --container-architecture linux/amd64
--P ubuntu-latest=ghcr.io/catthehacker/ubuntu:js-latest
+-P ubuntu-slim=ghcr.io/catthehacker/ubuntu:js-latest
 -P ubuntu-22.04=ghcr.io/catthehacker/ubuntu:js-22.04
 -P ubuntu-20.04=ghcr.io/catthehacker/ubuntu:js-20.04

--- a/dot_config/act/actrc
+++ b/dot_config/act/actrc
@@ -1,4 +1,5 @@
 --container-architecture linux/amd64
+-P ubuntu-latest=ghcr.io/catthehacker/ubuntu:js-latest
 -P ubuntu-slim=ghcr.io/catthehacker/ubuntu:js-latest
 -P ubuntu-22.04=ghcr.io/catthehacker/ubuntu:js-22.04
 -P ubuntu-20.04=ghcr.io/catthehacker/ubuntu:js-20.04


### PR DESCRIPTION
This PR updates the GitHub Actions workflow files and the local `act` configuration to use the `ubuntu-slim` runner label instead of `ubuntu-latest`. This ensures consistency across environments and potentially uses a more optimized runner image.

---
*PR created automatically by Jules for task [18170288765116960388](https://jules.google.com/task/18170288765116960388) started by @ryo246912*