### PR TITLE
feature2

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -178,7 +178,7 @@ run         = "actionlint -ignore 'SC2016:'"
 
 [tasks.lint-zizmor]
 description = "Run zizmor"
-run         = "zizmor --pedantic --gh-token=$(gh auth token) --min-severity=low .github/workflows"
+run         = "GH_TOKEN=$(gh auth token) zizmor --pedantic --min-severity=low .github/workflows"
 
 [tasks.lint-ghalint]
 description = "Run ghalint"

--- a/dot_config/mise/config.work2.toml
+++ b/dot_config/mise/config.work2.toml
@@ -2,6 +2,7 @@
 "aqua:aquasecurity/trivy"                   = "0.70.0"
 "aqua:aws/aws-cli"                          = "2.34.21"
 "aqua:direnv/direnv"                        = "2.37.1"
+"aqua:hashicorp/terraform"                  = "1.15.2"
 "aqua:keidarcy/e1s"                         = "1.0.53"
 "aqua:leg100/pug"                           = "0.6.5"
 "aqua:rclone/rclone"                        = "1.72.0"
@@ -12,4 +13,3 @@
 "go:gotest.tools/gotestsum"                 = "1.13.0"
 "pipx:awslogs"                              = "0.15.0"
 "pipx:tftui"                                = "0.13.4"
-terraform                                   = "1.15.2"

--- a/dot_config/navi/cheats/aws.cheat.md
+++ b/dot_config/navi/cheats/aws.cheat.md
@@ -19,8 +19,8 @@ aws sts get-caller-identity --profile <profile>
 # sso : login sso
 aws sso login --profile <profile> && export AWS_PROFILE=<profile>
 
-# aws-vault : run command with temporary credentials
-aws-vault exec <profile> -- aws sts get-caller-identity
+# aws-vault : run command with temporary credentials [ex.aws-vault exec <profile> -- aws sts get-caller-identity]
+aws-vault exec <profile> --
 
 # aws-vault : login AWS console
 aws-vault login <profile> && export AWS_PROFILE=<profile>

--- a/dot_config/navi/cheats/other.cheat.md
+++ b/dot_config/navi/cheats/other.cheat.md
@@ -65,10 +65,10 @@ rclone lsd <remote>:<folder-name>
 rclone copy <remote>:<folder-name> <remote2>:<folder-name2> -P
 
 # renovate: dry-run remote
-LOG_LEVEL=debug renovate --token "$(gh auth token)" --dry-run ryo246912/dotfiles
+RENOVATE_TOKEN=$(gh auth token) LOG_LEVEL=debug renovate --dry-run ryo246912/dotfiles
 
 # renovate: run local
-LOG_LEVEL=debug renovate --token "$(gh auth token)" --dry-run --platform=local
+RENOVATE_TOKEN=$(gh auth token) LOG_LEVEL=debug renovate --dry-run --platform=local
 
 # renovate: create renovate dependency dashboard
 RENOVATE_TOKEN=$(gh auth token) renovate --platform github ryo246912/dotfiles

--- a/dot_config/navi/cheats/other.cheat.md
+++ b/dot_config/navi/cheats/other.cheat.md
@@ -65,10 +65,13 @@ rclone lsd <remote>:<folder-name>
 rclone copy <remote>:<folder-name> <remote2>:<folder-name2> -P
 
 # renovate: dry-run remote
-LOG_LEVEL=debug renovate --token "$(ghtkn get)" --dry-run ryo246912/dotfiles
+LOG_LEVEL=debug renovate --token "$(gh auth token)" --dry-run ryo246912/dotfiles
 
 # renovate: run local
-LOG_LEVEL=debug renovate --token "$(ghtkn get)" --dry-run --platform=local
+LOG_LEVEL=debug renovate --token "$(gh auth token)" --dry-run --platform=local
+
+# renovate: create renovate dependency dashboard
+RENOVATE_TOKEN=$(gh auth token) renovate --platform github ryo246912/dotfiles
 
 # vim : move n rows
 :<n>

--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -247,7 +247,7 @@ set -g @plugin 'ryo246912/tmux-resurrect'
 set -g @resurrect-capture-pane-contents 'on'
 ## restore process [~:プロセス名が部分一致していたら、そのプロセスを復元する][->:復元の際に、指定したコマンド名で復元する][*:復元の際に、引数は保持した状態でコマンド名で復元する]
 ## https://github.com/tmux-plugins/tmux-resurrect/blob/cff343cf9e81983d3da0c8562b01616f12e8d548/docs/restoring_programs.md#clarifications
-set -g @resurrect-processes '"~vim -> vim" "~nvim > nvim" "~make" "~npm" "~docker"'
+set -g @resurrect-processes '"~vim -> vim" "~nvim -> nvim" "~make" "~docker"'
 ## restore vim session
 set -g @resurrect-strategy-vim 'session'
 set -g @resurrect-strategy-nvim 'session'

--- a/dot_config/zabrze/ai.toml
+++ b/dot_config/zabrze/ai.toml
@@ -18,13 +18,13 @@ trigger-pattern = "(^ccmc2$|ccmcc2)"
 [[snippets]]
 name    = "devcontainer up"
 snippet = "devcontainer up --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json"
-trigger = "dcu"
+trigger = "dcup"
 
 [[snippets]]
 cursor  = "👇"
 name    = "devcontainer exec"
 snippet = "devcontainer exec --workspace-folder . --config $HOME/.config/devcontainer/devcontainer.json -- 👇"
-trigger = "dce"
+trigger = "dcex"
 
 [[snippets]]
 name    = "mcp-cli"

--- a/dot_config/zabrze/terraform.toml
+++ b/dot_config/zabrze/terraform.toml
@@ -1,79 +1,111 @@
 [[snippets]]
+context         = "^(aws-vault\\s|[^\\s]+$)"
+global          = true
 name            = "terraform"
 snippet         = "terraform"
 trigger-pattern = "^tf$"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform init"
 snippet = "terraform init"
 trigger = "tfi"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform plan"
 snippet = "terraform plan"
 trigger = "tfp"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform plan (Debug: All)"
 snippet = "TF_LOG=DEBUG terraform plan"
 trigger = "tfpd"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform plan (Debug: Core)"
 snippet = "TF_LOG_CORE=DEBUG terraform plan"
 trigger = "tfpdc"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform plan (Debug: Provider)"
 snippet = "TF_LOG_PROVIDER=DEBUG terraform plan"
 trigger = "tfpdp"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform apply"
 snippet = "terraform apply"
 trigger = "tfa"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform apply (Debug: All)"
 snippet = "TF_LOG=DEBUG terraform apply"
 trigger = "tfad"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform apply (Debug: Core)"
 snippet = "TF_LOG_CORE=DEBUG terraform apply"
 trigger = "tfadc"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform apply (Debug: Provider)"
 snippet = "TF_LOG_PROVIDER=DEBUG terraform apply"
 trigger = "tfadp"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform fmt -recursive"
 snippet = "terraform fmt -recursive"
 trigger = "tff"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform validate"
 snippet = "terraform validate"
 trigger = "tfv"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform show"
 snippet = "terraform show"
 trigger = "tfs"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform state"
 snippet = "terraform state"
 trigger = "tfst"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform workspace"
 snippet = "terraform workspace"
 trigger = "tfw"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "terraform output"
 snippet = "terraform output"
 trigger = "tfo"
@@ -100,14 +132,18 @@ snippet = "tflint --fix"
 trigger = "tflf"
 
 [[snippets]]
+context = "^(aws-vault\\s|[^\\s]+$)"
+global  = true
 name    = "tftui"
 snippet = "tftui"
 trigger = "tft"
 
 [[snippets]]
-name    = "pug (tetui2)"
-snippet = "pug"
-trigger = "tft2"
+context         = "^(aws-vault\\s|[^\\s]+$)"
+global          = true
+name            = "pug (tftui2)"
+snippet         = "pug"
+trigger-pattern = "(tft2|tftt)"
 
 # trivy
 [[snippets]]

--- a/mise.toml
+++ b/mise.toml
@@ -40,7 +40,7 @@ run         = "actionlint -ignore 'SC2016:'"
 [tasks.lint-zizmor]
 description = "Run zizmor"
 hide        = true
-run         = "zizmor --config zizmor.yml --pedantic --gh-token=$(gh auth token) --min-severity=low .github/workflows"
+run         = "GH_TOKEN=$(gh auth token) zizmor --config zizmor.yml --pedantic --min-severity=low .github/workflows"
 
 [tasks.lint-ghalint]
 description = "Run ghalint"


### PR DESCRIPTION
- **chore: renovate snippet**
- **chore(tmux): update tmux.conf**
- **chore(ai): update ai snippet**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更内容概要

dotfiles のスニペット定義や設定ファイルの細かな更新をまとめた PR です。主な変更点は以下の通りです：
- renovate 関連のチートコマンドを更新し、トークン取得を $(ghtkn get) から $(gh auth token) に切替。依存関係ダッシュボード作成用の実行例（RENOVATE_TOKEN に gh トークンを設定しての実行）を追加。
- tmux の resurrect 設定を調整し、復元対象プロセスリストから ~npm を削除（~make と ~docker は維持）。
- zabrze の AI スニペットでトリガー名を変更（devcontainer up: dcu → dcup、devcontainer exec: dce → dcex）。
- Terraform 関連スニペットに context と global = true を追加し、いくつかのスニペットで trigger → trigger-pattern への移行や空ブロックの整理を実施（コミットにある「terraform スニペットの context 追加」を含む）。
- mise のツール定義で terraform を明示的に aqua:hashicorp/terraform で指定。

## 変更理由

- GitHub トークン取得コマンドや実務的な運用方法の変化（ghtkn から gh へ）に合わせるため。
- スニペットの適用範囲（context）やグローバル設定を明確にしてトリガーの競合を避け、ユーザビリティを向上させるため。
- tmux のセッション復元で不要なプロセスを復元しないよう挙動を見直すため。
- ツール指定を明確にして環境依存の差異を減らすため。

（terraform スニペットの context 追加は適用範囲明示が主目的と推測）

## 確認した項目

- 変更ファイルの基本的な形式・構文に重大な問題がないことを目視で確認（スニペット定義、tmux 設定、Markdown の整合）。
- renovate 関連コマンドと RENOVATE_TOKEN の取り扱いが整合していること。
- スニペットのトリガー名変更や trigger-pattern 化が既存トリガーと衝突しないこと（目視で確認）。
- terraform 関連の context/global 追加と mise のツール指定が期待どおりの適用範囲を示していること（差分からの確認）。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryo246912/dotfiles/pull/965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->