### PR TITLE
Add fzf task selection to multi-worktree subcommands

### DIFF
--- a/dot_local/bin/executable_multi-worktree
+++ b/dot_local/bin/executable_multi-worktree
@@ -1228,6 +1228,16 @@ cmd_recreate() {
 }
 
 # list サブコマンド
+# fzf を使用してタスクを選択する
+select_task_via_fzf() {
+    local selected
+    selected=$(cmd_list | fzf --header "Select a task" --preview "multi-worktree status {1}" 2>/dev/null)
+    if [[ -z "$selected" ]]; then
+        return 1
+    fi
+    echo "$selected" | cut -f1
+}
+
 cmd_list() {
     # 全グループを取得
     local all_groups=()
@@ -2009,9 +2019,11 @@ main() {
             check_config || return 1
 
             if [[ $# -eq 0 ]]; then
-                log_error "タスク名を指定してください"
-                show_usage
-                return 1
+                local task_name
+                if ! task_name=$(select_task_via_fzf); then
+                    return 0
+                fi
+                set -- "$task_name" "$@"
             fi
 
             local task_name="$1"
@@ -2051,9 +2063,11 @@ main() {
             check_config || return 1
 
             if [[ $# -eq 0 ]]; then
-                log_error "タスク名を指定してください"
-                show_usage
-                return 1
+                local task_name
+                if ! task_name=$(select_task_via_fzf); then
+                    return 0
+                fi
+                set -- "$task_name" "$@"
             fi
 
             if [[ "$1" == "main" ]]; then
@@ -2082,9 +2096,11 @@ main() {
             check_config || return 1
 
             if [[ $# -eq 0 ]]; then
-                log_error "タスク名を指定してください"
-                show_usage
-                return 1
+                local task_name
+                if ! task_name=$(select_task_via_fzf); then
+                    return 0
+                fi
+                set -- "$task_name" "$@"
             fi
 
             local task_name="$1"
@@ -2115,9 +2131,11 @@ main() {
             check_config || return 1
 
             if [[ $# -eq 0 ]]; then
-                log_error "タスク名を指定してください"
-                show_usage
-                return 1
+                local task_name
+                if ! task_name=$(select_task_via_fzf); then
+                    return 0
+                fi
+                set -- "$task_name" "$@"
             fi
 
             cmd_cd "$1" "${2:-}"
@@ -2127,9 +2145,11 @@ main() {
             check_config || return 1
 
             if [[ $# -eq 0 ]]; then
-                log_error "タスク名を指定してください"
-                show_usage
-                return 1
+                local task_name
+                if ! task_name=$(select_task_via_fzf); then
+                    return 0
+                fi
+                set -- "$task_name" "$@"
             fi
 
             local task_name="$1"
@@ -2142,9 +2162,11 @@ main() {
             check_config || return 1
 
             if [[ $# -eq 0 ]]; then
-                log_error "タスク名を指定してください"
-                show_usage
-                return 1
+                local task_name
+                if ! task_name=$(select_task_via_fzf); then
+                    return 0
+                fi
+                set -- "$task_name" "$@"
             fi
 
             if [[ "$1" == "main" ]]; then
@@ -2189,9 +2211,11 @@ main() {
             check_config || return 1
 
             if [[ $# -eq 0 ]]; then
-                log_error "タスク名を指定してください"
-                show_usage
-                return 1
+                local task_name
+                if ! task_name=$(select_task_via_fzf); then
+                    return 0
+                fi
+                set -- "$task_name" "$@"
             fi
 
             cmd_open "$1"
@@ -2201,9 +2225,11 @@ main() {
             check_config || return 1
 
             if [[ $# -eq 0 ]]; then
-                log_error "タスク名を指定してください"
-                show_usage
-                return 1
+                local task_name
+                if ! task_name=$(select_task_via_fzf); then
+                    return 0
+                fi
+                set -- "$task_name" "$@"
             fi
 
             local task_name="$1"


### PR DESCRIPTION
test


I improved the `multi-worktree` tool to support interactive task selection using `fzf`.

When subcommands like `cd`, `recreate`, `status`, `sync`, `dev`, `exec`, `open`, or `remove` are executed without specifying a task name, the tool now presents a list of available tasks via `fzf`. Selecting a task from the list will then proceed with that subcommand for the chosen task.

Key changes:
- Implemented `select_task_via_fzf()` helper function that uses `cmd_list` and `fzf`.
- Modified the `main` function to call this helper when the task name argument is missing for the affected subcommands.
- Ensured that "main" variants (like `status main` or `exec main`) still function correctly by only triggering `fzf` when no arguments are provided.

---
*PR created automatically by Jules for task [4507107140778097858](https://jules.google.com/task/4507107140778097858) started by @ryo246912*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added interactive task selection to `multi-worktree` using `fzf`. Running `cd`, `recreate`, `status`, `sync`, `dev`, `exec`, `open`, or `remove` without a task name now opens a picker and runs the command for the selected task.

- **New Features**
  - Added `select_task_via_fzf()` that uses `cmd_list` and previews `multi-worktree status {1}`.
  - Updated the main dispatcher to trigger selection only when no args; explicit task names (including `main`) still work as before.

<sup>Written for commit 22d6d0e57a584ca404b5d9cd9e9aeba3f45bf9fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

`dot_local/bin/executable_multi-worktree` に新規関数 `select_task_via_fzf()` を追加し、8つのサブコマンド（recreate、status、sync、cd、dev、exec、open、remove）が引数なしで実行された際に、fzf を用いた対話的なタスク選択機能を実装しました。

各サブコマンドは「タスク名引数が無い場合」に `select_task_via_fzf` を呼び出し、`cmd_list` の出力からユーザーが対話的にタスクを選択できるようになります。選択結果は位置引数として再設定されたうえで、既存のサブコマンド実装へ渡されます。

## 変更理由

ユーザーが複数のタスク間を頻繁に切り替える場合、毎回タスク名を明示的に指定する必要がありました。本変更により、サブコマンドのみの実行で fzf を通じて視覚的・対話的にタスク選択が可能となり、利便性が大幅に向上します。

## 確認した項目

- `select_task_via_fzf()` 関数が正しく実装され、`cmd_list` の出力を `fzf` でフィルタリング
- fzf 選択時にタスク状態の プレビュー表示が可能（`--preview "multi-worktree status {1}"`）
- キャンセル・失敗時は `return 1` で適切に処理される
- 8つのサブコマンドすべてで `[[ $# -eq 0 ]]` による引数チェック後に fzf 選択を実行
- 明示的なタスク名指定（例：`status main`）は引数ありのため従来通り動作

<!-- end of auto-generated comment: release notes by coderabbit.ai -->