### PR TITLE
feat(mise): add install_before setting

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -105,11 +105,12 @@ usage                                                       = "3.2.0"
 vim                                                         = "9.1.1006"
 
 [settings]
-auto_install = false
-experimental = true
-gpg_verify   = true
-jobs         = 1
-lockfile     = true
+auto_install   = false
+experimental   = true
+gpg_verify     = true
+install_before = "3d"
+jobs           = 1
+lockfile       = true
 
 [settings.npm]
 bun = true

--- a/mise.toml
+++ b/mise.toml
@@ -98,3 +98,6 @@ run = [
 "npm:@taplo/cli"               = "0.7.0"
 "npm:prettier"                 = "3.8.1"
 "pipx:zizmor"                  = "1.23.1"
+
+[settings]
+install_before = "3d"


### PR DESCRIPTION
Add `install_before = "3d"` to both global and project mise configurations.
This setting delays the installation of new tool versions by 3 days to
mitigate risks of supply chain attacks.

Reference: https://zenn.dev/23prime/articles/mise-install-before

---
*PR created automatically by Jules for task [909876131050931685](https://jules.google.com/task/909876131050931685) started by @ryo246912*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
グローバルおよびプロジェクトレベルのmise設定ファイルに `install_before = "3d"` 設定を追加しました。
- `mise.toml` に新規 `[settings]` セクションを作成し、`install_before = "3d"` を設定
- `dot_config/mise/config.toml` の既存 `[settings]` セクションに `install_before = "3d"` を追加

## 変更理由
新しいツールバージョンのインストールを3日間遅延させることで、ツール供給元でのセキュリティ上の問題やサプライチェーン攻撃のリスクが発覚した場合に対応する時間を確保します。

## 確認した項目
- 両ファイルへの `install_before = "3d"` の正常な追加を確認
- 既存の設定値（`auto_install`、`experimental`、`gpg_verify`、`jobs`、`lockfile` など）への影響なし

<!-- end of auto-generated comment: release notes by coderabbit.ai -->