### PR TITLE
fix: mise interactive command

### DIFF
--- a/dot_config/zabrze/mise.toml
+++ b/dot_config/zabrze/mise.toml
@@ -5,7 +5,7 @@ trigger-pattern = "^mi$"
 
 [[snippets]]
 name            = "mise install interactive"
-snippet         = "GITHUB_TOKEN=$(gh auth token) mise install --jobs=2 $(mise ls --current | fzf -m | awk '{printf \"%s \", $1}' | sed 's/ $//')"
+snippet         = "{ _a=($(mise ls --current | fzf -m | awk '{print $1}')); [[ ${#_a[@]} -gt 0 ]] && GITHUB_TOKEN=$(gh auth token) mise install --jobs=2 \"${_a[@]}\"; unset _a; }"
 trigger-pattern = "^mii$"
 
 [[snippets]]
@@ -15,7 +15,7 @@ trigger = "mls"
 
 [[snippets]]
 name    = "mise ls interactive"
-snippet = "mise ls $(mise ls --current | fzf -m | awk '{printf \"%s \", $1}' | sed 's/ $//')"
+snippet = "{ _a=($(mise ls --current | fzf -m | awk '{print $1}')); [[ ${#_a[@]} -gt 0 ]] && mise ls \"${_a[@]}\"; unset _a; }"
 trigger = "mlss"
 
 [[snippets]]
@@ -40,7 +40,7 @@ trigger-pattern = "^mu$"
 
 [[snippets]]
 name            = "mise uninstall interactive"
-snippet         = "mise uninstall $(mise ls --current | fzf -m | awk '{printf \"%s \", $1}' | sed 's/ $//') --all"
+snippet         = "{ _a=($(mise ls --current | fzf -m | awk '{print $1}')); [[ ${#_a[@]} -gt 0 ]] && mise uninstall \"${_a[@]}\" --all; unset _a; }"
 trigger-pattern = "^mui$"
 
 [[snippets]]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes interactive `mise` snippets to safely handle empty `fzf` selections and avoid running commands with empty args. Uses array capture and quoting to support multi-select.

- **Bug Fixes**
  - Capture selections into array `_a`; execute only if non-empty, then `unset _a`.
  - Applied to install (`mii`), list (`mlss`), and uninstall (`mui`); pass selections with `"${_a[@]}"`.
  - For install, set `GITHUB_TOKEN` via `gh auth token` only when executing; simplified selection with `awk '{print $1}'`.

<sup>Written for commit 108ee18afc68245611379551097b402b448efc2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

