### PR TITLE
chore: update gwq snippet

### DIFF
--- a/dot_config/zabrze/git-worktree.toml
+++ b/dot_config/zabrze/git-worktree.toml
@@ -20,7 +20,7 @@ trigger = "gwc"
 
 [[snippets]]
 name            = "gwq delete(remove)"
-snippet         = "gwq remove"
+snippet         = "gwq remove -b -f"
 trigger-pattern = "(gwd|gwr)"
 
 [[snippets]]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the `gwq delete(remove)` snippet in `git-worktree.toml` to run `gwq remove -b -f` by default, so the shortcut deletes the branch and forces removal without extra flags.

<sup>Written for commit 0b1eca7dfe9ff5f0c0a06ac9f7566b3a751d5479. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

`dot_config/zabrze/git-worktree.toml` の `gwq delete(remove)` スニペット定義が更新されました。実行コマンドが `gwq remove` から `gwq remove -b -f` に変更され、削除オプションとして強制削除フラグ（`-b -f`）が追加されました。

## 変更理由

raw_summary では具体的な理由記載がないため、詳細な背景は不明ですが、git worktree の削除時にブランチ削除と強制削除を同時に実行する意図と考えられます。

## 確認した項目

- ファイルの内容確認: `dot_config/zabrze/git-worktree.toml` の22-24行目に、更新されたスニペット定義が存在することを確認
- トリガーパターンは `(gwd|gwr)` のままで変更なし
- スニペット名は `"gwq delete(remove)"` で変更なし

<!-- end of auto-generated comment: release notes by coderabbit.ai -->