### PR TITLE
feature2

### DIFF
--- a/dot_config/git/gitignore
+++ b/dot_config/git/gitignore
@@ -31,3 +31,7 @@ settings.local.json
 
 ## VSCode
 mcp.json
+
+## AI
+plan/**
+

--- a/dot_config/nvim/lua/core/abbreviations.lua
+++ b/dot_config/nvim/lua/core/abbreviations.lua
@@ -1,4 +1,5 @@
 vim.cmd([[
+cabbr cd tcd
 cabbr he help
 cabbr te terminal
 cabbr teh horizontal terminal

--- a/dot_config/nvim/lua/plugins/fzf.lua
+++ b/dot_config/nvim/lua/plugins/fzf.lua
@@ -25,10 +25,12 @@ return {
         for _, tab in ipairs(tabs) do
           local tabnr = vim.api.nvim_tabpage_get_number(tab)
           local cwd = vim.fn.getcwd(-1, tabnr)
+          local parent = vim.fn.fnamemodify(cwd, ":h:t")
           local dirname = vim.fn.fnamemodify(cwd, ":t")
-          if dirname == "" then dirname = cwd end
+          local display = (parent ~= "" and parent ~= ".") and (parent .. "/" .. dirname) or dirname
+          if display == "" then display = cwd end
           local current = tab == current_tab and "*" or " "
-          table.insert(items, string.format("%d\t%s %s", tabnr, current, dirname))
+          table.insert(items, string.format("%d\t%s %s", tabnr, current, display))
         end
 
         fzf.fzf_exec(items, {
@@ -111,7 +113,7 @@ return {
         })
       end
 
-      keymap("n", "<leader>z", zoxide_tcd, { noremap = true, silent = true, desc = "Zoxide ディレクトリ検索（タブローカル）" })
+      keymap("n", "<leader>Z", zoxide_tcd, { noremap = true, silent = true, desc = "Zoxide ディレクトリ検索（タブローカル）" })
       -- :zz で zoxide を起動（タブローカルtcd版）
       vim.api.nvim_create_user_command("Zz", zoxide_tcd, {})
       vim.cmd("cabbr zz <Cmd>Zz<CR>")

--- a/dot_config/nvim/lua/plugins/git.lua
+++ b/dot_config/nvim/lua/plugins/git.lua
@@ -265,11 +265,14 @@ return {
                               table.insert(display, string.format("PR: #%d - %s", pr.number, pr.title))
                               table.insert(display, "URL: " .. pr.url)
                               table.insert(display, "")
-                              table.insert(display, "[o] PRをブラウザで開く  [d] diffviewで開く  [q] 閉じる")
+                              table.insert(display, "[o] PRをブラウザで開く")
+                              table.insert(display, "[d] diffviewで開く")
+                              table.insert(display, "[q] 閉じる")
                             else
                               table.insert(display, "PR: 見つかりません")
                               table.insert(display, "")
-                              table.insert(display, "[d] diffviewで開く  [q] 閉じる")
+                              table.insert(display, "[d] diffviewで開く")
+                              table.insert(display, "[q] 閉じる")
                             end
                           else
                             table.insert(display, "PR: 取得できません（gh CLI エラー）")

--- a/dot_config/nvim/lua/plugins/git.lua
+++ b/dot_config/nvim/lua/plugins/git.lua
@@ -99,20 +99,19 @@ return {
 
       -- 複数リポジトリのコミット履歴をタブで開く
       local function open_file_history_multi()
-        local dirs = find_dirs()
-        require("fzf-lua").fzf_exec(dirs, {
+        local repos = find_repos()
+        local entries = #repos > 0 and repos or find_dirs()
+        require("fzf-lua").fzf_exec(entries, {
           prompt = "リポジトリ選択（Tab複数選択）> ",
           fzf_opts = { ["--multi"] = true },
           actions = {
             ["default"] = function(selected)
               if not selected or #selected == 0 then return end
-              local orig_cwd = vim.fn.getcwd()
               for _, repo in ipairs(selected) do
                 vim.cmd("tabnew")
-                vim.fn.chdir(repo)
+                vim.cmd("tcd " .. vim.fn.fnameescape(repo))
                 vim.cmd("DiffviewFileHistory")
               end
-              vim.schedule(function() vim.fn.chdir(orig_cwd) end)
             end,
           },
         })
@@ -158,6 +157,10 @@ return {
       local function github_url_action(action)
         local lnum     = vim.api.nvim_win_get_cursor(0)[1]
         local filename = vim.api.nvim_buf_get_name(0)
+        if filename == "" then
+          vim.notify("未保存のバッファには使用できません", vim.log.levels.WARN)
+          return
+        end
         local repo_dir = vim.fn.fnamemodify(filename, ":h")
 
         get_github_base_url(repo_dir, function(base)

--- a/dot_config/nvim/lua/plugins/git.lua
+++ b/dot_config/nvim/lua/plugins/git.lua
@@ -36,29 +36,8 @@ return {
         },
       })
 
-      -- .git がディレクトリ（通常リポジトリ）またはファイル（worktree）か確認
-      local function is_git_root(dir)
-        local git = dir .. "/.git"
-        return vim.fn.isdirectory(git) == 1 or vim.fn.filereadable(git) == 1
-      end
-
-      -- cwd 配下のリポジトリ一覧を収集（cwd 自身 + 1〜2階層下）
-      local function find_repos()
-        local cwd = vim.fn.getcwd()
-        local repos = {}
-        if is_git_root(cwd) then
-          table.insert(repos, cwd)
-        end
-        for _, p in ipairs(vim.fn.glob(cwd .. "/*/.git", false, true)) do
-          local dir = vim.fn.fnamemodify(p, ":h")
-          if is_git_root(dir) then table.insert(repos, dir) end
-        end
-        for _, p in ipairs(vim.fn.glob(cwd .. "/*/*/.git", false, true)) do
-          local dir = vim.fn.fnamemodify(p, ":h")
-          if is_git_root(dir) then table.insert(repos, dir) end
-        end
-        return repos
-      end
+      local git_utils = require("utils.git")
+      local find_repos = git_utils.find_repos
 
       -- リポジトリを選択して cmd を実行（単一なら即実行、複数なら fzf-lua で選択）
       local function with_repo(cmd, fallback_cmd)
@@ -85,22 +64,10 @@ return {
         end
       end
 
-      -- cwd 直下の全ディレクトリを列挙（.git 有無問わず）
-      local function find_dirs()
-        local cwd = vim.fn.getcwd()
-        local dirs = { cwd }
-        for _, p in ipairs(vim.fn.glob(cwd .. "/*", false, true)) do
-          if vim.fn.isdirectory(p) == 1 then
-            table.insert(dirs, p)
-          end
-        end
-        return dirs
-      end
-
       -- 複数リポジトリのコミット履歴をタブで開く
       local function open_file_history_multi()
         local repos = find_repos()
-        local entries = #repos > 0 and repos or find_dirs()
+        local entries = repos
         require("fzf-lua").fzf_exec(entries, {
           prompt = "リポジトリ選択（Tab複数選択）> ",
           fzf_opts = { ["--multi"] = true },
@@ -515,16 +482,13 @@ return {
 
       local function open_lazygit_with_selection()
         local cwd = vim.fn.getcwd()
-        local dirs = { cwd }
-        for _, p in ipairs(vim.fn.glob(cwd .. "/*", false, true)) do
-          if vim.fn.isdirectory(p) == 1 then
-            table.insert(dirs, p)
-          end
-        end
-        if #dirs == 1 then
-          open_lazygit(dirs[1])
+        local repos = require("utils.git").find_repos()
+        if #repos == 0 then
+          open_lazygit(cwd)
+        elseif #repos == 1 then
+          open_lazygit(repos[1])
         else
-          require("fzf-lua").fzf_exec(dirs, {
+          require("fzf-lua").fzf_exec(repos, {
             prompt = "lazygit ディレクトリ選択> ",
             actions = {
               ["default"] = function(selected)

--- a/dot_config/nvim/lua/plugins/git.lua
+++ b/dot_config/nvim/lua/plugins/git.lua
@@ -36,17 +36,16 @@ return {
         },
       })
 
-      -- リポジトリを選択して DiffviewOpen
-      local function open_diffview()
+      -- .git がディレクトリ（通常リポジトリ）またはファイル（worktree）か確認
+      local function is_git_root(dir)
+        local git = dir .. "/.git"
+        return vim.fn.isdirectory(git) == 1 or vim.fn.filereadable(git) == 1
+      end
+
+      -- cwd 配下のリポジトリ一覧を収集（cwd 自身 + 1〜2階層下）
+      local function find_repos()
         local cwd = vim.fn.getcwd()
         local repos = {}
-
-        -- .git がディレクトリ（通常リポジトリ）またはファイル（worktree）か確認
-        local function is_git_root(dir)
-          local git = dir .. "/.git"
-          return vim.fn.isdirectory(git) == 1 or vim.fn.filereadable(git) == 1
-        end
-
         if is_git_root(cwd) then
           table.insert(repos, cwd)
         end
@@ -58,18 +57,20 @@ return {
           local dir = vim.fn.fnamemodify(p, ":h")
           if is_git_root(dir) then table.insert(repos, dir) end
         end
+        return repos
+      end
 
+      -- リポジトリを選択して cmd を実行（単一なら即実行、複数なら fzf-lua で選択）
+      local function with_repo(cmd, fallback_cmd)
+        local repos = find_repos()
         local function launch(repo)
           local prev_cwd = vim.fn.getcwd()
           vim.fn.chdir(repo)
-          vim.cmd("DiffviewOpen")
-          vim.schedule(function()
-            vim.fn.chdir(prev_cwd)
-          end)
+          vim.cmd(cmd)
+          vim.schedule(function() vim.fn.chdir(prev_cwd) end)
         end
-
         if #repos == 0 then
-          vim.cmd("DiffviewOpen")
+          vim.cmd(fallback_cmd or cmd)
         elseif #repos == 1 then
           launch(repos[1])
         else
@@ -84,9 +85,42 @@ return {
         end
       end
 
-      vim.keymap.set("n", "<leader>gd", open_diffview,                   { noremap = true, silent = true, desc = "Git差分パネル（複数リポジトリ対応）" })
-      vim.keymap.set("n", "<leader>gl", ":DiffviewFileHistory<CR>",   { noremap = true, silent = true, desc = "リポジトリ全体のコミット履歴（diffview）" })
-      vim.keymap.set("n", "<leader>gL", ":DiffviewFileHistory %<CR>", { noremap = true, silent = true, desc = "現在ファイルのコミット履歴（diffview）" })
+      -- cwd 直下の全ディレクトリを列挙（.git 有無問わず）
+      local function find_dirs()
+        local cwd = vim.fn.getcwd()
+        local dirs = { cwd }
+        for _, p in ipairs(vim.fn.glob(cwd .. "/*", false, true)) do
+          if vim.fn.isdirectory(p) == 1 then
+            table.insert(dirs, p)
+          end
+        end
+        return dirs
+      end
+
+      -- 複数リポジトリのコミット履歴をタブで開く
+      local function open_file_history_multi()
+        local dirs = find_dirs()
+        require("fzf-lua").fzf_exec(dirs, {
+          prompt = "リポジトリ選択（Tab複数選択）> ",
+          fzf_opts = { ["--multi"] = true },
+          actions = {
+            ["default"] = function(selected)
+              if not selected or #selected == 0 then return end
+              local orig_cwd = vim.fn.getcwd()
+              for _, repo in ipairs(selected) do
+                vim.cmd("tabnew")
+                vim.fn.chdir(repo)
+                vim.cmd("DiffviewFileHistory")
+              end
+              vim.schedule(function() vim.fn.chdir(orig_cwd) end)
+            end,
+          },
+        })
+      end
+
+      vim.keymap.set("n", "<leader>gd", function() with_repo("DiffviewOpen") end,    { noremap = true, silent = true, desc = "Git差分パネル（複数リポジトリ対応）" })
+      vim.keymap.set("n", "<leader>gl", open_file_history_multi,                      { noremap = true, silent = true, desc = "リポジトリ全体のコミット履歴（Tab複数選択・別タブ）" })
+      vim.keymap.set("n", "<leader>gL", ":DiffviewFileHistory %<CR>",                { noremap = true, silent = true, desc = "現在ファイルのコミット履歴（diffview）" })
 
     end,
   },

--- a/dot_config/nvim/lua/plugins/git.lua
+++ b/dot_config/nvim/lua/plugins/git.lua
@@ -128,6 +128,76 @@ return {
     "lewis6991/gitsigns.nvim",
     event = { "BufReadPre", "BufNewFile" },
     config = function()
+      local function get_github_base_url(repo_dir, callback)
+        vim.system({ "git", "remote", "get-url", "origin" }, { text = true, cwd = repo_dir }, function(r)
+          if r.code ~= 0 then callback(nil) return end
+          local raw = vim.trim(r.stdout or "")
+          local base = raw
+            :gsub("^git@github%.com:", "https://github.com/")
+            :gsub("%.git$", "")
+          if not base:match("^https://github%.com/") then
+            callback(nil) return
+          end
+          callback(base)
+        end)
+      end
+
+      local function get_repo_relative_path(repo_dir, filepath, callback)
+        vim.system({ "git", "rev-parse", "--show-toplevel" }, { text = true, cwd = repo_dir }, function(r)
+          if r.code ~= 0 then callback(nil) return end
+          local root = vim.trim(r.stdout or "")
+          local rel = filepath:sub(#root + 2)
+          callback(rel)
+        end)
+      end
+
+      local function build_github_url(base, sha, rel_path, lnum)
+        return string.format("%s/blob/%s/%s#L%d", base, sha, rel_path, lnum)
+      end
+
+      local function github_url_action(action)
+        local lnum     = vim.api.nvim_win_get_cursor(0)[1]
+        local filename = vim.api.nvim_buf_get_name(0)
+        local repo_dir = vim.fn.fnamemodify(filename, ":h")
+
+        get_github_base_url(repo_dir, function(base)
+          if not base then
+            vim.schedule(function()
+              vim.notify("GitHub リモートが見つかりません", vim.log.levels.WARN)
+            end)
+            return
+          end
+          get_repo_relative_path(repo_dir, filename, function(rel)
+            if not rel then return end
+            if action == "main" then
+              vim.system({ "git", "rev-parse", "--verify", "origin/main" },
+                { text = true, cwd = repo_dir },
+                function(rv)
+                  local branch = (rv.code == 0) and "main" or "master"
+                  local url = build_github_url(base, branch, rel, lnum)
+                  vim.schedule(function() vim.ui.open(url) end)
+                end)
+            else
+              vim.system({ "git", "rev-parse", "HEAD" },
+                { text = true, cwd = repo_dir },
+                function(rv)
+                  if rv.code ~= 0 then return end
+                  local head_sha = vim.trim(rv.stdout or "")
+                  local url = build_github_url(base, head_sha, rel, lnum)
+                  vim.schedule(function()
+                    if action == "copy" then
+                      vim.fn.setreg("+", url)
+                      vim.notify("コピーしました: " .. url, vim.log.levels.INFO)
+                    else
+                      vim.ui.open(url)
+                    end
+                  end)
+                end)
+            end
+          end)
+        end)
+      end
+
       require("gitsigns").setup({
         current_line_blame = true,
         current_line_blame_opts = {
@@ -267,17 +337,27 @@ return {
                               table.insert(display, "")
                               table.insert(display, "[o] PRをブラウザで開く")
                               table.insert(display, "[d] diffviewで開く")
+                              table.insert(display, "[y] パーマネントリンクをコピー")
+                              table.insert(display, "[b] ブラウザで開く（コミット）")
+                              table.insert(display, "[B] ブラウザで開く（main）")
                               table.insert(display, "[q] 閉じる")
                             else
                               table.insert(display, "PR: 見つかりません")
                               table.insert(display, "")
                               table.insert(display, "[d] diffviewで開く")
+                              table.insert(display, "[y] パーマネントリンクをコピー")
+                              table.insert(display, "[b] ブラウザで開く（コミット）")
+                              table.insert(display, "[B] ブラウザで開く（main）")
                               table.insert(display, "[q] 閉じる")
                             end
                           else
                             table.insert(display, "PR: 取得できません（gh CLI エラー）")
                             table.insert(display, "")
-                            table.insert(display, "[d] diffviewで開く  [q] 閉じる")
+                            table.insert(display, "[d] diffviewで開く")
+                            table.insert(display, "[y] パーマネントリンクをコピー")
+                            table.insert(display, "[b] ブラウザで開く（コミット）")
+                            table.insert(display, "[B] ブラウザで開く（main）")
+                            table.insert(display, "[q] 閉じる")
                           end
 
                           local max_w = 0
@@ -319,6 +399,49 @@ return {
                             close()
                             vim.cmd("DiffviewOpen " .. commit_sha .. "^.." .. commit_sha)
                           end, { buffer = float_buf, nowait = true, desc = "diffviewでコミットを開く" })
+                          vim.keymap.set("n", "y", function()
+                            get_github_base_url(repo_dir, function(base)
+                              if not base then
+                                vim.schedule(function()
+                                  vim.notify("GitHub リモートが見つかりません", vim.log.levels.WARN)
+                                end)
+                                return
+                              end
+                              get_repo_relative_path(repo_dir, filename, function(rel)
+                                if not rel then return end
+                                local url = build_github_url(base, commit_sha, rel, lnum)
+                                vim.schedule(function()
+                                  vim.fn.setreg("+", url)
+                                  vim.notify("コピーしました: " .. url, vim.log.levels.INFO)
+                                end)
+                              end)
+                            end)
+                          end, { buffer = float_buf, nowait = true, desc = "パーマネントリンクをコピー" })
+                          vim.keymap.set("n", "b", function()
+                            get_github_base_url(repo_dir, function(base)
+                              if not base then return end
+                              get_repo_relative_path(repo_dir, filename, function(rel)
+                                if not rel then return end
+                                local url = build_github_url(base, commit_sha, rel, lnum)
+                                vim.schedule(function() vim.ui.open(url) end)
+                              end)
+                            end)
+                          end, { buffer = float_buf, nowait = true, desc = "ブラウザで開く（コミット）" })
+                          vim.keymap.set("n", "B", function()
+                            get_github_base_url(repo_dir, function(base)
+                              if not base then return end
+                              get_repo_relative_path(repo_dir, filename, function(rel)
+                                if not rel then return end
+                                vim.system({ "git", "rev-parse", "--verify", "origin/main" },
+                                  { text = true, cwd = repo_dir },
+                                  function(rv)
+                                    local branch = (rv.code == 0) and "main" or "master"
+                                    local url = build_github_url(base, branch, rel, lnum)
+                                    vim.schedule(function() vim.ui.open(url) end)
+                                  end)
+                              end)
+                            end)
+                          end, { buffer = float_buf, nowait = true, desc = "ブラウザで開く（main ブランチ）" })
                         end)
                       end
                     )
@@ -338,6 +461,13 @@ return {
           map({ "o", "x" }, "ih", ":<C-U>Gitsigns select_hunk<CR>", { desc = "ハンクを選択" })
         end,
       })
+
+      vim.keymap.set("n", "<leader>gy", function() github_url_action("copy") end,
+        { noremap = true, silent = true, desc = "GitHub パーマネントリンクをコピー" })
+      vim.keymap.set("n", "<leader>go", function() github_url_action("open") end,
+        { noremap = true, silent = true, desc = "GitHub でファイルを開く（HEAD）" })
+      vim.keymap.set("n", "<leader>gO", function() github_url_action("main") end,
+        { noremap = true, silent = true, desc = "GitHub でファイルを開く（main）" })
     end,
   },
   {

--- a/dot_config/nvim/lua/plugins/git.lua
+++ b/dot_config/nvim/lua/plugins/git.lua
@@ -513,7 +513,29 @@ return {
         vim.cmd("startinsert")
       end
 
-      keymap("n", "<leader>lg", ":LazyGit<CR>", { noremap = true, silent = true, desc = "lazygit を開く" })
+      local function open_lazygit_with_selection()
+        local cwd = vim.fn.getcwd()
+        local dirs = { cwd }
+        for _, p in ipairs(vim.fn.glob(cwd .. "/*", false, true)) do
+          if vim.fn.isdirectory(p) == 1 then
+            table.insert(dirs, p)
+          end
+        end
+        if #dirs == 1 then
+          open_lazygit(dirs[1])
+        else
+          require("fzf-lua").fzf_exec(dirs, {
+            prompt = "lazygit ディレクトリ選択> ",
+            actions = {
+              ["default"] = function(selected)
+                if selected and selected[1] then open_lazygit(selected[1]) end
+              end,
+            },
+          })
+        end
+      end
+
+      keymap("n", "<leader>lg", open_lazygit_with_selection, { noremap = true, silent = true, desc = "lazygit を開く（ディレクトリ選択）" })
     end,
   },
 }

--- a/dot_config/nvim/lua/plugins/git.lua
+++ b/dot_config/nvim/lua/plugins/git.lua
@@ -112,13 +112,45 @@ return {
         vim.system({ "git", "rev-parse", "--show-toplevel" }, { text = true, cwd = repo_dir }, function(r)
           if r.code ~= 0 then callback(nil) return end
           local root = vim.trim(r.stdout or "")
-          local rel = filepath:sub(#root + 2)
+          local rel = vim.fs.relpath(root, vim.fs.normalize(filepath))
           callback(rel)
         end)
       end
 
+      local function get_default_branch(repo_dir, callback)
+        vim.system(
+          { "git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD" },
+          { text = true, cwd = repo_dir },
+          function(r)
+            if r.code == 0 then
+              local branch = vim.trim(r.stdout or ""):gsub("^origin/", "")
+              if branch ~= "" then
+                callback(branch)
+                return
+              end
+            end
+
+            vim.system(
+              { "gh", "repo", "view", "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name" },
+              { text = true, cwd = repo_dir },
+              function(gh_result)
+                if gh_result.code ~= 0 then callback(nil) return end
+                local branch = vim.trim(gh_result.stdout or "")
+                callback(branch ~= "" and branch or nil)
+              end
+            )
+          end
+        )
+      end
+
+      local function encode_url_path(path)
+        return path:gsub("[^%w%-%._~/]", function(char)
+          return string.format("%%%02X", string.byte(char))
+        end)
+      end
+
       local function build_github_url(base, sha, rel_path, lnum)
-        return string.format("%s/blob/%s/%s#L%d", base, sha, rel_path, lnum)
+        return string.format("%s/blob/%s/%s#L%d", base, sha, encode_url_path(rel_path), lnum)
       end
 
       local function github_url_action(action)
@@ -140,13 +172,16 @@ return {
           get_repo_relative_path(repo_dir, filename, function(rel)
             if not rel then return end
             if action == "main" then
-              vim.system({ "git", "rev-parse", "--verify", "origin/main" },
-                { text = true, cwd = repo_dir },
-                function(rv)
-                  local branch = (rv.code == 0) and "main" or "master"
-                  local url = build_github_url(base, branch, rel, lnum)
-                  vim.schedule(function() vim.ui.open(url) end)
-                end)
+              get_default_branch(repo_dir, function(branch)
+                if not branch then
+                  vim.schedule(function()
+                    vim.notify("既定ブランチを取得できません", vim.log.levels.WARN)
+                  end)
+                  return
+                end
+                local url = build_github_url(base, branch, rel, lnum)
+                vim.schedule(function() vim.ui.open(url) end)
+              end)
             else
               vim.system({ "git", "rev-parse", "HEAD" },
                 { text = true, cwd = repo_dir },
@@ -247,7 +282,7 @@ return {
             local repo_dir = vim.fn.fnamemodify(filename, ":h")
 
             vim.system(
-              { "git", "blame", "-L", lnum .. "," .. lnum, "--porcelain", filename },
+              { "git", "-c", "core.quotePath=false", "blame", "-L", lnum .. "," .. lnum, "--porcelain", filename },
               { text = true, cwd = repo_dir },
               function(blame_result)
                 if blame_result.code ~= 0 then
@@ -257,7 +292,9 @@ return {
                   return
                 end
 
-                local sha = blame_result.stdout:match("^(%x+)")
+                local sha, blame_lnum = blame_result.stdout:match("^(%x+) (%d+)")
+                local blame_filename = blame_result.stdout:match("\nfilename ([^\n]+)")
+                blame_lnum = tonumber(blame_lnum) or lnum
                 if not sha or sha:match("^0+$") then
                   vim.schedule(function()
                     vim.notify("コミット情報を取得できません（未コミットの行）", vim.log.levels.WARN)
@@ -377,24 +414,22 @@ return {
                                 end)
                                 return
                               end
-                              get_repo_relative_path(repo_dir, filename, function(rel)
-                                if not rel then return end
-                                local url = build_github_url(base, commit_sha, rel, lnum)
-                                vim.schedule(function()
-                                  vim.fn.setreg("+", url)
-                                  vim.notify("コピーしました: " .. url, vim.log.levels.INFO)
-                                end)
+                              local rel = blame_filename
+                              if not rel then return end
+                              local url = build_github_url(base, commit_sha, rel, blame_lnum)
+                              vim.schedule(function()
+                                vim.fn.setreg("+", url)
+                                vim.notify("コピーしました: " .. url, vim.log.levels.INFO)
                               end)
                             end)
                           end, { buffer = float_buf, nowait = true, desc = "パーマネントリンクをコピー" })
                           vim.keymap.set("n", "b", function()
                             get_github_base_url(repo_dir, function(base)
                               if not base then return end
-                              get_repo_relative_path(repo_dir, filename, function(rel)
-                                if not rel then return end
-                                local url = build_github_url(base, commit_sha, rel, lnum)
-                                vim.schedule(function() vim.ui.open(url) end)
-                              end)
+                              local rel = blame_filename
+                              if not rel then return end
+                              local url = build_github_url(base, commit_sha, rel, blame_lnum)
+                              vim.schedule(function() vim.ui.open(url) end)
                             end)
                           end, { buffer = float_buf, nowait = true, desc = "ブラウザで開く（コミット）" })
                           vim.keymap.set("n", "B", function()
@@ -402,13 +437,16 @@ return {
                               if not base then return end
                               get_repo_relative_path(repo_dir, filename, function(rel)
                                 if not rel then return end
-                                vim.system({ "git", "rev-parse", "--verify", "origin/main" },
-                                  { text = true, cwd = repo_dir },
-                                  function(rv)
-                                    local branch = (rv.code == 0) and "main" or "master"
-                                    local url = build_github_url(base, branch, rel, lnum)
-                                    vim.schedule(function() vim.ui.open(url) end)
-                                  end)
+                                get_default_branch(repo_dir, function(branch)
+                                  if not branch then
+                                    vim.schedule(function()
+                                      vim.notify("既定ブランチを取得できません", vim.log.levels.WARN)
+                                    end)
+                                    return
+                                  end
+                                  local url = build_github_url(base, branch, rel, lnum)
+                                  vim.schedule(function() vim.ui.open(url) end)
+                                end)
                               end)
                             end)
                           end, { buffer = float_buf, nowait = true, desc = "ブラウザで開く（main ブランチ）" })

--- a/dot_config/nvim/lua/plugins/github.lua
+++ b/dot_config/nvim/lua/plugins/github.lua
@@ -85,6 +85,7 @@ return {
             add_review_suggestion = { lhs = "s", desc = "サジェスト追加", mode = { "n", "x" } },
             submit_review         = { lhs = "S", desc = "レビュー送信" },
             goto_file             = { lhs = "O", desc = "ファイルを開く" },
+            close_review_tab      = { lhs = "q", desc = "diff viewを閉じる" },
           },
           review_thread = {
             add_reply      = { lhs = "r", desc = "返信追加" },

--- a/dot_config/nvim/lua/plugins/github.lua
+++ b/dot_config/nvim/lua/plugins/github.lua
@@ -84,7 +84,7 @@ return {
             add_review_comment    = { lhs = "c", desc = "コメント追加", mode = { "n", "x" } },
             add_review_suggestion = { lhs = "s", desc = "サジェスト追加", mode = { "n", "x" } },
             submit_review         = { lhs = "S", desc = "レビュー送信" },
-            goto_file             = { lhs = "o", desc = "ファイルを開く" },
+            goto_file             = { lhs = "O", desc = "ファイルを開く" },
           },
           review_thread = {
             add_reply      = { lhs = "r", desc = "返信追加" },

--- a/dot_config/nvim/lua/plugins/lsp.lua
+++ b/dot_config/nvim/lua/plugins/lsp.lua
@@ -21,6 +21,7 @@ return {
 
       vim.g.lsp_enabled = vim.g.lsp_enabled ~= false
       vim.g.inline_diagnostics_enabled = vim.g.inline_diagnostics_enabled ~= false
+      vim.g.inlay_hints_enabled = vim.g.inlay_hints_enabled ~= false
 
       local ts_server = has_lspconfig("ts_ls") and "ts_ls" or "tsserver"
       local python_server = has_lspconfig("pyright") and "pyright" or (has_lspconfig("basedpyright") and "basedpyright" or nil)
@@ -32,6 +33,15 @@ return {
               usePlaceholders = true,
               analyses = {
                 unusedparams = true,
+              },
+              hints = {
+                assignVariableTypes    = true,
+                compositeLiteralFields = true,
+                compositeLiteralTypes  = true,
+                constantValues         = true,
+                functionTypeParameters = true,
+                parameterNames         = true,
+                rangeVariableTypes     = true,
               },
             },
           },
@@ -55,11 +65,38 @@ return {
             },
           },
         },
-        [ts_server] = {},
+        [ts_server] = {
+          settings = {
+            typescript = {
+              inlayHints = {
+                includeInlayParameterNameHints              = "all",
+                includeInlayParameterNameHintsWhenArgumentMatchesName = false,
+                includeInlayFunctionParameterTypeHints      = true,
+                includeInlayVariableTypeHints               = true,
+                includeInlayVariableTypeHintsWhenTypeMatchesName = false,
+                includeInlayPropertyDeclarationTypeHints    = true,
+                includeInlayFunctionLikeReturnTypeHints     = true,
+                includeInlayEnumMemberValueHints            = true,
+              },
+            },
+            javascript = {
+              inlayHints = {
+                includeInlayParameterNameHints              = "all",
+                includeInlayParameterNameHintsWhenArgumentMatchesName = false,
+                includeInlayFunctionParameterTypeHints      = true,
+                includeInlayVariableTypeHints               = true,
+                includeInlayVariableTypeHintsWhenTypeMatchesName = false,
+                includeInlayPropertyDeclarationTypeHints    = true,
+                includeInlayFunctionLikeReturnTypeHints     = true,
+                includeInlayEnumMemberValueHints            = true,
+              },
+            },
+          },
+        },
       }
 
       if python_server then
-        servers[python_server] = {
+        local python_settings = {
           settings = {
             python = {
               analysis = {
@@ -74,6 +111,29 @@ return {
             },
           },
         }
+        if python_server == "basedpyright" then
+          python_settings.settings.basedpyright = {
+            analysis = {
+              inlayHints = {
+                variableTypes       = true,
+                functionReturnTypes = true,
+                parameterTypes      = true,
+                callArgumentNames   = true,
+                genericTypes        = true,
+              },
+            },
+          }
+        else
+          python_settings.settings.pyright = {
+            inlayHints = {
+              variableTypes       = true,
+              functionReturnTypes = true,
+              parameterTypes      = true,
+              callArgumentNames   = true,
+            },
+          }
+        end
+        servers[python_server] = python_settings
       end
 
       if has_lspconfig("ruff") then
@@ -273,6 +333,10 @@ return {
           return
         end
 
+        if vim.fn.has("nvim-0.10") == 1 and client.supports_method("textDocument/inlayHint") then
+          vim.lsp.inlay_hint.enable(vim.g.inlay_hints_enabled, { bufnr = bufnr })
+        end
+
         if vim.b[bufnr].vscode_like_lsp_maps then
           return
         end
@@ -414,6 +478,9 @@ return {
       pcall(vim.api.nvim_del_user_command, "InlineDiagnosticsEnable")
       pcall(vim.api.nvim_del_user_command, "InlineDiagnosticsDisable")
       pcall(vim.api.nvim_del_user_command, "InlineDiagnosticsToggle")
+      pcall(vim.api.nvim_del_user_command, "InlayHintsEnable")
+      pcall(vim.api.nvim_del_user_command, "InlayHintsDisable")
+      pcall(vim.api.nvim_del_user_command, "InlayHintsToggle")
 
       vim.api.nvim_create_user_command("LspEnable", enable_lsp, {})
       vim.api.nvim_create_user_command("LspDisable", disable_lsp, {})
@@ -445,6 +512,37 @@ return {
         noremap = true,
         silent = true,
         desc = "inline diagnostics を切り替え",
+      })
+
+      local function apply_inlay_hints(enabled)
+        for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+          if vim.api.nvim_buf_is_loaded(buf) then
+            pcall(vim.lsp.inlay_hint.enable, enabled, { bufnr = buf })
+          end
+        end
+      end
+
+      vim.api.nvim_create_user_command("InlayHintsEnable", function()
+        vim.g.inlay_hints_enabled = true
+        apply_inlay_hints(true)
+        vim.notify("inlay hints を有効化しました", vim.log.levels.INFO)
+      end, {})
+      vim.api.nvim_create_user_command("InlayHintsDisable", function()
+        vim.g.inlay_hints_enabled = false
+        apply_inlay_hints(false)
+        vim.notify("inlay hints を無効化しました", vim.log.levels.INFO)
+      end, {})
+      vim.api.nvim_create_user_command("InlayHintsToggle", function()
+        vim.g.inlay_hints_enabled = not vim.g.inlay_hints_enabled
+        apply_inlay_hints(vim.g.inlay_hints_enabled)
+        local status = vim.g.inlay_hints_enabled and "有効" or "無効"
+        vim.notify("inlay hints を " .. status .. " にしました", vim.log.levels.INFO)
+      end, {})
+
+      vim.keymap.set("n", "<leader>xh", "<cmd>InlayHintsToggle<CR>", {
+        noremap = true,
+        silent = true,
+        desc = "inlay hints を切り替え",
       })
     end,
   },

--- a/dot_config/nvim/lua/plugins/lsp.lua
+++ b/dot_config/nvim/lua/plugins/lsp.lua
@@ -123,15 +123,6 @@ return {
               },
             },
           }
-        else
-          python_settings.settings.pyright = {
-            inlayHints = {
-              variableTypes       = true,
-              functionReturnTypes = true,
-              parameterTypes      = true,
-              callArgumentNames   = true,
-            },
-          }
         end
         servers[python_server] = python_settings
       end

--- a/dot_config/nvim/lua/utils/git.lua
+++ b/dot_config/nvim/lua/utils/git.lua
@@ -1,0 +1,26 @@
+local M = {}
+
+function M.is_git_root(dir)
+  local git = dir .. "/.git"
+  return vim.fn.isdirectory(git) == 1 or vim.fn.filereadable(git) == 1
+end
+
+-- cwd 配下のリポジトリ一覧を収集（cwd 自身 + 1〜2階層下）
+function M.find_repos()
+  local cwd = vim.fn.getcwd()
+  local repos = {}
+  if M.is_git_root(cwd) then
+    table.insert(repos, cwd)
+  end
+  for _, p in ipairs(vim.fn.glob(cwd .. "/*/.git", false, true)) do
+    local dir = vim.fn.fnamemodify(p, ":h")
+    if M.is_git_root(dir) then table.insert(repos, dir) end
+  end
+  for _, p in ipairs(vim.fn.glob(cwd .. "/*/*/.git", false, true)) do
+    local dir = vim.fn.fnamemodify(p, ":h")
+    if M.is_git_root(dir) then table.insert(repos, dir) end
+  end
+  return repos
+end
+
+return M

--- a/dot_config/zabrze/git.toml
+++ b/dot_config/zabrze/git.toml
@@ -215,6 +215,11 @@ snippet = "git merge --abort"
 trigger = "gma"
 
 [[snippets]]
+name    = "git merge --continue"
+snippet = "git merge --continue"
+trigger = "gmc"
+
+[[snippets]]
 name    = "git merge --squash"
 snippet = "git merge --squash"
 trigger = "gms"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve Neovim Git workflow with multi-repo `diffview.nvim`, GitHub permalink actions, and a smarter `lazygit` launcher; also enable inlay hints across languages with quick toggles. Adds a git snippet, ignores `plan/**`, and adds a handy `cd` → `tcd` abbreviation.

- **New Features**
  - Multi-repo: choose repos via `fzf-lua` for `DiffviewOpen` and open multiple histories in tabs. Keys: `<leader>gd`, `<leader>gl`, `<leader>gL`.
  - GitHub links: copy/open permalinks for the current line (HEAD or main). Keys: `<leader>gy`, `<leader>go`, `<leader>gO`. PR popup actions: y/b/B/d.
  - Inlay hints: enabled and configurable for `gopls`, TypeScript/JavaScript, and Pyright/Basedpyright. Commands: `:InlayHintsEnable/Disable/Toggle`, key: `<leader>xh`.
  - `lazygit`: pick a directory with `fzf-lua` before launching. Key: `<leader>lg`.
  - Misc: ignore `plan/**`; add `gmc` (`git merge --continue`); command-line abbr `cd` → `tcd`.

- **Refactors**
  - Extracted repo/worktree detection into `utils.git`; safer temporary `cwd` switching for `diffview.nvim`.
  - GitHub UIs: improved `gitsigns.nvim` PR popup; review view now uses `O` for goto_file and adds `q` to close the diff tab.
  - `fzf-lua`: clearer tab cwd labels; zoxide picker moved to `<leader>Z`.

<sup>Written for commit 70ef4941e8ac86dfecfde65bc380c890d462fc8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更内容概要
Neovim 周りと Git/GitHub 操作の改善を中心とした設定追加・リファクタです。主な変更点は以下です。
- Diffview のマルチリポジトリ対応：fzf-lua でリポジトリ選択・複数リポジトリの履歴をタブで開く機能とキー割当の追加（<leader>gd / <leader>gl / <leader>gL）。repo/worktree 判定を utils.git に切り出し、呼び出し時の一時 cwd 切替を安全化。
- GitHub パーマリンク操作：カーソル行から HEAD または main に対する permalink を組み立ててコピー／ブラウザで開く機能（PR ポップアップの追加アクション y/b/B/d を含む）と通常モードキー（<leader>gy / <leader>go / <leader>gO）。
- Inlay hints の導入と制御：gopls、TypeScript/JavaScript、BasedPyright 向けの inlay hints 設定追加。起動時・バッファ単位で有効化制御できるようにし、ユーザコマンド（InlayHintsEnable / InlayHintsDisable / InlayHintsToggle）とトグルキー <leader>xh を追加。
- Lazygit ランチャー改善：fzf-lua でディレクトリを選んで lazgiyt を起動する挙動に変更（<leader>lg）。
- その他：git スニペットに gmc（git merge --continue）追加、.gitignore に plan/** 追加、octo.nvim の goto_file キーを o→O、fzf-lua のタブ表示ラベル改善、zoxide ピッカーを <leader>Z に移動。

## 変更理由
複数リポジトリやワークツリー環境での操作性を高め、Neovim 内での Git/GitHub フロー（履歴参照、permalink 取得、PR 操作）をより直感的かつ安全に行えるようにするためです。LSP の inlay hints を各言語に適切に有効化して可読性を向上させ、AI 用の一時ファイル（plan/**）を追跡対象外にする運用上の整理や、日常的な操作（マージ継続など）を短縮するためのスニペット追加も目的としています。

## 確認した項目
- 主要な新キー割り当て（<leader>gd / <leader>gl / <leader>gL / <leader>gy / <leader>go / <leader>gO / <leader>xh）が既存設定と衝突しないこと
- utils.git による .git 判定とリポジトリ探索（フォールバック含む）が期待通りに動作すること
- Diffview と lazygit のディレクトリ選択フロー（0/1/複数リポジトリ時の挙動）が正しく動作すること
- gitsigns の PR ポップアップでの permalink の生成・コピー・ブラウザ起動（y/b/B）の挙動が正しいこと
- inlay hints の有効／無効切替が gopls・TypeScript/JavaScript・BasedPyright の各設定に反映され、Neovim 起動時およびバッファ単位で期待通り動作すること
<!-- end of auto-generated comment: release notes by coderabbit.ai -->