### PR TITLE
chore: nvim git settings

### DIFF
--- a/dot_config/nvim/lua/core/keymaps.lua
+++ b/dot_config/nvim/lua/core/keymaps.lua
@@ -48,7 +48,14 @@ end
 
 local function jump_current_word(direction)
   return function()
-    ensure_current_word_search()
+    local initialized = ensure_current_word_search()
+    if initialized then
+      local flags = direction == "n" and "W" or "bW"
+      for _ = 1, vim.v.count1 do
+        vim.fn.search(vim.fn.getreg("/"), flags)
+      end
+      return
+    end
     vim.cmd(("normal! %d%s"):format(vim.v.count1, direction))
   end
 end

--- a/dot_config/nvim/lua/core/keymaps.lua
+++ b/dot_config/nvim/lua/core/keymaps.lua
@@ -50,7 +50,7 @@ local function jump_current_word(direction)
   return function()
     local initialized = ensure_current_word_search()
     if initialized then
-      local flags = direction == "n" and "W" or "bW"
+      local flags = direction == "n" and "" or "b"
       for _ = 1, vim.v.count1 do
         vim.fn.search(vim.fn.getreg("/"), flags)
       end

--- a/dot_config/nvim/lua/plugins/colorscheme.lua
+++ b/dot_config/nvim/lua/plugins/colorscheme.lua
@@ -10,7 +10,9 @@ return {
       -- カラースキーム設定
       vim.cmd.colorscheme("molokai")
 
+      vim.api.nvim_set_hl(0, "CursorLine",   { bg = "#3a3d41" })
       vim.api.nvim_set_hl(0, "CursorColumn", { ctermbg = 236, bg = "#3a3d41" })
+      vim.api.nvim_set_hl(0, "GitSignsCurrentLineBlame", { fg = "#888888", italic = true })
 
       -- タブライン: molokaでfgが背景と同色になるため明示的に上書き
       vim.api.nvim_set_hl(0, "TabLine",     { fg = "#bcbcbc", bg = "#3a3d41", underline = false })

--- a/dot_config/nvim/lua/plugins/colorscheme.lua
+++ b/dot_config/nvim/lua/plugins/colorscheme.lua
@@ -14,6 +14,12 @@ return {
       vim.api.nvim_set_hl(0, "CursorColumn", { ctermbg = 236, bg = "#3a3d41" })
       vim.api.nvim_set_hl(0, "GitSignsCurrentLineBlame", { fg = "#888888", italic = true })
 
+      -- diff (diffview / git delta 風)
+      vim.api.nvim_set_hl(0, "DiffAdd",    { bg = "#1a2f1a" })
+      vim.api.nvim_set_hl(0, "DiffDelete", { bg = "#2f1a1a" })
+      vim.api.nvim_set_hl(0, "DiffChange", { bg = "#1a2535" })
+      vim.api.nvim_set_hl(0, "DiffText",   { bg = "#2f4a2f", fg = "#88cc88", bold = true })
+
       -- タブライン: molokaでfgが背景と同色になるため明示的に上書き
       vim.api.nvim_set_hl(0, "TabLine",     { fg = "#bcbcbc", bg = "#3a3d41", underline = false })
       vim.api.nvim_set_hl(0, "TabLineSel",  { fg = "#ffffff", bg = "#005f87", bold = true })

--- a/dot_config/nvim/lua/plugins/editor.lua
+++ b/dot_config/nvim/lua/plugins/editor.lua
@@ -1,5 +1,14 @@
 return {
   {
+    "folke/which-key.nvim",
+    event = "VeryLazy",
+    config = function()
+      require("which-key").setup({
+        delay = 500,
+      })
+    end,
+  },
+  {
     "windwp/nvim-autopairs",
     config = function()
       require("nvim-autopairs").setup({})

--- a/dot_config/nvim/lua/plugins/fzf.lua
+++ b/dot_config/nvim/lua/plugins/fzf.lua
@@ -87,7 +87,7 @@ return {
       -- ファイル履歴を表示
       keymap("n", "<leader>r", fzf.oldfiles, { noremap = true, silent = true, desc = "ファイル履歴" })
       -- コマンド履歴を表示
-      keymap("n", "<leader>H", fzf.command_history, { noremap = true, silent = true, desc = "コマンド履歴" })
+      keymap("n", "<leader>R", fzf.command_history, { noremap = true, silent = true, desc = "コマンド履歴" })
       -- タブを選択して切り替え
       keymap("n", "<leader>w", select_tabpage, { noremap = true, silent = true, desc = "タブ選択" })
 

--- a/dot_config/nvim/lua/plugins/fzf.lua
+++ b/dot_config/nvim/lua/plugins/fzf.lua
@@ -81,7 +81,7 @@ return {
       -- バッファを表示
       keymap("n", "<leader>b", fzf.buffers, { noremap = true, silent = true, desc = "バッファ検索" })
       -- コマンドを表示
-      keymap("n", "<leader>C", fzf.commands, { noremap = true, silent = true, desc = "コマンド検索" })
+      keymap("n", "<leader>c", fzf.commands, { noremap = true, silent = true, desc = "コマンド検索" })
       -- ヘルプを表示
       keymap("n", "<leader>H", fzf.help_tags, { noremap = true, silent = true, desc = "ヘルプ検索" })
       -- ファイル履歴を表示

--- a/dot_config/nvim/lua/plugins/fzf.lua
+++ b/dot_config/nvim/lua/plugins/fzf.lua
@@ -83,11 +83,11 @@ return {
       -- コマンドを表示
       keymap("n", "<leader>c", fzf.commands, { noremap = true, silent = true, desc = "コマンド検索" })
       -- ヘルプを表示
-      keymap("n", "<leader>H", fzf.help_tags, { noremap = true, silent = true, desc = "ヘルプ検索" })
+      keymap("n", "<leader>?", fzf.help_tags, { noremap = true, silent = true, desc = "ヘルプ検索" })
       -- ファイル履歴を表示
       keymap("n", "<leader>r", fzf.oldfiles, { noremap = true, silent = true, desc = "ファイル履歴" })
       -- コマンド履歴を表示
-      keymap("n", "<leader>R", fzf.command_history, { noremap = true, silent = true, desc = "コマンド履歴" })
+      keymap("n", "<leader>H", fzf.command_history, { noremap = true, silent = true, desc = "コマンド履歴" })
       -- タブを選択して切り替え
       keymap("n", "<leader>w", select_tabpage, { noremap = true, silent = true, desc = "タブ選択" })
 

--- a/dot_config/nvim/lua/plugins/git.lua
+++ b/dot_config/nvim/lua/plugins/git.lua
@@ -79,7 +79,9 @@ return {
         end
       end
 
-      vim.keymap.set("n", "<leader>g", open_diffview, { noremap = true, silent = true, desc = "Git差分パネル（複数リポジトリ対応）" })
+      vim.keymap.set("n", "<leader>g",  open_diffview,                   { noremap = true, silent = true, desc = "Git差分パネル（複数リポジトリ対応）" })
+      vim.keymap.set("n", "<leader>gH", ":DiffviewFileHistory<CR>",      { noremap = true, silent = true, desc = "リポジトリ全体のコミット履歴（diffview）" })
+      vim.keymap.set("n", "<leader>gh", ":DiffviewFileHistory %<CR>",    { noremap = true, silent = true, desc = "現在ファイルのコミット履歴（diffview）" })
     end,
   },
   {
@@ -87,6 +89,14 @@ return {
     event = { "BufReadPre", "BufNewFile" },
     config = function()
       require("gitsigns").setup({
+        current_line_blame = true,
+        current_line_blame_opts = {
+          virt_text = true,
+          virt_text_pos = "eol",
+          delay = 500,
+          ignore_whitespace = true,
+        },
+        current_line_blame_formatter = "<author>, <author_time:%R> • <summary>",
         signs = {
           add          = { text = "│" },
           change       = { text = "│" },
@@ -149,6 +159,122 @@ return {
           map("n", "<leader>hb", function() gs.blame_line({ full = true }) end, { desc = "行のBlame表示" })
           map("n", "<leader>hB", gs.toggle_current_line_blame, { desc = "行Blame仮想テキスト切り替え" })
 
+          -- コミット + PR 情報ポップアップ
+          local function show_commit_with_pr()
+            local lnum = vim.api.nvim_win_get_cursor(0)[1]
+            local filename = vim.api.nvim_buf_get_name(bufnr)
+
+            vim.system(
+              { "git", "blame", "-L", lnum .. "," .. lnum, "--porcelain", filename },
+              { text = true },
+              function(blame_result)
+                if blame_result.code ~= 0 then
+                  vim.schedule(function()
+                    vim.notify("git blame 失敗: " .. (blame_result.stderr or ""), vim.log.levels.ERROR)
+                  end)
+                  return
+                end
+
+                local sha = blame_result.stdout:match("^(%x+)")
+                if not sha or sha:match("^0+$") then
+                  vim.schedule(function()
+                    vim.notify("コミット情報を取得できません（未コミットの行）", vim.log.levels.WARN)
+                  end)
+                  return
+                end
+
+                vim.system(
+                  { "git", "show", "--format=%H%n%an%n%ai%n%s", "--no-patch", sha },
+                  { text = true },
+                  function(commit_result)
+                    local info = vim.split(commit_result.stdout or "", "\n")
+                    local commit_sha = info[1] or sha
+                    local author     = info[2] or "Unknown"
+                    local date       = info[3] or ""
+                    local subject    = info[4] or ""
+
+                    vim.system(
+                      { "gh", "pr", "list", "--search", sha, "--state", "merged",
+                        "--json", "number,title,url", "--limit", "1" },
+                      { text = true },
+                      function(pr_result)
+                        vim.schedule(function()
+                          local display = {
+                            "Commit: " .. commit_sha:sub(1, 8),
+                            "Author: " .. author,
+                            "Date:   " .. date,
+                            "",
+                            subject,
+                            "",
+                          }
+
+                          local pr_url = nil
+                          if pr_result.code == 0 and pr_result.stdout and pr_result.stdout ~= "" then
+                            local ok, prs = pcall(vim.fn.json_decode, pr_result.stdout)
+                            if ok and prs and #prs > 0 then
+                              local pr = prs[1]
+                              pr_url = pr.url
+                              table.insert(display, string.format("PR: #%d - %s", pr.number, pr.title))
+                              table.insert(display, "URL: " .. pr.url)
+                              table.insert(display, "")
+                              table.insert(display, "[o] ブラウザで開く  [q] 閉じる")
+                            else
+                              table.insert(display, "PR: 見つかりません")
+                              table.insert(display, "")
+                              table.insert(display, "[q] 閉じる")
+                            end
+                          else
+                            table.insert(display, "PR: 取得できません（gh CLI エラー）")
+                            table.insert(display, "")
+                            table.insert(display, "[q] 閉じる")
+                          end
+
+                          local max_w = 0
+                          for _, line in ipairs(display) do
+                            max_w = math.max(max_w, vim.fn.strdisplaywidth(line))
+                          end
+                          local width  = math.max(50, math.min(max_w + 4, vim.o.columns - 4))
+                          local height = #display
+
+                          local float_buf = vim.api.nvim_create_buf(false, true)
+                          vim.api.nvim_buf_set_lines(float_buf, 0, -1, false, display)
+                          vim.bo[float_buf].modifiable = false
+
+                          local float_win = vim.api.nvim_open_win(float_buf, true, {
+                            relative = "cursor",
+                            row      = 1,
+                            col      = 0,
+                            width    = width,
+                            height   = height,
+                            style    = "minimal",
+                            border   = "rounded",
+                            title    = " Commit Info ",
+                            title_pos = "center",
+                          })
+
+                          local close = function()
+                            if vim.api.nvim_win_is_valid(float_win) then
+                              vim.api.nvim_win_close(float_win, true)
+                            end
+                          end
+                          vim.keymap.set("n", "q",     close, { buffer = float_buf, nowait = true })
+                          vim.keymap.set("n", "<Esc>", close, { buffer = float_buf, nowait = true })
+                          if pr_url then
+                            vim.keymap.set("n", "o", function()
+                              vim.ui.open(pr_url)
+                            end, { buffer = float_buf, nowait = true, desc = "PRをブラウザで開く" })
+                          end
+                        end)
+                      end
+                    )
+                  end
+                )
+              end
+            )
+          end
+
+          map("n", "<leader>hm", show_commit_with_pr, { desc = "コミット＋PR情報を表示" })
+
           -- 差分表示
           map("n", "<leader>hd", gs.diffthis, { desc = "working directoryとの差分" })
           map("n", "<leader>hD", function() gs.diffthis("~") end, { desc = "最後のコミットとの差分" })
@@ -170,8 +296,8 @@ return {
       keymap("n", "<leader>gd", ":Git diff<CR>", { noremap = true })
       -- Git差分 (分割表示)
       keymap("n", "<leader>gv", ":Gdiffsplit<CR>", { noremap = true })
-      -- Git show (最新コミットの詳細)
-      keymap("n", "<leader>gh", ":Git show<CR>", { noremap = true })
+      -- Git show (最新コミットの詳細) ※ <leader>gh は diffview に移管
+      keymap("n", "<leader>gS", ":Git show<CR>", { noremap = true, desc = "Git show（最新コミット詳細）" })
       -- Git log -p
       keymap("n", "<leader>gl", ':Git log -p --pretty=format:"%C(auto)%h (%C(blue)%cd%C(auto))%d %s %Cblue[%cn]" --date=format:"%Y/%m/%d %H:%M:%S"<CR>', { noremap = true })
       -- Git log
@@ -180,6 +306,24 @@ return {
       keymap("n", "<leader>gb", ":Git branch<CR>", { noremap = true })
       -- Git current branch
       keymap("n", "<leader>gB", ":Git branch --show-current<CR>", { noremap = true })
+      -- コミットログ（fzf-lua + diffview）
+      keymap("n", "<leader>gc", function()
+        require("fzf-lua").git_commits({
+          actions = {
+            ["default"] = function(selected)
+              if not selected or not selected[1] then return end
+              local commit = selected[1]:match("^(%x+)")
+              if commit then
+                vim.cmd("DiffviewOpen " .. commit .. "^.." .. commit)
+              end
+            end,
+          },
+        })
+      end, { noremap = true, silent = true, desc = "Gitコミットログ（fzf-lua）" })
+      -- 現在ファイルのコミットログ（fzf-lua）
+      keymap("n", "<leader>gC", function()
+        require("fzf-lua").git_bcommits()
+      end, { noremap = true, silent = true, desc = "現在ファイルのGitコミットログ（fzf-lua）" })
     end,
   },
   {

--- a/dot_config/nvim/lua/plugins/git.lua
+++ b/dot_config/nvim/lua/plugins/git.lua
@@ -170,10 +170,11 @@ return {
           local function show_commit_with_pr()
             local lnum = vim.api.nvim_win_get_cursor(0)[1]
             local filename = vim.api.nvim_buf_get_name(bufnr)
+            local repo_dir = vim.fn.fnamemodify(filename, ":h")
 
             vim.system(
               { "git", "blame", "-L", lnum .. "," .. lnum, "--porcelain", filename },
-              { text = true },
+              { text = true, cwd = repo_dir },
               function(blame_result)
                 if blame_result.code ~= 0 then
                   vim.schedule(function()
@@ -192,8 +193,14 @@ return {
 
                 vim.system(
                   { "git", "show", "--format=%H%n%an%n%ai%n%s", "--no-patch", sha },
-                  { text = true },
+                  { text = true, cwd = repo_dir },
                   function(commit_result)
+                    if commit_result.code ~= 0 then
+                      vim.schedule(function()
+                        vim.notify("git show 失敗: " .. (commit_result.stderr or ""), vim.log.levels.ERROR)
+                      end)
+                      return
+                    end
                     local info = vim.split(commit_result.stdout or "", "\n")
                     local commit_sha = info[1] or sha
                     local author     = info[2] or "Unknown"
@@ -203,7 +210,7 @@ return {
                     vim.system(
                       { "gh", "pr", "list", "--search", sha, "--state", "merged",
                         "--json", "number,title,url", "--limit", "1" },
-                      { text = true },
+                      { text = true, cwd = repo_dir },
                       function(pr_result)
                         vim.schedule(function()
                           local display = {

--- a/dot_config/nvim/lua/plugins/git.lua
+++ b/dot_config/nvim/lua/plugins/git.lua
@@ -79,7 +79,7 @@ return {
         end
       end
 
-      vim.keymap.set("n", "<leader>g",  open_diffview,                   { noremap = true, silent = true, desc = "Git差分パネル（複数リポジトリ対応）" })
+      vim.keymap.set("n", "<leader>gd", open_diffview,                   { noremap = true, silent = true, desc = "Git差分パネル（複数リポジトリ対応）" })
       vim.keymap.set("n", "<leader>gH", ":DiffviewFileHistory<CR>",      { noremap = true, silent = true, desc = "リポジトリ全体のコミット履歴（diffview）" })
       vim.keymap.set("n", "<leader>gh", ":DiffviewFileHistory %<CR>",    { noremap = true, silent = true, desc = "現在ファイルのコミット履歴（diffview）" })
     end,
@@ -292,8 +292,6 @@ return {
 
       -- Gitステータス
       keymap("n", "<leader>gs", ":Git<CR>", { noremap = true })
-      -- Git差分
-      keymap("n", "<leader>gd", ":Git diff<CR>", { noremap = true })
       -- Git差分 (分割表示)
       keymap("n", "<leader>gv", ":Gdiffsplit<CR>", { noremap = true })
       -- Git show (最新コミットの詳細) ※ <leader>gh は diffview に移管

--- a/dot_config/nvim/lua/plugins/git.lua
+++ b/dot_config/nvim/lua/plugins/git.lua
@@ -18,12 +18,17 @@ return {
         },
         keymaps = {
           file_panel = {
-            { "n", "<CR>", "<Cmd>lua require('diffview.actions').select_entry()<CR>", { desc = "差分を開く" } },
-            { "n", "s",    "<Cmd>lua require('diffview.actions').toggle_stage_entry()<CR>", { desc = "ステージ/アンステージ切替" } },
-            { "n", "S",    "<Cmd>lua require('diffview.actions').stage_all()<CR>", { desc = "全てステージ" } },
-            { "n", "U",    "<Cmd>lua require('diffview.actions').unstage_all()<CR>", { desc = "全てアンステージ" } },
-            { "n", "q",    "<Cmd>DiffviewClose<CR>", { desc = "閉じる" } },
-            { "n", "?",    "<Cmd>lua require('diffview.actions').help('file_panel')<CR>", { desc = "ヘルプ" } },
+            { "n", "<CR>", "<Cmd>lua require('diffview.actions').select_entry()<CR>",  { desc = "差分を開く" } },
+            { "n", "O",    "<Cmd>lua require('diffview.actions').goto_file_edit()<CR>", { desc = "現在のファイルを開く" } },
+            { "n", "s",      "<Cmd>lua require('diffview.actions').toggle_stage_entry()<CR>", { desc = "ステージ/アンステージ切替" } },
+            { "n", "S",      "<Cmd>lua require('diffview.actions').stage_all()<CR>", { desc = "全てステージ" } },
+            { "n", "U",      "<Cmd>lua require('diffview.actions').unstage_all()<CR>", { desc = "全てアンステージ" } },
+            { "n", "q",      "<Cmd>DiffviewClose<CR>", { desc = "閉じる" } },
+            { "n", "?",      "<Cmd>lua require('diffview.actions').help('file_panel')<CR>", { desc = "ヘルプ" } },
+          },
+          file_history_panel = {
+            { "n", "O", "<Cmd>lua require('diffview.actions').goto_file_edit()<CR>", { desc = "現在のファイルを開く" } },
+            { "n", "q", "<Cmd>DiffviewClose<CR>", { desc = "閉じる" } },
           },
           view = {
             { "n", "q", "<Cmd>DiffviewClose<CR>", { desc = "閉じる" } },
@@ -80,8 +85,9 @@ return {
       end
 
       vim.keymap.set("n", "<leader>gd", open_diffview,                   { noremap = true, silent = true, desc = "Git差分パネル（複数リポジトリ対応）" })
-      vim.keymap.set("n", "<leader>gH", ":DiffviewFileHistory<CR>",      { noremap = true, silent = true, desc = "リポジトリ全体のコミット履歴（diffview）" })
-      vim.keymap.set("n", "<leader>gh", ":DiffviewFileHistory %<CR>",    { noremap = true, silent = true, desc = "現在ファイルのコミット履歴（diffview）" })
+      vim.keymap.set("n", "<leader>gl", ":DiffviewFileHistory<CR>",   { noremap = true, silent = true, desc = "リポジトリ全体のコミット履歴（diffview）" })
+      vim.keymap.set("n", "<leader>gL", ":DiffviewFileHistory %<CR>", { noremap = true, silent = true, desc = "現在ファイルのコミット履歴（diffview）" })
+
     end,
   },
   {
@@ -158,6 +164,7 @@ return {
           -- Blame
           map("n", "<leader>hb", function() gs.blame_line({ full = true }) end, { desc = "行のBlame表示" })
           map("n", "<leader>hB", gs.toggle_current_line_blame, { desc = "行Blame仮想テキスト切り替え" })
+          map("n", "<leader>gb", gs.blame, { desc = "Blameウィンドウをトグル" })
 
           -- コミット + PR 情報ポップアップ
           local function show_commit_with_pr()
@@ -217,16 +224,16 @@ return {
                               table.insert(display, string.format("PR: #%d - %s", pr.number, pr.title))
                               table.insert(display, "URL: " .. pr.url)
                               table.insert(display, "")
-                              table.insert(display, "[o] ブラウザで開く  [q] 閉じる")
+                              table.insert(display, "[o] PRをブラウザで開く  [d] diffviewで開く  [q] 閉じる")
                             else
                               table.insert(display, "PR: 見つかりません")
                               table.insert(display, "")
-                              table.insert(display, "[q] 閉じる")
+                              table.insert(display, "[d] diffviewで開く  [q] 閉じる")
                             end
                           else
                             table.insert(display, "PR: 取得できません（gh CLI エラー）")
                             table.insert(display, "")
-                            table.insert(display, "[q] 閉じる")
+                            table.insert(display, "[d] diffviewで開く  [q] 閉じる")
                           end
 
                           local max_w = 0
@@ -264,6 +271,10 @@ return {
                               vim.ui.open(pr_url)
                             end, { buffer = float_buf, nowait = true, desc = "PRをブラウザで開く" })
                           end
+                          vim.keymap.set("n", "d", function()
+                            close()
+                            vim.cmd("DiffviewOpen " .. commit_sha .. "^.." .. commit_sha)
+                          end, { buffer = float_buf, nowait = true, desc = "diffviewでコミットを開く" })
                         end)
                       end
                     )
@@ -273,7 +284,7 @@ return {
             )
           end
 
-          map("n", "<leader>hm", show_commit_with_pr, { desc = "コミット＋PR情報を表示" })
+          map("n", "<leader>gp", show_commit_with_pr, { desc = "コミット＋PR情報を表示" })
 
           -- 差分表示
           map("n", "<leader>hd", gs.diffthis, { desc = "working directoryとの差分" })
@@ -290,38 +301,8 @@ return {
     config = function()
       local keymap = vim.keymap.set
 
-      -- Gitステータス
-      keymap("n", "<leader>gs", ":Git<CR>", { noremap = true })
-      -- Git差分 (分割表示)
-      keymap("n", "<leader>gv", ":Gdiffsplit<CR>", { noremap = true })
-      -- Git show (最新コミットの詳細) ※ <leader>gh は diffview に移管
-      keymap("n", "<leader>gS", ":Git show<CR>", { noremap = true, desc = "Git show（最新コミット詳細）" })
-      -- Git log -p
-      keymap("n", "<leader>gl", ':Git log -p --pretty=format:"%C(auto)%h (%C(blue)%cd%C(auto))%d %s %Cblue[%cn]" --date=format:"%Y/%m/%d %H:%M:%S"<CR>', { noremap = true })
-      -- Git log
-      keymap("n", "<leader>gL", ':Git log --pretty=format:"%C(auto)%h (%C(blue)%cd%C(auto))%d %s %Cblue[%cn]" --date=format:"%Y/%m/%d %H:%M:%S"<CR>', { noremap = true })
-      -- Git branch
-      keymap("n", "<leader>gb", ":Git branch<CR>", { noremap = true })
       -- Git current branch
       keymap("n", "<leader>gB", ":Git branch --show-current<CR>", { noremap = true })
-      -- コミットログ（fzf-lua + diffview）
-      keymap("n", "<leader>gc", function()
-        require("fzf-lua").git_commits({
-          actions = {
-            ["default"] = function(selected)
-              if not selected or not selected[1] then return end
-              local commit = selected[1]:match("^(%x+)")
-              if commit then
-                vim.cmd("DiffviewOpen " .. commit .. "^.." .. commit)
-              end
-            end,
-          },
-        })
-      end, { noremap = true, silent = true, desc = "Gitコミットログ（fzf-lua）" })
-      -- 現在ファイルのコミットログ（fzf-lua）
-      keymap("n", "<leader>gC", function()
-        require("fzf-lua").git_bcommits()
-      end, { noremap = true, silent = true, desc = "現在ファイルのGitコミットログ（fzf-lua）" })
     end,
   },
   {
@@ -355,10 +336,7 @@ return {
         vim.cmd("startinsert")
       end
 
-      -- lazygit をフローティングウィンドウで開く（cwd）
-      keymap("n", "<leader>lg", ":LazyGit<CR>",            { noremap = true, silent = true, desc = "lazygit を開く" })
-      -- 現在ファイルのリポジトリで lazygit を開く
-      keymap("n", "<leader>lf", ":LazyGitCurrentFile<CR>", { noremap = true, silent = true, desc = "lazygit（現在ファイル）" })
+      keymap("n", "<leader>lg", ":LazyGit<CR>", { noremap = true, silent = true, desc = "lazygit を開く" })
     end,
   },
 }

--- a/dot_config/nvim/lua/plugins/github.lua
+++ b/dot_config/nvim/lua/plugins/github.lua
@@ -11,22 +11,43 @@ return {
       {
         "<leader>gm",
         function()
+          local function admin_merge(squash)
+            local label = squash and "adminスカッシュマージ" or "adminマージ"
+            local flags = squash and "--squash" or "--merge"
+            vim.ui.select({ "はい", "いいえ" }, { prompt = label .. " しますか？" }, function(choice)
+              if choice ~= "はい" then return end
+              vim.system(
+                { "gh", "pr", "merge", "--admin", flags },
+                { text = true },
+                function(result)
+                  vim.schedule(function()
+                    if result.code == 0 then
+                      vim.notify(label .. " 完了", vim.log.levels.INFO)
+                    else
+                      vim.notify(label .. " 失敗: " .. (result.stderr or ""), vim.log.levels.ERROR)
+                    end
+                  end)
+                end
+              )
+            end)
+          end
+
           local items = {
-            { label = "PR一覧",               cmd = "Octo pr list" },
-            { label = "PR作成",               cmd = "Octo pr create" },
-            { label = "PR差分を見る",         cmd = "Octo review diff" },
-            { label = "チェックステータス",   cmd = "Octo pr checks" },
-            { label = "PRをブラウザで開く",   cmd = "Octo pr browser" },
-            { label = "コメント追加",         cmd = "Octo comment add" },
-            { label = "レビュー開始",         cmd = "Octo review start" },
-            { label = "レビュー送信（承認含む）", cmd = "Octo review submit" },
-            { label = "レビュアー追加",       cmd = "Octo reviewer add" },
-            { label = "マージ",               cmd = "Octo pr merge" },
-            { label = "スカッシュマージ",     cmd = "Octo pr merge squash" },
-            { label = "PRをクローズ",         cmd = "Octo pr close" },
-            { label = "URL をコピー",         cmd = "Octo pr url" },
-            { label = "レビュー準備完了",     cmd = "Octo pr ready" },
-            { label = "Issue一覧",            cmd = "Octo issue list" },
+            { label = "PR一覧",                    cmd = "Octo pr list" },
+            { label = "PR作成",                    cmd = "Octo pr create" },
+            { label = "PR差分を見る",              cmd = "Octo review diff" },
+            { label = "チェックステータス",        cmd = "Octo pr checks" },
+            { label = "PRをブラウザで開く",        cmd = "Octo pr browser" },
+            { label = "コメント追加",              cmd = "Octo comment add" },
+            { label = "レビュー開始",              cmd = "Octo review start" },
+            { label = "レビュー送信（承認含む）",  cmd = "Octo review submit" },
+            { label = "レビュアー追加",            cmd = "Octo reviewer add" },
+            { label = "マージ",                    cmd = "gh pr merge --admin --merge",  fn = function() admin_merge(false) end },
+            { label = "スカッシュマージ",          cmd = "gh pr merge --admin --squash", fn = function() admin_merge(true) end },
+            { label = "PRをクローズ",              cmd = "Octo pr close" },
+            { label = "URL をコピー",              cmd = "Octo pr url" },
+            { label = "レビュー準備完了",          cmd = "Octo pr ready" },
+            { label = "Issue一覧",                 cmd = "Octo issue list" },
           }
           local display = vim.tbl_map(function(i) return i.label .. "  (" .. i.cmd .. ")" end, items)
           require("fzf-lua").fzf_exec(display, {
@@ -36,7 +57,12 @@ return {
                 if not sel or not sel[1] then return end
                 for idx, d in ipairs(display) do
                   if d == sel[1] then
-                    vim.cmd(items[idx].cmd)
+                    local item = items[idx]
+                    if item.fn then
+                      item.fn()
+                    else
+                      vim.cmd(item.cmd)
+                    end
                     return
                   end
                 end

--- a/dot_config/nvim/lua/plugins/github.lua
+++ b/dot_config/nvim/lua/plugins/github.lua
@@ -8,18 +8,79 @@ return {
     },
     cmd = "Octo",
     keys = {
-      { "<leader>op", "<Cmd>Octo pr list<CR>",      mode = "n", silent = true, desc = "PR一覧" },
-      { "<leader>oc", "<Cmd>Octo pr create<CR>",    mode = "n", silent = true, desc = "PR作成" },
-      { "<leader>or", "<Cmd>Octo review start<CR>", mode = "n", silent = true, desc = "PRレビュー開始" },
-      { "<leader>oi", "<Cmd>Octo issue list<CR>",   mode = "n", silent = true, desc = "Issue一覧" },
-      { "<leader>oI", "<Cmd>Octo issue create<CR>", mode = "n", silent = true, desc = "Issue作成" },
+      {
+        "<leader>gm",
+        function()
+          local items = {
+            { label = "PR一覧",               cmd = "Octo pr list" },
+            { label = "PR作成",               cmd = "Octo pr create" },
+            { label = "PR差分を見る",         cmd = "Octo review diff" },
+            { label = "チェックステータス",   cmd = "Octo pr checks" },
+            { label = "PRをブラウザで開く",   cmd = "Octo pr browser" },
+            { label = "コメント追加",         cmd = "Octo comment add" },
+            { label = "レビュー開始",         cmd = "Octo review start" },
+            { label = "レビュー送信（承認含む）", cmd = "Octo review submit" },
+            { label = "レビュアー追加",       cmd = "Octo reviewer add" },
+            { label = "マージ",               cmd = "Octo pr merge" },
+            { label = "スカッシュマージ",     cmd = "Octo pr merge squash" },
+            { label = "PRをクローズ",         cmd = "Octo pr close" },
+            { label = "URL をコピー",         cmd = "Octo pr url" },
+            { label = "レビュー準備完了",     cmd = "Octo pr ready" },
+            { label = "Issue一覧",            cmd = "Octo issue list" },
+          }
+          local display = vim.tbl_map(function(i) return i.label .. "  (" .. i.cmd .. ")" end, items)
+          require("fzf-lua").fzf_exec(display, {
+            prompt = "Octo> ",
+            actions = {
+              ["default"] = function(sel)
+                if not sel or not sel[1] then return end
+                for idx, d in ipairs(display) do
+                  if d == sel[1] then
+                    vim.cmd(items[idx].cmd)
+                    return
+                  end
+                end
+              end,
+            },
+          })
+        end,
+        mode = "n",
+        silent = true,
+        desc = "Octoコマンドメニュー",
+      },
     },
     config = function()
       require("octo").setup({
         picker = "fzf-lua",
         default_remote = { "upstream", "origin" },
-        -- GitHub Enterprise の場合は以下を設定
-        -- github_hostname = "github.example.com",
+        mappings = {
+          review_diff = {
+            add_review_comment    = { lhs = "c", desc = "コメント追加", mode = { "n", "x" } },
+            add_review_suggestion = { lhs = "s", desc = "サジェスト追加", mode = { "n", "x" } },
+            submit_review         = { lhs = "S", desc = "レビュー送信" },
+            goto_file             = { lhs = "o", desc = "ファイルを開く" },
+          },
+          review_thread = {
+            add_reply      = { lhs = "r", desc = "返信追加" },
+            delete_comment = { lhs = "d", desc = "コメント削除" },
+          },
+        },
+      })
+
+      vim.api.nvim_create_autocmd("BufEnter", {
+        callback = function(args)
+          local ok = pcall(vim.api.nvim_buf_get_var, args.buf, "octo_diff_props")
+          if not ok then return end
+          vim.keymap.set("n", "C", function()
+            local panel = require("octo.reviews.file-panel")
+            local before = vim.fn.line(".")
+            panel.next_thread()
+            if vim.fn.line(".") == before then
+              vim.api.nvim_win_set_cursor(0, { 1, 0 })
+              panel.next_thread()
+            end
+          end, { buffer = args.buf, silent = true, desc = "次のスレッドへ（ループ）" })
+        end,
       })
     end,
   },

--- a/dot_config/nvim/lua/plugins/terminal.lua
+++ b/dot_config/nvim/lua/plugins/terminal.lua
@@ -139,10 +139,8 @@ return {
       end
 
       keymap({ "n", "t" }, "<leader>t", toggle_terminal, { noremap = true, silent = true, desc = "ターミナル開閉" })
-      keymap({ "n", "t" }, "<leader>h", toggle_terminal, { noremap = true, silent = true, desc = "ターミナル開閉" })
-      keymap("n", "<leader>cp", function() run_popup_command("chezmoi apply --interactive") end, { noremap = true, silent = true, desc = "chezmoi apply --interactive" })
-      keymap("n", "<leader>C", open_popup_command_picker, { noremap = true, silent = true, desc = "コマンドを選んでポップアップ実行" })
-      keymap({ "n", "t" }, "<leader>gk", toggle_keifu, { noremap = true, silent = true, desc = "keifu を開閉" })
+      keymap({ "n", "t" }, "<leader>H", open_popup_command_picker, { noremap = true, silent = true, desc = "コマンド履歴・実行ポップアップ" })
+keymap({ "n", "t" }, "<leader>gk", toggle_keifu, { noremap = true, silent = true, desc = "keifu を開閉" })
       keymap({ "n", "t" }, "<leader>E", toggle_filetree, { noremap = true, silent = true, desc = "filetree(ft) を開閉" })
     end,
   },

--- a/dot_config/nvim/lua/plugins/terminal.lua
+++ b/dot_config/nvim/lua/plugins/terminal.lua
@@ -139,6 +139,7 @@ return {
       end
 
       keymap({ "n", "t" }, "<leader>t", toggle_terminal, { noremap = true, silent = true, desc = "ターミナル開閉" })
+      keymap({ "n", "t" }, "<leader>h", toggle_terminal, { noremap = true, silent = true, desc = "ターミナル開閉" })
       keymap("n", "<leader>cp", function() run_popup_command("chezmoi apply --interactive") end, { noremap = true, silent = true, desc = "chezmoi apply --interactive" })
       keymap("n", "<leader>C", open_popup_command_picker, { noremap = true, silent = true, desc = "コマンドを選んでポップアップ実行" })
       keymap({ "n", "t" }, "<leader>gk", toggle_keifu, { noremap = true, silent = true, desc = "keifu を開閉" })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhances Neovim’s Git workflow with tighter `diffview.nvim`/`gitsigns.nvim` integration, a commit+PR popup, an `octo.nvim` command menu (now with admin merge/squash), and clearer diff highlights. Also fixes the initial word-jump so the first search advances, and refines FZF/terminal keymaps.

- **New Features**
  - `diffview.nvim`: new keymaps for file panel and history (open file with O, stage/unstage, close/help). Shortcuts: <leader>gd (diff panel), <leader>gl (repo history), <leader>gL (current file history).
  - `gitsigns.nvim`: enable current line blame with EOL text, 500ms delay, whitespace ignore, and custom formatter. New maps: <leader>gb (blame window), <leader>gp (commit+PR popup with [o] open PR in browser, [d] open commit in Diffview).
  - `octo.nvim`: add FZF-powered menu at <leader>gm for common PR/issue/review actions, including admin merge and squash with confirmation; refine review/diff mappings; add looping next-thread jump with C in review diffs.
  - `lazygit`: simplify to <leader>lg.
  - Theme tweaks: add CursorLine, refine CursorColumn, style GitSignsCurrentLineBlame, and set DiffAdd/Delete/Change/Text to a diffview/delta-like palette.
  - Extras: add `which-key.nvim` (500ms delay), switch FZF commands picker to <leader>c and help to <leader>?, and add a terminal command history/runner popup on <leader>H.

<sup>Written for commit 108d995c2156fd855a8b76827f0e57d6795882d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更内容概要

Neovim の Git 周りの操作性と表示を改善するための設定変更を行いました。主な変更は以下の通りです。
- diffview.nvim / gitsigns.nvim / lazygit 等の Git 関連プラグイン設定とキーマップを拡充・整理し、Diffview の開閉・ファイル履歴表示・現在ファイル履歴へのショートカット（例: <leader>gd / <leader>gl / <leader>gL）や、gitsigns のインライン blame 表示・blame ウィンドウ・コミット＋PR 情報ポップアップ（<leader>gb / <leader>gp）を追加しました。
- colorscheme の微調整で CursorLine・CursorColumn・GitSignsCurrentLineBlame および Diff 系ハイライト（DiffAdd/DiffDelete/DiffChange/DiffText）を上書きし、差分や blame 表示の可視性を向上させました。
- keymaps の細かな改善として、単語ジャンプ処理（jump_current_word）の初期検索の扱いを修正し最初の検索が正しく進むようにしました。
- そのほか、which-key の導入（delay=500）、lazygit の簡潔なマッピング（<leader>lg）、octo.nvim のキー操作をメニュー型に置き換える変更、ターミナルトグルの新規マッピング（<leader>h）や fzf の一部キーマップ修正などの調整を含みます。

## 変更理由

Neovim 内での Git ワークフローをより効率的・発見しやすくするため、差分確認・行単位の blame・コミットと紐づく PR 情報の参照をワンアクションで行えるようにし、関連 UI の視認性を高める目的です。キー配置の整理により既存コマンドとの競合を減らし、which-key 導入でキーバインドの案内を改善します。jump_current_word の修正は検索ジャンプの信頼性向上が狙いです。

## 確認した項目

- コミット＋PR ポップアップは git blame → git show → gh pr list の順で情報取得を試み、失敗時に適切なフォールバックメッセージを出す実装になっていること。
- diffview のファイルパネルとファイル履歴パネル用のキーマップが整理され、グローバルな Diffview 起動やファイル／履歴表示のショートカットが追加されていること。
- gitsigns の current_line_blame 表示設定（EOL 表示／遅延／ホワイトスペース無視／フォーマッタ）と blame ウィンドウ用キーマップが追加されていること。
- jump_current_word の初期検索処理が改善され、最初のジャンプで正しく進むようになっていること。
- which-key の導入（遅延設定）、lazygit のマッピング変更、octo のメニュー化、ターミナルトグルの新規キーマップなど、付随するキーマップ変更が意図通り整理されていること。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->