### PR TITLE
feature

### DIFF
--- a/dot_config/obsidian/obsidian-web-clipper-settings.json
+++ b/dot_config/obsidian/obsidian-web-clipper-settings.json
@@ -1,126 +1,11 @@
 {
-  "general_settings": {
-    "betaFeatures": false,
-    "legacyMode": false,
-    "openBehavior": "popup",
-    "saveBehavior": "addToObsidian",
-    "showMoreActionsButton": false,
-    "silentOpen": true
-  },
-  "highlighter_settings": {
-    "alwaysShowHighlights": true,
-    "highlightBehavior": "highlight-inline",
-    "highlighterEnabled": true
-  },
-  "interpreter_settings": {
-    "defaultPromptContext": "{{content}}",
-    "interpreterAutoRun": false,
-    "interpreterEnabled": false,
-    "interpreterModel": "1748053054250",
-    "models": [],
-    "providers": []
-  },
-  "migrationVersion": 1,
-  "property_types": [
-    {
-      "defaultValue": "{{title}}",
-      "name": "title",
-      "type": "text"
-    },
-    {
-      "defaultValue": "{{url}}",
-      "name": "source",
-      "type": "text"
-    },
-    {
-      "defaultValue": "{{author|split:\", \"|wikilink|join}}",
-      "name": "author",
-      "type": "multitext"
-    },
-    {
-      "defaultValue": "{{published|date:\"YYYY-MM-DD HH:mm\"}}",
-      "name": "published",
-      "type": "date"
-    },
-    {
-      "defaultValue": "{{date|date:\"YYYY-MM-DD HH:mm\"}}",
-      "name": "created",
-      "type": "date"
-    },
-    {
-      "defaultValue": "clippings",
-      "name": "tags",
-      "type": "multitext"
-    }
-  ],
-  "reader_settings": {
-    "fontSize": 1.5,
-    "lineHeight": 1.6,
-    "maxWidth": 38,
-    "theme": "default",
-    "themeMode": "auto"
-  },
-  "stats": {
-    "addToObsidian": 447,
-    "copyToClipboard": 0,
-    "saveFile": 1,
-    "share": 0
-  },
-  "template_17479604476272zkthch46": {
-    "id": "17479604476272zkthch46",
-    "name": "その他",
-    "behavior": "create",
-    "noteNameFormat": "{{title | safe_name}}",
-    "path": "Zettelkasten/B-literatures-その他",
-    "noteContentFormat": "# 本文\n{{content}}\n\n{{description}}",
-    "context": "",
-    "properties": [
-      {
-        "id": "17479604476298ml4ark8l",
-        "name": "title",
-        "value": "{{title}}",
-        "type": "text"
-      },
-      {
-        "id": "17479604476292e8zkrk27",
-        "name": "source",
-        "value": "{{url}}",
-        "type": "text"
-      },
-      {
-        "id": "1747960447629aqditkkpo",
-        "name": "author",
-        "value": "{{author|split:\\\", \\\"|wikilink|join}}",
-        "type": "multitext"
-      },
-      {
-        "id": "1747960447629qvyt0i0j6",
-        "name": "published",
-        "value": "{{published|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
-        "type": "date"
-      },
-      {
-        "id": "1747960447629pyu4quqor",
-        "name": "created",
-        "value": "{{date|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
-        "type": "date"
-      },
-      {
-        "id": "1747960447629h94smprei",
-        "name": "tags",
-        "value": "",
-        "type": "multitext"
-      }
-    ],
-    "triggers": []
-  },
   "template_1748048827125g2jzjqoyo": {
     "id": "1748048827125g2jzjqoyo",
     "name": "Twitter",
     "behavior": "create",
-    "noteNameFormat": "{{meta:property:og:title | split:\":\" | nth:n+2 | join:\"--\" | safe_name | slice:0,40}}",
+    "noteNameFormat": "{{meta:property:\"og:title\" | split:\":\" | slice:-2 | join:\"--\" | safe_name | slice:0,40}}",
     "path": "Zettelkasten/B-Tweet",
-    "noteContentFormat": "{{content}}\n\n{{description}}",
+    "noteContentFormat": "{{content}}",
     "context": "",
     "properties": [
       {
@@ -162,7 +47,437 @@
     ],
     "triggers": [
       "https://x.com/"
-    ]
+    ],
+    "vault": "obsidian"
+  },
+  "template_1762524538731sgguhvrz4": {
+    "id": "1762524538731sgguhvrz4",
+    "name": "Twitter(その他)",
+    "behavior": "create",
+    "noteNameFormat": "{{meta:property:\"og:title\" | split:\":\" | slice:-2 | join:\"--\" | safe_name | slice:0,40}}",
+    "path": "Zettelkasten/B-Tweet-その他",
+    "noteContentFormat": "{{content}}",
+    "context": "",
+    "properties": [
+      {
+        "id": "17479604476298ml4ark8l",
+        "name": "title",
+        "value": "{{meta:property:og:title}}",
+        "type": "text"
+      },
+      {
+        "id": "17479604476292e8zkrk27",
+        "name": "source",
+        "value": "{{url}}",
+        "type": "text"
+      },
+      {
+        "id": "1747960447629aqditkkpo",
+        "name": "author",
+        "value": "{{author|split:\\\", \\\"|wikilink|join}}",
+        "type": "multitext"
+      },
+      {
+        "id": "1747960447629qvyt0i0j6",
+        "name": "published",
+        "value": "{{published|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
+        "type": "date"
+      },
+      {
+        "id": "1747960447629pyu4quqor",
+        "name": "created",
+        "value": "{{date|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
+        "type": "date"
+      },
+      {
+        "id": "1747960447629h94smprei",
+        "name": "tags",
+        "value": "clippings,twitter",
+        "type": "multitext"
+      }
+    ],
+    "triggers": [
+      "https://x.com/"
+    ],
+    "vault": "obsidian"
+  },
+  "stats": {
+    "addToObsidian": 450,
+    "copyToClipboard": 0,
+    "saveFile": 1,
+    "share": 0
+  },
+  "migrationVersion": 1,
+  "vaults": [
+    "obsidian"
+  ],
+  "general_settings": {
+    "showMoreActionsButton": false,
+    "betaFeatures": false,
+    "legacyMode": false,
+    "silentOpen": true,
+    "openBehavior": "popup",
+    "saveBehavior": "addToObsidian"
+  },
+  "highlighter_settings": {
+    "highlighterEnabled": true,
+    "alwaysShowHighlights": true,
+    "highlightBehavior": "highlight-inline"
+  },
+  "property_types": [
+    {
+      "defaultValue": "{{title}}",
+      "name": "title",
+      "type": "text"
+    },
+    {
+      "defaultValue": "{{url}}",
+      "name": "source",
+      "type": "text"
+    },
+    {
+      "defaultValue": "{{author|split:\", \"|wikilink|join}}",
+      "name": "author",
+      "type": "multitext"
+    },
+    {
+      "defaultValue": "{{published|date:\"YYYY-MM-DD HH:mm\"}}",
+      "name": "published",
+      "type": "date"
+    },
+    {
+      "defaultValue": "{{date|date:\"YYYY-MM-DD HH:mm\"}}",
+      "name": "created",
+      "type": "date"
+    },
+    {
+      "defaultValue": "clippings",
+      "name": "tags",
+      "type": "multitext"
+    }
+  ],
+  "template_1762524404538gn36gf2aj": {
+    "id": "1762524404538gn36gf2aj",
+    "name": "Twitter(投資)",
+    "behavior": "create",
+    "noteNameFormat": "{{meta:property:\"og:title\" | split:\":\" | slice:-2 | join:\"--\" | safe_name | slice:0,40}}",
+    "path": "Zettelkasten/B-Tweet-投資",
+    "noteContentFormat": "{{content}}",
+    "context": "",
+    "properties": [
+      {
+        "id": "17479604476298ml4ark8l",
+        "name": "title",
+        "value": "{{meta:property:og:title}}",
+        "type": "text"
+      },
+      {
+        "id": "17479604476292e8zkrk27",
+        "name": "source",
+        "value": "{{url}}",
+        "type": "text"
+      },
+      {
+        "id": "1747960447629aqditkkpo",
+        "name": "author",
+        "value": "{{author|split:\\\", \\\"|wikilink|join}}",
+        "type": "multitext"
+      },
+      {
+        "id": "1747960447629qvyt0i0j6",
+        "name": "published",
+        "value": "{{published|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
+        "type": "date"
+      },
+      {
+        "id": "1747960447629pyu4quqor",
+        "name": "created",
+        "value": "{{date|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
+        "type": "date"
+      },
+      {
+        "id": "1747960447629h94smprei",
+        "name": "tags",
+        "value": "clippings,twitter",
+        "type": "multitext"
+      }
+    ],
+    "triggers": [
+      "https://x.com/"
+    ],
+    "vault": "obsidian"
+  },
+  "template_1762524566401svkuvd3x7": {
+    "id": "1762524566401svkuvd3x7",
+    "name": "Twitter(料理)",
+    "behavior": "create",
+    "noteNameFormat": "{{meta:property:\"og:title\" | split:\":\" | slice:-2 | join:\"--\" | safe_name | slice:0,40}}",
+    "path": "01-生活/料理/レシピ一覧",
+    "noteContentFormat": "{{content}}",
+    "context": "",
+    "properties": [
+      {
+        "id": "17479604476298ml4ark8l",
+        "name": "title",
+        "value": "{{meta:property:og:title}}",
+        "type": "text"
+      },
+      {
+        "id": "17479604476292e8zkrk27",
+        "name": "source",
+        "value": "{{url}}",
+        "type": "text"
+      },
+      {
+        "id": "1747960447629aqditkkpo",
+        "name": "author",
+        "value": "{{author|split:\\\", \\\"|wikilink|join}}",
+        "type": "multitext"
+      },
+      {
+        "id": "1747960447629qvyt0i0j6",
+        "name": "published",
+        "value": "{{published|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
+        "type": "date"
+      },
+      {
+        "id": "1747960447629pyu4quqor",
+        "name": "created",
+        "value": "{{date|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
+        "type": "date"
+      },
+      {
+        "id": "1747960447629h94smprei",
+        "name": "tags",
+        "value": "clippings,twitter",
+        "type": "multitext"
+      }
+    ],
+    "triggers": [
+      "https://x.com/"
+    ],
+    "vault": "obsidian"
+  },
+  "reader_settings": {
+    "fontSize": 1.5,
+    "lineHeight": 1.6,
+    "maxWidth": 38,
+    "lightTheme": "default",
+    "darkTheme": "same",
+    "appearance": "auto",
+    "fonts": [],
+    "defaultFont": "",
+    "blendImages": true,
+    "colorLinks": false,
+    "followLinks": true,
+    "pinPlayer": true,
+    "autoScroll": true,
+    "highlightActiveLine": true,
+    "customCss": ""
+  },
+  "template_17697040617408wzbska46": {
+    "id": "17697040617408wzbska46",
+    "name": "料理",
+    "behavior": "create",
+    "noteNameFormat": "{{title | safe_name}}",
+    "path": "01-生活/料理/レシピ一覧",
+    "noteContentFormat": "#content\n{{content}}\n\n#description\n{{description}}\n\n#schema:@VideoObject:description\n{{schema:@VideoObject:description}}",
+    "context": "",
+    "properties": [
+      {
+        "id": "17479604476298ml4ark8l",
+        "name": "title",
+        "value": "{{title}}",
+        "type": "text"
+      },
+      {
+        "id": "17479604476292e8zkrk27",
+        "name": "source",
+        "value": "{{url}}",
+        "type": "text"
+      },
+      {
+        "id": "1747960447629aqditkkpo",
+        "name": "author",
+        "value": "{{author|split:\\\", \\\"|wikilink|join}}",
+        "type": "multitext"
+      },
+      {
+        "id": "1747960447629qvyt0i0j6",
+        "name": "published",
+        "value": "{{published|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
+        "type": "date"
+      },
+      {
+        "id": "1747960447629pyu4quqor",
+        "name": "created",
+        "value": "{{date|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
+        "type": "date"
+      },
+      {
+        "id": "1747960447629h94smprei",
+        "name": "tags",
+        "value": "料理",
+        "type": "multitext"
+      }
+    ],
+    "triggers": [],
+    "vault": "obsidian"
+  },
+  "template_17479604476272zkthch46": {
+    "id": "17479604476272zkthch46",
+    "name": "その他",
+    "behavior": "create",
+    "noteNameFormat": "{{title | safe_name}}",
+    "path": "Zettelkasten/B-literatures-その他",
+    "noteContentFormat": "#content\n{{content}}\n\n#description\n{{description}}\n\n#schema:@VideoObject:description\n{{schema:@VideoObject:description}}",
+    "context": "",
+    "properties": [
+      {
+        "id": "17479604476298ml4ark8l",
+        "name": "title",
+        "value": "{{title}}",
+        "type": "text"
+      },
+      {
+        "id": "17479604476292e8zkrk27",
+        "name": "source",
+        "value": "{{url}}",
+        "type": "text"
+      },
+      {
+        "id": "1747960447629aqditkkpo",
+        "name": "author",
+        "value": "{{author|split:\\\", \\\"|wikilink|join}}",
+        "type": "multitext"
+      },
+      {
+        "id": "1747960447629qvyt0i0j6",
+        "name": "published",
+        "value": "{{published|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
+        "type": "date"
+      },
+      {
+        "id": "1747960447629pyu4quqor",
+        "name": "created",
+        "value": "{{date|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
+        "type": "date"
+      },
+      {
+        "id": "1747960447629h94smprei",
+        "name": "tags",
+        "value": "",
+        "type": "multitext"
+      }
+    ],
+    "triggers": [],
+    "vault": "obsidian"
+  },
+  "template_17697036889821b4i3eg8d": {
+    "id": "17697036889821b4i3eg8d",
+    "name": "デフォルト",
+    "behavior": "create",
+    "noteNameFormat": "{{title | safe_name}}",
+    "path": "Zettelkasten/B-literatures",
+    "noteContentFormat": "# 本文\n{{content}}\n\n{{description}}",
+    "context": "",
+    "properties": [
+      {
+        "id": "17479604476298ml4ark8l",
+        "name": "title",
+        "value": "{{title}}",
+        "type": "text"
+      },
+      {
+        "id": "17479604476292e8zkrk27",
+        "name": "source",
+        "value": "{{url}}",
+        "type": "text"
+      },
+      {
+        "id": "1747960447629aqditkkpo",
+        "name": "author",
+        "value": "{{author|split:\\\", \\\"|wikilink|join}}",
+        "type": "multitext"
+      },
+      {
+        "id": "1747960447629qvyt0i0j6",
+        "name": "published",
+        "value": "{{published|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
+        "type": "date"
+      },
+      {
+        "id": "1747960447629pyu4quqor",
+        "name": "created",
+        "value": "{{date|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
+        "type": "date"
+      },
+      {
+        "id": "1747960447629h94smprei",
+        "name": "tags",
+        "value": "",
+        "type": "multitext"
+      }
+    ],
+    "triggers": [],
+    "vault": "obsidian"
+  },
+  "template_1763793173378ns8wxka41": {
+    "id": "1763793173378ns8wxka41",
+    "name": "投資",
+    "behavior": "create",
+    "noteNameFormat": "{{title | safe_name}}",
+    "path": "Zettelkasten/B-literatures-投資",
+    "noteContentFormat": "#content\n{{content}}\n\n#description\n{{description}}\n\n#schema:@VideoObject:description\n{{schema:@VideoObject:description}}",
+    "context": "",
+    "properties": [
+      {
+        "id": "17479604476298ml4ark8l",
+        "name": "title",
+        "value": "{{title}}",
+        "type": "text"
+      },
+      {
+        "id": "17479604476292e8zkrk27",
+        "name": "source",
+        "value": "{{url}}",
+        "type": "text"
+      },
+      {
+        "id": "1747960447629aqditkkpo",
+        "name": "author",
+        "value": "{{author|split:\\\", \\\"|wikilink|join}}",
+        "type": "multitext"
+      },
+      {
+        "id": "1747960447629qvyt0i0j6",
+        "name": "published",
+        "value": "{{published|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
+        "type": "date"
+      },
+      {
+        "id": "1747960447629pyu4quqor",
+        "name": "created",
+        "value": "{{date|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
+        "type": "date"
+      },
+      {
+        "id": "1747960447629h94smprei",
+        "name": "tags",
+        "value": "",
+        "type": "multitext"
+      }
+    ],
+    "triggers": [],
+    "vault": "obsidian"
+  },
+  "interpreter_settings": {
+    "interpreterModel": "1748053054250",
+    "models": [],
+    "providers": [],
+    "interpreterEnabled": false,
+    "interpreterAutoRun": false,
+    "defaultPromptContext": "{{content}}"
   },
   "template_1748071137900417311pbg": {
     "id": "1748071137900417311pbg",
@@ -212,15 +527,16 @@
     ],
     "triggers": [
       "https://speakerdeck.com/"
-    ]
+    ],
+    "vault": "obsidian"
   },
-  "template_1748160596431c0rxqbq4k": {
-    "id": "1748160596431c0rxqbq4k",
-    "name": "検索メモ",
+  "template_1770458445953fde3ae9jb": {
+    "id": "1770458445953fde3ae9jb",
+    "name": "娯楽",
     "behavior": "create",
     "noteNameFormat": "{{title | safe_name}}",
-    "path": "Zettelkasten/A-fleetings",
-    "noteContentFormat": "{{content}}",
+    "path": "Zettelkasten/B-literatures-娯楽",
+    "noteContentFormat": "#content\n{{content}}\n\n#description\n{{description}}\n\n#schema:@VideoObject:description\n{{schema:@VideoObject:description}}",
     "context": "",
     "properties": [
       {
@@ -256,317 +572,23 @@
       {
         "id": "1747960447629h94smprei",
         "name": "tags",
-        "value": "clippings,検索メモ",
+        "value": "料理",
         "type": "multitext"
       }
     ],
-    "triggers": []
-  },
-  "template_1762524404538gn36gf2aj": {
-    "id": "1762524404538gn36gf2aj",
-    "name": "Twitter(投資)",
-    "behavior": "create",
-    "noteNameFormat": "{{meta:property:og:title | split:\":\" | nth:n+2 | join:\"--\" | safe_name | slice:0,40}}",
-    "path": "Zettelkasten/B-Tweet-投資",
-    "noteContentFormat": "{{content}}\n\n{{description}}",
-    "context": "",
-    "properties": [
-      {
-        "id": "17479604476298ml4ark8l",
-        "name": "title",
-        "value": "{{meta:property:og:title}}",
-        "type": "text"
-      },
-      {
-        "id": "17479604476292e8zkrk27",
-        "name": "source",
-        "value": "{{url}}",
-        "type": "text"
-      },
-      {
-        "id": "1747960447629aqditkkpo",
-        "name": "author",
-        "value": "{{author|split:\\\", \\\"|wikilink|join}}",
-        "type": "multitext"
-      },
-      {
-        "id": "1747960447629qvyt0i0j6",
-        "name": "published",
-        "value": "{{published|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
-        "type": "date"
-      },
-      {
-        "id": "1747960447629pyu4quqor",
-        "name": "created",
-        "value": "{{date|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
-        "type": "date"
-      },
-      {
-        "id": "1747960447629h94smprei",
-        "name": "tags",
-        "value": "clippings,twitter",
-        "type": "multitext"
-      }
-    ],
-    "triggers": [
-      "https://x.com/"
-    ]
-  },
-  "template_1762524538731sgguhvrz4": {
-    "id": "1762524538731sgguhvrz4",
-    "name": "Twitter(その他)",
-    "behavior": "create",
-    "noteNameFormat": "{{meta:property:og:title | split:\":\" | nth:n+2 | join:\"--\" | safe_name | slice:0,40}}",
-    "path": "Zettelkasten/B-Tweet-その他",
-    "noteContentFormat": "{{content}}\n\n{{description}}",
-    "context": "",
-    "properties": [
-      {
-        "id": "17479604476298ml4ark8l",
-        "name": "title",
-        "value": "{{meta:property:og:title}}",
-        "type": "text"
-      },
-      {
-        "id": "17479604476292e8zkrk27",
-        "name": "source",
-        "value": "{{url}}",
-        "type": "text"
-      },
-      {
-        "id": "1747960447629aqditkkpo",
-        "name": "author",
-        "value": "{{author|split:\\\", \\\"|wikilink|join}}",
-        "type": "multitext"
-      },
-      {
-        "id": "1747960447629qvyt0i0j6",
-        "name": "published",
-        "value": "{{published|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
-        "type": "date"
-      },
-      {
-        "id": "1747960447629pyu4quqor",
-        "name": "created",
-        "value": "{{date|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
-        "type": "date"
-      },
-      {
-        "id": "1747960447629h94smprei",
-        "name": "tags",
-        "value": "clippings,twitter",
-        "type": "multitext"
-      }
-    ],
-    "triggers": [
-      "https://x.com/"
-    ]
-  },
-  "template_1762524566401svkuvd3x7": {
-    "id": "1762524566401svkuvd3x7",
-    "name": "Twitter(料理)",
-    "behavior": "create",
-    "noteNameFormat": "{{meta:property:og:title | split:\":\" | nth:n+2 | join:\"--\" | safe_name | slice:0,40}}",
-    "path": "01-生活/料理/レシピ一覧",
-    "noteContentFormat": "{{content}}\n\n{{description}}",
-    "context": "",
-    "properties": [
-      {
-        "id": "17479604476298ml4ark8l",
-        "name": "title",
-        "value": "{{meta:property:og:title}}",
-        "type": "text"
-      },
-      {
-        "id": "17479604476292e8zkrk27",
-        "name": "source",
-        "value": "{{url}}",
-        "type": "text"
-      },
-      {
-        "id": "1747960447629aqditkkpo",
-        "name": "author",
-        "value": "{{author|split:\\\", \\\"|wikilink|join}}",
-        "type": "multitext"
-      },
-      {
-        "id": "1747960447629qvyt0i0j6",
-        "name": "published",
-        "value": "{{published|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
-        "type": "date"
-      },
-      {
-        "id": "1747960447629pyu4quqor",
-        "name": "created",
-        "value": "{{date|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
-        "type": "date"
-      },
-      {
-        "id": "1747960447629h94smprei",
-        "name": "tags",
-        "value": "clippings,twitter",
-        "type": "multitext"
-      }
-    ],
-    "triggers": [
-      "https://x.com/"
-    ]
-  },
-  "template_1763793173378ns8wxka41": {
-    "id": "1763793173378ns8wxka41",
-    "name": "投資",
-    "behavior": "create",
-    "noteNameFormat": "{{title | safe_name}}",
-    "path": "Zettelkasten/B-literatures-投資",
-    "noteContentFormat": "# 本文\n{{content}}\n\n{{description}}",
-    "context": "",
-    "properties": [
-      {
-        "id": "17479604476298ml4ark8l",
-        "name": "title",
-        "value": "{{title}}",
-        "type": "text"
-      },
-      {
-        "id": "17479604476292e8zkrk27",
-        "name": "source",
-        "value": "{{url}}",
-        "type": "text"
-      },
-      {
-        "id": "1747960447629aqditkkpo",
-        "name": "author",
-        "value": "{{author|split:\\\", \\\"|wikilink|join}}",
-        "type": "multitext"
-      },
-      {
-        "id": "1747960447629qvyt0i0j6",
-        "name": "published",
-        "value": "{{published|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
-        "type": "date"
-      },
-      {
-        "id": "1747960447629pyu4quqor",
-        "name": "created",
-        "value": "{{date|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
-        "type": "date"
-      },
-      {
-        "id": "1747960447629h94smprei",
-        "name": "tags",
-        "value": "",
-        "type": "multitext"
-      }
-    ],
-    "triggers": []
-  },
-  "template_1763793197119danu9ab27": {
-    "id": "1763793197119danu9ab27",
-    "name": "デフォルト",
-    "behavior": "create",
-    "noteNameFormat": "{{title | safe_name}}",
-    "path": "Zettelkasten/B-literatures",
-    "noteContentFormat": "# 本文\n{{content}}\n\n{{description}}",
-    "context": "",
-    "properties": [
-      {
-        "id": "17479604476298ml4ark8l",
-        "name": "title",
-        "value": "{{title}}",
-        "type": "text"
-      },
-      {
-        "id": "17479604476292e8zkrk27",
-        "name": "source",
-        "value": "{{url}}",
-        "type": "text"
-      },
-      {
-        "id": "1747960447629aqditkkpo",
-        "name": "author",
-        "value": "{{author|split:\\\", \\\"|wikilink|join}}",
-        "type": "multitext"
-      },
-      {
-        "id": "1747960447629qvyt0i0j6",
-        "name": "published",
-        "value": "{{published|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
-        "type": "date"
-      },
-      {
-        "id": "1747960447629pyu4quqor",
-        "name": "created",
-        "value": "{{date|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
-        "type": "date"
-      },
-      {
-        "id": "1747960447629h94smprei",
-        "name": "tags",
-        "value": "",
-        "type": "multitext"
-      }
-    ],
-    "triggers": []
-  },
-  "template_17687212970972eaym0ydg": {
-    "id": "17687212970972eaym0ydg",
-    "name": "料理",
-    "behavior": "create",
-    "noteNameFormat": "{{title | safe_name}}",
-    "path": "01-生活/料理/レシピ一覧",
-    "noteContentFormat": "# 本文\n{{content}}\n\n{{description}}",
-    "context": "",
-    "properties": [
-      {
-        "id": "17479604476298ml4ark8l",
-        "name": "title",
-        "value": "{{title}}",
-        "type": "text"
-      },
-      {
-        "id": "17479604476292e8zkrk27",
-        "name": "source",
-        "value": "{{url}}",
-        "type": "text"
-      },
-      {
-        "id": "1747960447629aqditkkpo",
-        "name": "author",
-        "value": "{{author|split:\\\", \\\"|wikilink|join}}",
-        "type": "multitext"
-      },
-      {
-        "id": "1747960447629qvyt0i0j6",
-        "name": "published",
-        "value": "{{published|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
-        "type": "date"
-      },
-      {
-        "id": "1747960447629pyu4quqor",
-        "name": "created",
-        "value": "{{date|date:\\\"YYYY-MM-DD HH:mm\\\"}}",
-        "type": "date"
-      },
-      {
-        "id": "1747960447629h94smprei",
-        "name": "tags",
-        "value": "",
-        "type": "multitext"
-      }
-    ],
-    "triggers": []
+    "triggers": [],
+    "vault": "obsidian"
   },
   "template_list": [
-    "1763793197119danu9ab27",
+    "17697036889821b4i3eg8d",
+    "17697040617408wzbska46",
+    "1770458445953fde3ae9jb",
     "17479604476272zkthch46",
     "1763793173378ns8wxka41",
-    "17687212970972eaym0ydg",
     "1748071137900417311pbg",
     "1748048827125g2jzjqoyo",
     "1762524404538gn36gf2aj",
     "1762524566401svkuvd3x7",
-    "1762524538731sgguhvrz4",
-    "1748160596431c0rxqbq4k"
-  ],
-  "vaults": []
+    "1762524538731sgguhvrz4"
+  ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

Obsidian Web Clipper の設定ファイルを更新しました。

主な変更は以下の通りです：
- Twitter関連テンプレート（複数）の `noteNameFormat` を変更し、`og:title` からタイトルを抽出する処理を統一
- Twitter関連テンプレートの `triggers` を `https://x.com/` に明示的に設定
- `reader_settings` を大幅に拡張（フォントサイズ、行高、最大幅、テーマ設定、外観モード、画像表示やリンク動作など 12 項目以上を新規追加）
- `vaults` 配列を導入し、Vault設定を明示的に管理可能に
- `template_list` に新しいテンプレート（ID: `1770458445953fde3ae9jb`、名称「娯楽」）を追加し、テンプレートの順序を変更

## 変更理由

Web Clipper の使用体験向上と、クリップ対象の分類をより細かく管理するための機能拡張です。特に reader_settings の拡張により、Web コンテンツの表示スタイルやテーマ対応をより柔軟に制御できるようになり、Twitter/X のリンク検出を明示的に設定することで動作の安定性を向上させています。

## 確認した項目

- reader_settings に fontSize（1.5）、lineHeight（1.6）、maxWidth（38）、lightTheme/darkTheme、appearance（auto）、fonts、colorLinks、followLinks、pinPlayer、autoScroll、highlightActiveLine、customCss など 12 項目以上が新規追加
- vaults 配列が導入され、現在は "obsidian" が設定
- template_list が 10 項目で構成され、新テンプレート「娯楽」が含まれ、表示順序が変更
- 既存の general_settings、highlighter_settings、property_types は基本構造は維持
- 合計 594 行のファイル構成で +180/-158 行の変更

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryo246912/dotfiles/pull/961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->