### PR TITLE
feat(nvim): add aerial.nvim for code outline and navigation

### DIFF
--- a/dot_config/nvim/lua/plugins/aerial.lua
+++ b/dot_config/nvim/lua/plugins/aerial.lua
@@ -1,0 +1,25 @@
+return {
+  {
+    "stevearc/aerial.nvim",
+    dependencies = {
+      "nvim-treesitter/nvim-treesitter",
+      "nvim-tree/nvim-web-devicons",
+    },
+    config = function()
+      require("aerial").setup({
+        -- optionally use on_attach to set keymaps when aerial has attached to a buffer
+        on_attach = function(bufnr)
+          -- Jump forwards/backwards with '{' and '}'
+          vim.keymap.set("n", "{", "<cmd>AerialPrev<CR>", { buffer = bufnr })
+          vim.keymap.set("n", "}", "<cmd>AerialNext<CR>", { buffer = bufnr })
+        end,
+        layout = {
+          -- Priority for the right side
+          default_direction = "right",
+        },
+      })
+      -- Keybinding: <leader>o to toggle Aerial (leader is ",")
+      vim.keymap.set("n", "<leader>o", "<cmd>AerialToggle<CR>", { desc = "Toggle Aerial" })
+    end,
+  },
+}

--- a/dot_config/nvim/lua/plugins/aerial.lua
+++ b/dot_config/nvim/lua/plugins/aerial.lua
@@ -1,0 +1,19 @@
+return {
+  {
+    "stevearc/aerial.nvim",
+    dependencies = {
+      "nvim-treesitter/nvim-treesitter",
+      "nvim-tree/nvim-web-devicons",
+    },
+    keys = {
+      { "<leader>o", "<cmd>AerialToggle<CR>", desc = "Toggle Aerial" },
+    },
+    config = function()
+      require("aerial").setup({
+        layout = {
+          default_direction = "right",
+        },
+      })
+    end,
+  },
+}


### PR DESCRIPTION
Add aerial.nvim configuration in dot_config/nvim/lua/plugins/aerial.lua.
- Configure aerial to open on the right side by default.
- Add keybinding <leader>o (,o) to toggle aerial window.
- Enable treesitter-based outline navigation (supports Markdown headings).
- Add dependencies on nvim-treesitter and nvim-web-devicons.

---
*PR created automatically by Jules for task [3159046899848100348](https://jules.google.com/task/3159046899848100348) started by @ryo246912*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

Neovim プラグインマネージャーの対応形式に従い、`dot_config/nvim/lua/plugins/aerial.lua` に aerial.nvim のプラグイン定義を新規追加しました。

aerial.nvim は、Treesitter ベースのコード構造をアウトラインパネルで表示するプラグインです。本設定では以下を構成しています：

- アウトラインパネルをデフォルトで右側に配置
- `<leader>o`（`,o`）でアウトラインウィンドウの表示/非表示を切り替え
- `{` キーで前のシンボルへ、`}` キーで次のシンボルへジャンプ
- 依存プラグインとして nvim-treesitter および nvim-web-devicons を指定

## 変更理由

コード構造の可視化とシンボル間の素早いナビゲーション機能を Neovim エディタに導入するため。

## 確認した項目

- aerial.nvim の基本設定は正しく実装されている
- 依存プラグインの指定が適切に行われている
- キーマップ（`{`、`}`、`<leader>o`）は競合を避けた形で設定されている
- Lua プラグイン定義の構文に誤りはない

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryo246912/dotfiles/pull/946)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->