### PR TITLE
Feature2

### DIFF
--- a/dot_config/nvim/lua/core/abbreviations.lua
+++ b/dot_config/nvim/lua/core/abbreviations.lua
@@ -1,6 +1,7 @@
 vim.cmd([[
 cabbr cd tcd
 cabbr he help
+cabbr <expr> tc getcmdtype() ==# ':' && getcmdline() ==# 'tc' ? (tabpagenr('$') ==# 1 ? 'qa' : 'tabclose') : 'tc'
 cabbr te terminal
 cabbr teh horizontal terminal
 cabbr tet horizontal terminal

--- a/dot_config/nvim/lua/core/autocmds.lua
+++ b/dot_config/nvim/lua/core/autocmds.lua
@@ -39,6 +39,22 @@ vim.api.nvim_create_autocmd('TabNewEntered', {
   end,
 })
 
+-- :qa時にterminalバッファのjobを停止してから終了する
+local quit_group = vim.api.nvim_create_augroup('QuitCleanup', { clear = true })
+vim.api.nvim_create_autocmd('VimLeavePre', {
+  group = quit_group,
+  callback = function()
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.api.nvim_buf_is_valid(buf) and vim.bo[buf].buftype == 'terminal' then
+        local job_id = vim.b[buf].terminal_job_id
+        if job_id then
+          vim.fn.jobstop(job_id)
+        end
+      end
+    end
+  end,
+})
+
 -- terminalを開いたら即入力できるようにする（:terminal, split terminal, toggleterm共通）
 local terminal_group = vim.api.nvim_create_augroup('TerminalInsert', { clear = true })
 vim.api.nvim_create_autocmd('TermOpen', {

--- a/dot_config/nvim/lua/plugins/git.lua
+++ b/dot_config/nvim/lua/plugins/git.lua
@@ -149,8 +149,62 @@ return {
         end)
       end
 
-      local function build_github_url(base, sha, rel_path, lnum)
+      local function build_github_url(base, sha, rel_path, lnum, end_lnum)
+        if end_lnum and end_lnum ~= lnum then
+          return string.format("%s/blob/%s/%s#L%d-L%d", base, sha, encode_url_path(rel_path), lnum, end_lnum)
+        end
         return string.format("%s/blob/%s/%s#L%d", base, sha, encode_url_path(rel_path), lnum)
+      end
+
+      local function github_url_action_visual(action)
+        local start_lnum = vim.fn.line("'<")
+        local end_lnum   = vim.fn.line("'>")
+        local filename   = vim.api.nvim_buf_get_name(0)
+        if filename == "" then
+          vim.notify("未保存のバッファには使用できません", vim.log.levels.WARN)
+          return
+        end
+        local repo_dir = vim.fn.fnamemodify(filename, ":h")
+
+        get_github_base_url(repo_dir, function(base)
+          if not base then
+            vim.schedule(function()
+              vim.notify("GitHub リモートが見つかりません", vim.log.levels.WARN)
+            end)
+            return
+          end
+          get_repo_relative_path(repo_dir, filename, function(rel)
+            if not rel then return end
+            if action == "main" then
+              get_default_branch(repo_dir, function(branch)
+                if not branch then
+                  vim.schedule(function()
+                    vim.notify("既定ブランチを取得できません", vim.log.levels.WARN)
+                  end)
+                  return
+                end
+                local url = build_github_url(base, branch, rel, start_lnum, end_lnum)
+                vim.schedule(function() vim.ui.open(url) end)
+              end)
+            else
+              vim.system({ "git", "rev-parse", "HEAD" },
+                { text = true, cwd = repo_dir },
+                function(rv)
+                  if rv.code ~= 0 then return end
+                  local head_sha = vim.trim(rv.stdout or "")
+                  local url = build_github_url(base, head_sha, rel, start_lnum, end_lnum)
+                  vim.schedule(function()
+                    if action == "copy" then
+                      vim.fn.setreg("+", url)
+                      vim.notify("コピーしました: " .. url, vim.log.levels.INFO)
+                    else
+                      vim.ui.open(url)
+                    end
+                  end)
+                end)
+            end
+          end)
+        end)
       end
 
       local function github_url_action(action)
@@ -472,6 +526,8 @@ return {
 
       vim.keymap.set("n", "<leader>gy", function() github_url_action("copy") end,
         { noremap = true, silent = true, desc = "GitHub パーマネントリンクをコピー" })
+      vim.keymap.set("v", "<leader>gy", function() github_url_action_visual("copy") end,
+        { noremap = true, silent = true, desc = "GitHub パーマネントリンクをコピー（範囲）" })
       vim.keymap.set("n", "<leader>go", function() github_url_action("open") end,
         { noremap = true, silent = true, desc = "GitHub でファイルを開く（HEAD）" })
       vim.keymap.set("n", "<leader>gO", function() github_url_action("main") end,

--- a/dot_config/nvim/lua/plugins/git.lua
+++ b/dot_config/nvim/lua/plugins/git.lua
@@ -156,10 +156,8 @@ return {
         return string.format("%s/blob/%s/%s#L%d", base, sha, encode_url_path(rel_path), lnum)
       end
 
-      local function github_url_action_visual(action)
-        local start_lnum = vim.fn.line("'<")
-        local end_lnum   = vim.fn.line("'>")
-        local filename   = vim.api.nvim_buf_get_name(0)
+      local function execute_github_url_action(action, start_lnum, end_lnum)
+        local filename = vim.api.nvim_buf_get_name(0)
         if filename == "" then
           vim.notify("未保存のバッファには使用できません", vim.log.levels.WARN)
           return
@@ -207,54 +205,14 @@ return {
         end)
       end
 
-      local function github_url_action(action)
-        local lnum     = vim.api.nvim_win_get_cursor(0)[1]
-        local filename = vim.api.nvim_buf_get_name(0)
-        if filename == "" then
-          vim.notify("未保存のバッファには使用できません", vim.log.levels.WARN)
-          return
-        end
-        local repo_dir = vim.fn.fnamemodify(filename, ":h")
+      local function github_url_action_visual(action)
+        local anchor = vim.fn.line("v")
+        local cursor = vim.fn.line(".")
+        execute_github_url_action(action, math.min(anchor, cursor), math.max(anchor, cursor))
+      end
 
-        get_github_base_url(repo_dir, function(base)
-          if not base then
-            vim.schedule(function()
-              vim.notify("GitHub リモートが見つかりません", vim.log.levels.WARN)
-            end)
-            return
-          end
-          get_repo_relative_path(repo_dir, filename, function(rel)
-            if not rel then return end
-            if action == "main" then
-              get_default_branch(repo_dir, function(branch)
-                if not branch then
-                  vim.schedule(function()
-                    vim.notify("既定ブランチを取得できません", vim.log.levels.WARN)
-                  end)
-                  return
-                end
-                local url = build_github_url(base, branch, rel, lnum)
-                vim.schedule(function() vim.ui.open(url) end)
-              end)
-            else
-              vim.system({ "git", "rev-parse", "HEAD" },
-                { text = true, cwd = repo_dir },
-                function(rv)
-                  if rv.code ~= 0 then return end
-                  local head_sha = vim.trim(rv.stdout or "")
-                  local url = build_github_url(base, head_sha, rel, lnum)
-                  vim.schedule(function()
-                    if action == "copy" then
-                      vim.fn.setreg("+", url)
-                      vim.notify("コピーしました: " .. url, vim.log.levels.INFO)
-                    else
-                      vim.ui.open(url)
-                    end
-                  end)
-                end)
-            end
-          end)
-        end)
+      local function github_url_action(action)
+        execute_github_url_action(action, vim.api.nvim_win_get_cursor(0)[1])
       end
 
       require("gitsigns").setup({

--- a/dot_config/nvim/lua/plugins/session.lua
+++ b/dot_config/nvim/lua/plugins/session.lua
@@ -80,6 +80,8 @@ return {
         return auto_session_lib.get_latest_session(auto_session.get_root_dir())
       end
 
+      local TIMESTAMP_PATTERN = "_%d%d%d%d%d%d%d%d_%d%d%d%d%d%d$"
+
       local session_group = vim.api.nvim_create_augroup("AutoSessionCustom", { clear = true })
       vim.api.nvim_create_autocmd("VimEnter", {
         group = session_group,
@@ -94,7 +96,19 @@ return {
           vim.schedule(function()
             local latest = latest_session()
             if latest then
-              auto_session.restore_session(latest, { show_message = false })
+              local session_name = vim.fn.fnamemodify(latest, ":t:r")
+                :gsub(TIMESTAMP_PATTERN, "")
+              local choice = vim.fn.confirm(
+                "セッションを復元しますか？\n[" .. session_name .. "]",
+                "&Yes\n&No",
+                1
+              )
+              if choice == 1 then
+                local ok, err = pcall(auto_session.restore_session, latest, { show_message = false })
+                if not ok then
+                  vim.notify("セッションの復元に失敗しました: " .. tostring(err), vim.log.levels.ERROR)
+                end
+              end
             end
           end)
         end,
@@ -122,7 +136,7 @@ return {
         save_timer:start(5 * 60 * 1000, 5 * 60 * 1000, vim.schedule_wrap(function()
           if vim.v.this_session ~= "" and vim.fn.mode(1):sub(1, 1) == "n" and not has_floating_window() then
             local active_session = vim.v.this_session
-            local session_name = vim.fn.fnamemodify(active_session, ":t:r"):gsub("_%d%d%d%d%d%d%d%d_%d%d%d%d%d%d$", "")
+            local session_name = vim.fn.fnamemodify(active_session, ":t:r"):gsub(TIMESTAMP_PATTERN, "")
             local snapshot_name = session_name .. "_" .. os.date("%Y%m%d_%H%M%S")
             local ok = pcall(auto_session.save_session, snapshot_name, {
               show_message = false,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds visual-mode GitHub permalinks for selected ranges, asks before restoring the latest session, stops terminal jobs on quit, and improves `tc` to close the tab or quit if it’s the only one.

- **New Features**
  - Visual mode `<leader>gy` copies a GitHub permalink for the selected lines (`#Lstart-Lend`).
  - Session restore prompts with the session name.
  - `cabbr <expr> tc` closes the current tab, or runs `:qa` when it’s the only tab.

- **Bug Fixes**
  - Stops terminal jobs on `VimLeavePre` so `:qa` exits cleanly.

<sup>Written for commit 80d91d88c453e40e5893299c3a2d88d7a3927d2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更内容概要

- コマンドライン略語の追加: `tc` を `tabclose` 相当で使えるようにする略語を追加（単独入力時にタブ数が1なら `qa` を使う挙動を含む）
- 終了時のクリーンアップ処理: `VimLeavePre` で terminal バッファのジョブを安全に停止する処理を追加し、`:qa` 等で終了できるように改善
- GitHub パーマネントリンク生成の拡張: gitsigns の URL 生成をビジュアル選択の行範囲対応（`#Lstart-Lend`）に拡張し、ビジュアルモード向けのキーマップを追加
- セッション復元の確認ダイアログ化: 起動時の最新セッション復元を自動実行から「復元しますか？」の確認表示へ変更（表示するセッション名はタイムスタンプ拡張子を除去したベース名）

## 変更理由

- 操作効率の向上: 頻繁に使うタブ関連操作を短縮できるようにするため  
- 終了時の安定化: 終了前に端末ジョブを明示的に停止して、不意のプロセス残留や終了失敗を防ぐため  
- リンクの汎用性向上: 複数行を範囲指定した GitHub リンクを簡単に生成できるようにして、コード参照やレビューを効率化するため  
- 意図しない復元防止: 起動時の自動復元を確認制にして、誤ったセッション復元を避けるため

## 確認した項目

- 変更対象ファイル（abbreviations.lua、autocmds.lua、plugins/git.lua、plugins/session.lua）の変更点を確認  
- `tc` のコマンド略語が単独入力時の挙動（タブ数1で `qa`、それ以外で `tabclose`）を含めて定義されていることを確認  
- `VimLeavePre` で terminal_job_id を持つバッファのジョブを `jobstop` で停止する処理が追加されていることを確認（:qa がクリーンに終了する改善）  
- GitHub URL 生成が開始行・終了行を受け取り範囲形式（`#Lstart-Lend`）で組み立てられ、ビジュアルモード用ハンドラとキーマップが追加されていることを確認  
- セッション名から末尾のタイムスタンプ（_YYYYMMDD_HHMMSS 風）を除去して表示するロジックと、確認ダイアログでの復元処理が正しく実装されていることを確認
<!-- end of auto-generated comment: release notes by coderabbit.ai -->