### PR TITLE
feat: introduce gh-infra for declarative repository management

### DIFF
--- a/.rulesync/rules/CLAUDE.md
+++ b/.rulesync/rules/CLAUDE.md
@@ -95,7 +95,9 @@ This is a comprehensive personal dotfiles repository managed with [chezmoi](http
 6. **Configure GitHub repositories:**
 
    ```bash
-   setup-github
+   # Initial setup (requires gh-infra extension)
+   mise run gh-infra-setup
+   mise run gh-infra-apply
    ```
 
 7. **Apply Karabiner key mappings (macOS only):**
@@ -194,6 +196,8 @@ This repository treats personal development environment as code:
 - The repository supports both personal and work environments with dedicated configuration files
 
 - All command-line tools are managed through mise for version consistency
+
+- GitHub repository settings and files are managed via gh-infra
 
 - Chezmoi templates use hash-based change detection for efficient updates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,9 @@ This is a comprehensive personal dotfiles repository managed with [chezmoi](http
 6. **Configure GitHub repositories:**
 
    ```bash
-   setup-github
+   # Initial setup (requires gh-infra extension)
+   mise run gh-infra-setup
+   mise run gh-infra-apply
    ```
 
 7. **Apply Karabiner key mappings (macOS only):**
@@ -186,6 +188,8 @@ This repository treats personal development environment as code:
 - The repository supports both personal and work environments with dedicated configuration files
 
 - All command-line tools are managed through mise for version consistency
+
+- GitHub repository settings and files are managed via gh-infra
 
 - Chezmoi templates use hash-based change detection for efficient updates
 

--- a/dot_config/gh-infra/dotfiles.yaml
+++ b/dot_config/gh-infra/dotfiles.yaml
@@ -1,0 +1,43 @@
+apiVersion: gh-infra/v1
+kind: Repository
+metadata:
+  name: ryo246912/dotfiles
+spec:
+  description: "ryo246912's dotfiles"
+  visibility: public
+  topics:
+    - dotfiles
+    - chezmoi
+    - mise
+    - zsh
+  homepage_url: https://github.com/ryo246912/dotfiles
+  has_issues: true
+  has_projects: false
+  has_wiki: false
+  allow_squash_merge: true
+  allow_merge_commit: true
+  allow_rebase_merge: false
+  delete_branch_on_merge: true
+  allow_update_branch: true
+  squash_merge_commit_title: PR_TITLE
+  squash_merge_commit_message: PR_BODY
+  rulesets:
+    - name: main
+      enforcement: active
+      target: branch
+      conditions:
+        ref_name:
+          include:
+            - "~DEFAULT_BRANCH"
+          exclude: []
+      rules:
+        - type: deletion
+        - type: non_fast_forward
+        - type: required_signatures
+        - type: pull_request
+          parameters:
+            required_approving_review_count: 1
+            dismiss_stale_reviews_on_push: true
+            require_code_owner_review: false
+            require_last_push_approval: true
+            required_review_thread_resolution: false

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -208,3 +208,15 @@ run         = "prettier --check '**/*.json'"
 [tasks.fix-json]
 description = "Run fix json files"
 run         = "prettier --write '**/*.json'"
+
+[tasks.gh-infra-setup]
+description = "Install gh-infra extension"
+run         = "gh extension install babarot/gh-infra"
+
+[tasks.gh-infra-plan]
+description = "Run gh-infra plan"
+run         = "gh infra plan dot_config/gh-infra/"
+
+[tasks.gh-infra-apply]
+description = "Run gh-infra apply"
+run         = "gh infra apply dot_config/gh-infra/"

--- a/dot_config/rulesync/exact_dot_rulesync/skills/gh-infra/SKILL.md
+++ b/dot_config/rulesync/exact_dot_rulesync/skills/gh-infra/SKILL.md
@@ -1,0 +1,17 @@
+# gh-infra
+
+Manage GitHub repository settings and files declaratively using gh-infra.
+
+## Commands
+
+### /gh-infra-plan
+
+Run `gh infra plan` to see changes.
+
+### /gh-infra-apply
+
+Run `gh infra apply` to apply changes.
+
+## Usage
+
+Use these commands when you want to update GitHub repository settings (topics, visibility, merge strategies) or distribute files across repositories managed by gh-infra.

--- a/dot_config/zabrze/github.toml
+++ b/dot_config/zabrze/github.toml
@@ -1,0 +1,14 @@
+[[snippets]]
+name    = "gh infra plan"
+snippet = "gh infra plan dot_config/gh-infra/"
+trigger = "ghip"
+
+[[snippets]]
+name    = "gh infra apply"
+snippet = "gh infra apply dot_config/gh-infra/"
+trigger = "ghia"
+
+[[snippets]]
+name    = "gh infra import"
+snippet = "gh infra import"
+trigger = "ghii"

--- a/mise.toml
+++ b/mise.toml
@@ -98,3 +98,15 @@ run = [
 "npm:@taplo/cli"               = "0.7.0"
 "npm:prettier"                 = "3.8.1"
 "pipx:zizmor"                  = "1.23.1"
+
+[tasks.gh-infra-setup]
+description = "Install gh-infra extension"
+run         = "gh extension install babarot/gh-infra"
+
+[tasks.gh-infra-plan]
+description = "Run gh-infra plan"
+run         = "gh infra plan dot_config/gh-infra/"
+
+[tasks.gh-infra-apply]
+description = "Run gh-infra apply"
+run         = "gh infra apply dot_config/gh-infra/"

--- a/setup.md
+++ b/setup.md
@@ -1,17 +1,20 @@
 # Setup
 
 ## Mac
+
 ### 初期設定
+
 - [ ] XCode CLIのインストール
+
   ```sh
   xcode-select --install
   ```
 
 - [ ] chezmoiの実行
+
   ```sh
   sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply ryo246912
   ```
-
 
 - [ ] miseの実行
   - [ ] ghコマンドのインストール
@@ -54,7 +57,6 @@
     - [ ] 設定で`Vimium Options.json`をインポート
   - [ ] Tab Position Options
 
-
 - [ ] Raycast
   - [ ] `Raycast.rayconfig`をインポート
 
@@ -77,6 +79,7 @@
   - [ ] 設定ファイルをコピー
 
 ### 追加設定
+
 - [ ] システム設定
   - [ ] 指紋認証
     - [ ] 「TouchIDとパスワード」→指紋追加
@@ -103,15 +106,15 @@
     ```
 - [ ] git
   - [ ] 秘密鍵の設定
-      - 既存の秘密鍵を使用する場合は、以下のコマンドを実行
+    - 既存の秘密鍵を使用する場合は、以下のコマンドを実行
       export済みの`secret_key.asc`を`.gnupg`にコピーしてきて、importする
-      ```sh
-      gpg --import ~/.gnupg/secret_key.asc
-      ```
-      もし再度exportしたい場合は、以下のコマンドを実行
-      ```sh
-      gpg --export-secret-keys --armor <fingerprint> > ~/.secret_key.asc
-      ```
+    ```sh
+    gpg --import ~/.gnupg/secret_key.asc
+    ```
+    もし再度exportしたい場合は、以下のコマンドを実行
+    ```sh
+    gpg --export-secret-keys --armor <fingerprint> > ~/.secret_key.asc
+    ```
         - fingerprintは、以下のコマンドの`YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY`の内容
         ```sh
         gpg --list-secret-keys --keyid-format LONG
@@ -122,61 +125,68 @@
         # ssb   rsa4096/ZZZZZZZZZZZZZZZZ  2023-01-01 [E]
         ```
         - パスフレーズは、パスワードマネージャーに保存しているものを参照
-      - 新規に秘密鍵を作成する場合は、以下のコマンドを実行
-        - 基本そのままEnterを押していく
-        - 名前・メールアドレスは、gitの設定と同じものを使用
+
+    - 新規に秘密鍵を作成する場合は、以下のコマンドを実行
+      - 基本そのままEnterを押していく
+      - 名前・メールアドレスは、gitの設定と同じものを使用
+    ```sh
+    gpg --full-generate-key
+    ```
+
+    - 作成後、以下のコマンドでfingerprintを確認
+      - GPG_KEY_IDの内容をgitconfigに設定する
+    ```sh
+    gpg --list-secret-keys --keyid-format LONG
+    ```
+
+    - (新しいメールアドレスを紐づける場合)GPGキーにメールアドレスを追加
       ```sh
-      gpg --full-generate-key
+      gpg --edit-key XXXXXXXXXXXXXXXX
       ```
-      - 作成後、以下のコマンドでfingerprintを確認
-        - GPG_KEY_IDの内容をgitconfigに設定する
+
+      - adduidで編集、以下を入力して新しいメールアドレスを追加
+        - Real name: 登録したい名前
+        - Email address: 登録したいメールアドレス
+        - Comment: コメント（任意）
       ```sh
-      gpg --list-secret-keys --keyid-format LONG
+      gpg> adduid
       ```
-      - (新しいメールアドレスを紐づける場合)GPGキーにメールアドレスを追加
-        ```sh
-        gpg --edit-key XXXXXXXXXXXXXXXX
-        ```
-        - adduidで編集、以下を入力して新しいメールアドレスを追加
-          - Real name: 登録したい名前
-          - Email address: 登録したいメールアドレス
-          - Comment: コメント（任意）
-        ```sh
-        gpg> adduid
-        ```
-      - 登録済みのGPGキーを削除後、GitHubに新しいGPGキーを登録
-      ```sh
-      gh gpg-key delete $(gh gpg-key list | awk '{print $3}')
-      ```
-      ```sh
-      gpg --armor --export XXXXXXXXXXXXXXXX | gh gpg-key add
-      ```
+    - 登録済みのGPGキーを削除後、GitHubに新しいGPGキーを登録
+    ```sh
+    gh gpg-key delete $(gh gpg-key list | awk '{print $3}')
+    ```
+    ```sh
+    gpg --armor --export XXXXXXXXXXXXXXXX | gh gpg-key add
+    ```
   - [ ] gpg_agent・gitの設定
-     ```
-     setup-git-gpg
-     ```
+    ```
+    setup-git-gpg
+    ```
   - [ ] [sshの設定](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key)
     - 秘密鍵の生成
       1. ssh-keygenで生成→登録
-        ```sh
-        ssh-keygen -t ed25519 -C "<mail_address>"
-        ```
-        - パスフレーズを入力
-        - Githubに公開鍵を登録
-        ```sh
-        gh ssh-key add ~/.ssh/id_ed25519.pub -t <title>
-        ```
+      ```sh
+      ssh-keygen -t ed25519 -C "<mail_address>"
+      ```
+
+      - パスフレーズを入力
+      - Githubに公開鍵を登録
+      ```sh
+      gh ssh-key add ~/.ssh/id_ed25519.pub -t <title>
+      ```
+
       2. ghコマンドで生成→登録
-        - sshを選択
-        ```sh
-        gh auth login
-        ```
-        - 途中の画面で新しいキーを生成する→ghコマンドが自動で公開鍵をGitHubに登録
-        ```
-        ? Generate a new SSH key to add to your GitHub account? (Y/n) Y
-        ? Enter a passphrase for your new SSH key (Optional)
-        ? Title for your SSH key: (GitHub CLI)
-        ```
+      - sshを選択
+      ```sh
+      gh auth login
+      ```
+
+      - 途中の画面で新しいキーを生成する→ghコマンドが自動で公開鍵をGitHubに登録
+      ```
+      ? Generate a new SSH key to add to your GitHub account? (Y/n) Y
+      ? Enter a passphrase for your new SSH key (Optional)
+      ? Title for your SSH key: (GitHub CLI)
+      ```
     - ssh-agentにsshキーを追加
     ```sh
     eval "$(ssh-agent -s)"
@@ -204,6 +214,7 @@
   -----END RSA PRIVATE KEY-----
   EOF
   ```
+
   - sshコマンド
     - サーバーの以下教えてもらう
       - port
@@ -212,12 +223,14 @@
     ```sh
     ssh -i ~/.ssh/xx.pem -p <port> <user>@<bastion_host>
     ```
+
     - 踏み台サーバ経由してのポートフォワーディング
     ```sh
     ssh -i ~/.ssh/xx.pem -p <port> -L <local_port>:<target_host>:<target_port> <user>@<bastion_host>
     ```
 
 ### プライベート設定
+
 - [ ] thunderbird
   - [ ] アカウントの設定
   - [ ] アドオンの設定
@@ -227,9 +240,11 @@
   - [ ] obsidian-web-clipperの設定をインポート・ショートカットキーの設定
 
 ## Windows
+
 ### 初期セットアップ
 
 #### パッケージマネージャーのインストール
+
 - [ ] Scoop のインストール
   ```powershell
   Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
@@ -237,6 +252,7 @@
   ```
 
 #### 基本ツールのインストール
+
 - [ ] Git
   ```powershell
   scoop install git
@@ -256,6 +272,7 @@
   ```
 
 #### Windows PC設定
+
 - [ ] トラックパッドの設定
   - [ ] スクロール方法を調整
 - [ ] クリップボード履歴を有効化
@@ -267,6 +284,7 @@
   - [ ] 「デバイス設定」→「バッテリー充電しきい値 / 保守モード」から充電上限を設定
 
 #### ブラウザの初期設定
+
 - [ ] Firefox でログイン
   - [ ] Mozilla アカウントでログイン
   - [ ] Twitter Container を設定
@@ -275,6 +293,7 @@
   - [ ] ホームページ設定
 
 #### その他アプリケーション
+
 - [ ] Google Drive のインストール
   ```powershell
   winget install --id Google.GoogleDrive -e
@@ -305,6 +324,7 @@
   - [ ] エンコーダーを設定
 
 #### NAS の接続
+
 - [ ] QNAP Finder Pro のインストール
   ```powershell
   winget install QNAP.QfinderPro
@@ -313,6 +333,7 @@
 - [ ] ネットワークドライブを割り当て
 
 #### WSL のインストール
+
 - [ ] PowerShell を起動（管理者権限）
 - [ ] 実行ポリシーを設定
   ```powershell
@@ -325,6 +346,7 @@
 - [ ] ユーザー名とパスワードを設定
 
 - [ ] chezmoiの実行
+
   ```sh
   sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply ryo246912
   ```
@@ -351,3 +373,8 @@
     ```sh
     mise install --jobs=2
     ```
+
+### gh-infra setup
+
+Run `mise run gh-infra-setup` to install the gh-infra extension.
+Use `mise run gh-infra-plan` and `mise run gh-infra-apply` to manage repository settings.


### PR DESCRIPTION
Introduce gh-infra to manage GitHub repository settings and files declaratively.
- Created dot_config/gh-infra/dotfiles.yaml for dotfiles repository management.
- Added mise tasks for setup, plan, and apply in both root and config.toml.
- Added zabrze abbreviations (ghip, ghia, ghii) in dot_config/zabrze/github.toml.
- Updated setup.md and CLAUDE.md to replace setup-github with gh-infra.
- Added gh-infra skill for AI agents in dot_config/rulesync.

---
*PR created automatically by Jules for task [15149192065187816130](https://jules.google.com/task/15149192065187816130) started by @ryo246912*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 1. 変更内容概要

GitHub リポジトリ設定を宣言的に管理するツール「gh-infra」を導入しました。以下の内容が追加/更新されています：

- `dot_config/gh-infra/dotfiles.yaml`: dotfiles リポジトリの構成設定（マージポリシー、ルールセットなど）を定義
- `mise.toml` と `dot_config/mise/config.toml`: gh-infra のセットアップ・プラン・適用タスクを追加
- `dot_config/zabrze/github.toml`: gh-infra 関連のショートカット定義（3つのプリセット）を追加
- `dot_config/rulesync/exact_dot_rulesync/skills/gh-infra/SKILL.md`: AI エージェント向けのスキル定義を追加
- `setup.md` と `CLAUDE.md`: セットアップワークフローの更新（`setup-github` コマンドを `mise run gh-infra-setup` と `mise run gh-infra-apply` に置き換え）

## 2. 変更理由

GitHub リポジトリ設定を従来のコマンドから宣言的な設定ファイルベースの管理に移行することで、設定の再現性と追跡可能性を向上させます。gh-infra 拡張機能を活用し、リポジトリ設定とファイルの管理を自動化・スケーラブルにすることが狙いです。

## 3. 確認した項目

- 新規追加ファイルはすべてドキュメント・設定ファイルのみで、コード実行ロジックを含まない
- mise タスク定義により、既存の setup ワークフローとの統合が設定済み
- 公開リポジトリ設定の詳細（マージ戦略、ルールセット、レビュー要件など）が YAML 形式で明確に定義されている

<!-- end of auto-generated comment: release notes by coderabbit.ai -->