### PR TITLE
chore: update nvim setting

### DIFF
--- a/dot_config/nvim/lua/core/autocmds.lua
+++ b/dot_config/nvim/lua/core/autocmds.lua
@@ -12,6 +12,33 @@ if vim.fn.has('unix') == 1 and vim.fn.system('uname -r'):find('microsoft') and v
   })
 end
 
+-- nvim起動時にneo-treeを自動で開き、カーソルをエディタ側に移動
+local neotree_open_group = vim.api.nvim_create_augroup('NeoTreeOpen', { clear = true })
+vim.api.nvim_create_autocmd('VimEnter', {
+  group = neotree_open_group,
+  callback = function()
+    local argv0 = vim.fn.argv(0)
+    local is_no_arg = vim.fn.argc() == 0
+    local is_dir_arg = vim.fn.argc() == 1 and vim.fn.isdirectory(argv0) == 1
+    if is_no_arg or is_dir_arg then
+      vim.cmd('Neotree filesystem show left')
+      vim.cmd('wincmd l')
+    end
+  end,
+})
+
+-- タブごとにtcdで独立したpwdを持つ
+local tab_cwd_group = vim.api.nvim_create_augroup('TabLocalCwd', { clear = true })
+vim.api.nvim_create_autocmd('TabNewEntered', {
+  group = tab_cwd_group,
+  callback = function()
+    local dir = vim.fn.expand('%:p:h')
+    if vim.fn.isdirectory(dir) == 1 then
+      vim.cmd('tcd ' .. vim.fn.fnameescape(dir))
+    end
+  end,
+})
+
 -- terminalを開いたら即入力できるようにする（:terminal, split terminal, toggleterm共通）
 local terminal_group = vim.api.nvim_create_augroup('TerminalInsert', { clear = true })
 vim.api.nvim_create_autocmd('TermOpen', {

--- a/dot_config/nvim/lua/core/options.lua
+++ b/dot_config/nvim/lua/core/options.lua
@@ -9,6 +9,9 @@ vim.opt.history = 10000
 -- options/localoptions 以外は保存して、編集状態を広く復元する
 vim.opt.sessionoptions = { "blank", "buffers", "curdir", "folds", "help", "tabpages", "winsize", "terminal" }
 
+-- vim-markdown (vim-polyglot) のデフォルトキーマップを無効化
+vim.g.vim_markdown_no_default_key_mappings = 1
+
 -- ファイラー(netrw)
 -- ファイルタイプの自動検出、ファイルタイプ用の プラグインとインデント設定 を自動読み込み
 vim.cmd("filetype plugin indent on")

--- a/dot_config/nvim/lua/core/options.lua
+++ b/dot_config/nvim/lua/core/options.lua
@@ -1,3 +1,6 @@
+-- 真の色（24bit）を有効化（DSR問い合わせ不要にしてnvim起動時の遅延を防ぐ）
+vim.opt.termguicolors = true
+
 -- バックアップファイルを作らない
 vim.opt.backup = false
 -- スワップファイルを作らない

--- a/dot_config/nvim/lua/core/options.lua
+++ b/dot_config/nvim/lua/core/options.lua
@@ -86,3 +86,26 @@ vim.opt.diffopt = "vertical"
 
 -- カーソル形状の変更
 vim.opt.guicursor = "n-v-c:block,i-ci-ve:ver25,r-cr:hor20,o:hor50"
+
+-- タブラインを常時表示し、各タブにタブローカルCWDのフォルダ名を表示
+vim.opt.showtabline = 2
+
+_G.MyTabline = function()
+  local s = ""
+  local current = vim.fn.tabpagenr()
+  for i = 1, vim.fn.tabpagenr("$") do
+    -- getcwd(-1, tabnr): tcdで設定したタブローカルCWD、未設定ならグローバルCWD
+    local cwd = vim.fn.getcwd(-1, i)
+    local dirname = vim.fn.fnamemodify(cwd, ":t")
+    if dirname == "" then dirname = cwd end
+    if i == current then
+      s = s .. "%#TabLineSel#"
+    else
+      s = s .. "%#TabLine#"
+    end
+    s = s .. " " .. i .. ":" .. dirname .. " "
+  end
+  return s .. "%#TabLineFill#"
+end
+
+vim.opt.tabline = "%!v:lua.MyTabline()"

--- a/dot_config/nvim/lua/plugins/colorscheme.lua
+++ b/dot_config/nvim/lua/plugins/colorscheme.lua
@@ -11,6 +11,11 @@ return {
       vim.cmd.colorscheme("molokai")
 
       vim.api.nvim_set_hl(0, "CursorColumn", { ctermbg = 236, bg = "#3a3d41" })
+
+      -- タブライン: molokaでfgが背景と同色になるため明示的に上書き
+      vim.api.nvim_set_hl(0, "TabLine",     { fg = "#bcbcbc", bg = "#3a3d41", underline = false })
+      vim.api.nvim_set_hl(0, "TabLineSel",  { fg = "#ffffff", bg = "#005f87", bold = true })
+      vim.api.nvim_set_hl(0, "TabLineFill", { fg = "#bcbcbc", bg = "#1a1a1a" })
     end,
   },
 }

--- a/dot_config/nvim/lua/plugins/filer.lua
+++ b/dot_config/nvim/lua/plugins/filer.lua
@@ -44,6 +44,11 @@ return {
         },
 
         filesystem = {
+          cwd_target = {
+            -- サイドバーのルートをタブのtcdに追従させる
+            sidebar = "tab",
+            current = "window",
+          },
           filtered_items = {
             -- 隠しファイルを表示
             visible = true,

--- a/dot_config/nvim/lua/plugins/fzf.lua
+++ b/dot_config/nvim/lua/plugins/fzf.lua
@@ -81,22 +81,42 @@ return {
       end, { noremap = true, silent = true, desc = "カーソル下の単語で検索" })
 
       -- バッファを表示
-      keymap("n", "<leader>b", fzf.buffers,         { noremap = true, silent = true, desc = "バッファ検索" })
+      keymap("n", "<leader>b", fzf.buffers, { noremap = true, silent = true, desc = "バッファ検索" })
       -- コマンドを表示
-      keymap("n", "<leader>C", fzf.commands,        { noremap = true, silent = true, desc = "コマンド検索" })
+      keymap("n", "<leader>C", fzf.commands, { noremap = true, silent = true, desc = "コマンド検索" })
       -- ヘルプを表示
-      keymap("n", "<leader>H", fzf.help_tags,       { noremap = true, silent = true, desc = "ヘルプ検索" })
+      keymap("n", "<leader>H", fzf.help_tags, { noremap = true, silent = true, desc = "ヘルプ検索" })
       -- ファイル履歴を表示
-      keymap("n", "<leader>r", fzf.oldfiles,        { noremap = true, silent = true, desc = "ファイル履歴" })
+      keymap("n", "<leader>r", fzf.oldfiles, { noremap = true, silent = true, desc = "ファイル履歴" })
       -- コマンド履歴を表示
       keymap("n", "<leader>R", fzf.command_history, { noremap = true, silent = true, desc = "コマンド履歴" })
       -- タブを選択して切り替え
-      keymap("n", "<leader>w", select_tabpage,      { noremap = true, silent = true, desc = "タブ選択" })
+      keymap("n", "<leader>w", select_tabpage, { noremap = true, silent = true, desc = "タブ選択" })
 
-      -- zoxideを使用してディレクトリ移動
-      keymap("n", "<leader>z", fzf.zoxide, { noremap = true, silent = true, desc = "Zoxide ディレクトリ検索" })
-      -- :zz で zoxide を起動
-      vim.cmd("cnoremap zz <Cmd>lua require('fzf-lua').zoxide()<CR>")
+      -- zoxideでディレクトリ選択後、現在タブのみtcdで移動
+      -- zoxide query --list で純粋なパス一覧を取得して fzf_exec に渡す
+      local function zoxide_tcd()
+        fzf.fzf_exec("zoxide query --list", {
+          prompt = "Zoxide> ",
+          actions = {
+            ["default"] = function(selected)
+              if not selected or not selected[1] then return end
+              local dir = vim.trim(selected[1])
+              if dir == "" then return end
+              vim.cmd("tcd " .. vim.fn.fnameescape(dir))
+              local ok, neo = pcall(require, "neo-tree.command")
+              if ok then
+                neo.execute({ action = "show", source = "filesystem", position = "left", dir = dir })
+              end
+            end,
+          },
+        })
+      end
+
+      keymap("n", "<leader>z", zoxide_tcd, { noremap = true, silent = true, desc = "Zoxide ディレクトリ検索（タブローカル）" })
+      -- :zz で zoxide を起動（タブローカルtcd版）
+      vim.api.nvim_create_user_command("Zz", zoxide_tcd, {})
+      vim.cmd("cabbr zz <Cmd>Zz<CR>")
     end,
   },
 }

--- a/dot_config/nvim/lua/plugins/fzf.lua
+++ b/dot_config/nvim/lua/plugins/fzf.lua
@@ -23,14 +23,12 @@ return {
         local items = {}
 
         for _, tab in ipairs(tabs) do
-          local wins = vim.api.nvim_tabpage_list_wins(tab)
-          local win = wins[1]
-          local buf = win and vim.api.nvim_win_get_buf(win) or nil
-          local name = buf and vim.api.nvim_buf_get_name(buf) or ""
-          local label = name ~= "" and vim.fn.fnamemodify(name, ":~:.") or "[No Name]"
           local tabnr = vim.api.nvim_tabpage_get_number(tab)
+          local cwd = vim.fn.getcwd(-1, tabnr)
+          local dirname = vim.fn.fnamemodify(cwd, ":t")
+          if dirname == "" then dirname = cwd end
           local current = tab == current_tab and "*" or " "
-          table.insert(items, string.format("%d\t%s %s", tabnr, current, label))
+          table.insert(items, string.format("%d\t%s %s", tabnr, current, dirname))
         end
 
         fzf.fzf_exec(items, {

--- a/dot_config/nvim/lua/plugins/util.lua
+++ b/dot_config/nvim/lua/plugins/util.lua
@@ -54,4 +54,11 @@ return {
     "vim-jp/vimdoc-ja",
     lazy = true,
   },
+  {
+    "chrishrb/gx.nvim",
+    keys = { { "gx", "<cmd>Browse<cr>", mode = { "n", "x" } } },
+    opts = {
+      open_browser_app = vim.fn.has("mac") == 1 and "open" or vim.fn.has("wsl") == 1 and "wslview" or "xdg-open",
+    },
+  },
 }

--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -21,6 +21,8 @@ set -g status-interval 1
 set -g default-terminal "screen-256color"
 # set -g default-terminal "tmux-256color" # tmux-256colorではMacOSでは表示崩れがあったため
 set -ag terminal-overrides ",alacritty:RGB,rio:Tc,wezterm:RGB,xterm-256color:RGB,xterm-ghostty:RGB,ghostty:RGB"
+# screen-256colorでDSR（Device Status Report）をサポートし、nvim起動時の遅延警告を抑制
+set -ga terminal-features "screen-256color:DSR-cursor-pos"
 
 # tmuxを経由して実際のターミナルに直接エスケープシーケンスを送信できるようにする
 set -g allow-passthrough on


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `chrishrb/gx.nvim` to open URLs with `gx` using `open` (macOS), `wslview` (WSL), or `xdg-open` (Linux).
Added tab-local dirs via a zoxide picker (`<leader>z`/`:Zz`) that sets `tcd`, auto-opens Neo-tree, and keeps the sidebar in sync. Introduced an always-on tabline that labels tabs by the tab cwd and updated the tab switcher to show these names; also fixed the Neovim DSR startup warning in tmux, enabled truecolor, and disabled `vim-markdown` default mappings.

<sup>Written for commit f8066809521ae3a00530857148d7480ec7b85d6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

Neovimのプラグイン設定に`chrishrb/gx.nvim`を追加しました。このプラグインは、ノーマルモード・ビジュアルモードでの`gx`キーマップを`:Browse`コマンドに割り当て、URLやパスをブラウザで開く機能を提供します。開く際のアプリケーションはmacでは`open`、その他のプラットフォームでは`wslview`を使用するように設定しています。

同時に、vim-markdown（vim-polyglot）のデフォルトキーマップを無効化する設定を追加しました。

## 変更理由

`gx`キーマップをより柔軟に管理するためにgx.nvimを導入し、プラットフォーム別にブラウザを開くアプリケーションを適切に設定しています。

## 確認した項目

- プラグイン追加時の構文・設定の正確性
- プラットフォーム別のアプリケーション設定（macとWSL環境対応）
- vim-markdownのキーマップ無効化が正しく反映されるか

<!-- end of auto-generated comment: release notes by coderabbit.ai -->