### PR TITLE
Add bagel security inventory tool and mise tasks

### DIFF
--- a/dot_config/bagel/bagel.yaml
+++ b/dot_config/bagel/bagel.yaml
@@ -1,0 +1,26 @@
+version: 1
+probes:
+  git:
+    enabled: true
+  ssh:
+    enabled: true
+  npm:
+    enabled: true
+  env:
+    enabled: true
+  shell_history:
+    enabled: true
+  cloud:
+    enabled: true
+  jetbrains:
+    enabled: true
+  gh:
+    enabled: true
+  ai_cli:
+    enabled: true
+privacy:
+  redact_paths: []
+  exclude_env_prefixes: []
+output:
+  include_file_hashes: false
+  include_file_content: false

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -15,6 +15,7 @@ ASDF_FFMPEG_ENABLE = "gpl libx264"
 "aqua:astral-sh/uv"                                         = "0.11.7"
 "aqua:atuinsh/atuin"                                        = "18.8.0"
 "aqua:bitwarden/clients"                                    = "2025.9.0"
+"aqua:boostsecurityio/bagel"                             = "0.6.1"
 "aqua:cli/cli"                                              = "2.90.0"
 "aqua:dandavison/delta"                                     = "0.19.2"
 "aqua:denisidoro/navi"                                      = "2.23.0"
@@ -211,3 +212,11 @@ run         = "prettier --check '**/*.json'"
 [tasks.fix-json]
 description = "Run fix json files"
 run         = "prettier --write '**/*.json'"
+
+[tasks.bagel-scan]
+description = "Run bagel scan to inventory security-relevant metadata"
+run         = "bagel scan"
+
+[tasks.bagel-version]
+description = "Show bagel version"
+run         = "bagel version"

--- a/mise.toml
+++ b/mise.toml
@@ -93,8 +93,17 @@ run = [
 
 [tools]
 "aqua:rhysd/actionlint"        = "1.7.12"
+"aqua:boostsecurityio/bagel"      = "0.6.1"
 "aqua:suzuki-shunsuke/ghalint" = "1.5.5"
 "aqua:suzuki-shunsuke/pinact"  = "3.9.2"
 "aqua:tamasfe/taplo"           = "0.10.0"
 "npm:prettier"                 = "3.8.1"
 "pipx:zizmor"                  = "1.23.1"
+
+[tasks.bagel-scan]
+description = "Run bagel scan to inventory security-relevant metadata"
+run         = "bagel scan"
+
+[tasks.bagel-version]
+description = "Show bagel version"
+run         = "bagel version"


### PR DESCRIPTION
Added the bagel security inventory tool (v0.6.1) to the mise configuration files (mise.toml and dot_config/mise/config.toml). Created a default configuration file at dot_config/bagel/bagel.yaml and added relevant mise tasks for scanning and version checking.

---
*PR created automatically by Jules for task [16282047554981518552](https://jules.google.com/task/16282047554981518552) started by @ryo246912*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

Bagel セキュリティインベントリツール（v0.6.1）をプロジェクトに統合しました。具体的には以下を実施しています:

- 新たに `dot_config/bagel/bagel.yaml` 設定ファイルを作成し、git、ssh、npm、env、shell_history、cloud、jetbrains、gh、ai_cliの各プローブを有効化
- `mise.toml` と `dot_config/mise/config.toml` に bagel ツール（v0.6.1）を追加
- bagel スキャンとバージョン確認用の mise タスク（`bagel-scan`、`bagel-version`）を追加

## 変更理由

セキュリティ関連メタデータの自動インベントリ化を可能にするための環境構築です。

## 確認した項目

- 設定ファイルの正確性（YAML フォーマット、プローブ設定）
- mise ツール追加時の正しい aqua パッケージ指定
- mise タスクの定義と実行コマンド

<!-- end of auto-generated comment: release notes by coderabbit.ai -->