### PR TITLE
Update renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,7 +77,7 @@
     {  
       "matchDepNames": ["aqua:openai/codex","codex"],  
       "extractVersion": "^(?:rust-)?v?(?<version>.+)"  
-    },
+    }
   ],
   "customManagers": [
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -74,9 +74,9 @@
       ],
       "groupName": "atuin"
     },
-    {  
-      "matchDepNames": ["aqua:openai/codex","codex"],  
-      "extractVersion": "^(?:rust-)?v?(?<version>.+)"  
+    {
+      "matchDepNames": ["aqua:openai/codex", "codex"],
+      "extractVersion": "^(?:rust-)?v?(?<version>.+)"
     }
   ],
   "customManagers": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -73,7 +73,11 @@
         "ghcr.io/atuinsh/atuin"
       ],
       "groupName": "atuin"
-    }
+    },
+    {  
+      "matchDepNames": ["aqua:openai/codex","codex"],  
+      "extractVersion": "^(?:rust-)?v?(?<version>.+)"  
+    },
   ],
   "customManagers": [
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 1. 変更内容概要

`.github/renovate.json`の`packageRules`配列に新しいルールエントリを追加しました。`aqua:openai/codex`と`codex`という依存関係に対して、`rust-`プレフィックスやオプションの`v`プレフィックスを含むバージョン文字列を正規化するための`extractVersion`ルールを設定しています。

## 2. 変更理由

OpenAI Codex関連の依存関係でバージョン文字列が`v1.0.0`、`rust-v1.0.0`、`1.0.0`など複数の形式で存在する可能性があり、Renovateが正確にバージョンを認識・比較できるようにするために追加されたものと考えられます。

## 3. 確認した項目

- 正規表現`^(?:rust-)?v?(?<version>.+)`により、`rust-`プレフィックス（オプション）と`v`プレフィックス（オプション）の両方に対応していることを確認しました
- `matchDepNames`で対象となる依存関係を明確に指定しており、他のルールへの影響がないことを確認しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->