### PR TITLE
Fix git-secrets configuration error in git config template

### DIFF
--- a/dot_config/git/config.tmpl
+++ b/dot_config/git/config.tmpl
@@ -57,5 +57,5 @@
 [secrets]
 	providers = git secrets --aws-provider
 	patterns = (A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}
-	patterns = \"?aws_secret_access_key\"?[[:space:]]*[:=][[:space:]]*\"?[A-Za-z0-9/\+=]{40}\"?
-	patterns = \"?aws_session_token\"?[[:space:]]*[:=][[:space:]]*\"?[A-Za-z0-9/\+=]{16,}\"?
+	patterns = \"?aws_secret_access_key\"?[[:space:]]*[:=][[:space:]]*\"?[A-Za-z0-9/\\+=]{40}\"?
+	patterns = \"?aws_session_token\"?[[:space:]]*[:=][[:space:]]*\"?[A-Za-z0-9/\\+=]{16,}\"?


### PR DESCRIPTION
Corrected the regex patterns for git-secrets in the dotfiles git config template. The previous patterns were not properly quoted or escaped for the Git configuration file format, resulting in "fatal: bad config line" errors. Verified the fix by confirming that the generated config is now valid and correctly interpreted by Git.

---
*PR created automatically by Jules for task [6933103213335560367](https://jules.google.com/task/6933103213335560367) started by @ryo246912*