### PR TITLE
Fix Yazi TOML parse error in keymap.toml

### DIFF
--- a/dot_config/yazi/keymap.toml
+++ b/dot_config/yazi/keymap.toml
@@ -1,5 +1,4 @@
 # https://github.com/sxyazi/yazi/blob/shipped/yazi-config/preset/keymap-default.toml
-"$schema" = "https://yazi-rs.github.io/schemas/keymap.json"
 [mgr]
 prepend_keymap = [
     { on = "z", run = "plugin zoxide", desc = "Jump to a directory via zoxide" },


### PR DESCRIPTION
The error was caused by the `"$schema"` key in `dot_config/yazi/keymap.toml`. Yazi's TOML parser requires top-level keys to be kebab-cased, and `"$schema"` violates this rule. Additionally, Yazi does not natively support the `$schema` key.

I have removed the line to resolve the parse error and verified that the file now passes basic TOML validation.

---
*PR created automatically by Jules for task [12619919451497805910](https://jules.google.com/task/12619919451497805910) started by @ryo246912*