### PR TITLE
Neovim: ウィンドウ復元とディレクトリ移動を改善

### DIFF
--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -63,6 +63,10 @@ customCommands:
         body: "merge {{.CheckedOutBranch.Name}} to {{.SelectedLocalBranch.Name}}?"
     description: "Merge current branch into selected branch"
     loadingText: "Merging..."
+  - command: "gh pr view --web 2>/dev/null || gh pr create --web --head {{.CheckedOutBranch.Name}}"
+    key: o
+    context: "localBranches, commits, files, worktrees"
+    description: "Open/Create PR for current branch"
 promptToReturnFromSubprocess: false
 gui:
   language: "ja"

--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -63,7 +63,7 @@ customCommands:
         body: "merge {{.CheckedOutBranch.Name}} to {{.SelectedLocalBranch.Name}}?"
     description: "Merge current branch into selected branch"
     loadingText: "Merging..."
-  - command: "gh pr view --web 2>/dev/null || gh pr create --web --head {{.CheckedOutBranch.Name}}"
+  - command: "gh pr view --web 2>/dev/null || gh pr create --web --head {{.CheckedOutBranch.Name | quote}}"
     key: o
     context: "localBranches, commits, files, worktrees"
     description: "Open/Create PR for current branch"

--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -63,7 +63,7 @@ customCommands:
         body: "merge {{.CheckedOutBranch.Name}} to {{.SelectedLocalBranch.Name}}?"
     description: "Merge current branch into selected branch"
     loadingText: "Merging..."
-  - command: "gh pr view --web 2>/dev/null || gh pr create --web --head {{.CheckedOutBranch.Name | quote}}"
+  - command: "gh pr view --web 2>/dev/null || gh pr create --web --head {{ .CheckedOutBranch.Name | quote }}"
     key: o
     context: "localBranches, commits, files, worktrees"
     description: "Open/Create PR for current branch"

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -119,8 +119,12 @@ vim                                     = "9.1.1006"
 [settings]
 auto_install = false
 experimental = true
-gpg_verify   = true
-lockfile     = true
+gpg_verify = true
+lockfile = true
+trusted_config_paths = [
+    "~/.local/share/chezmoi",
+    "~/.local/share/worktrees",
+]
 
 [task_config]
 includes = ["tasks/*.toml"]

--- a/dot_config/mise/config.work2.toml
+++ b/dot_config/mise/config.work2.toml
@@ -13,3 +13,8 @@
 "go:gotest.tools/gotestsum"                 = "1.13.0"
 "pipx:awslogs"                              = "0.15.0"
 "pipx:tftui"                                = "0.13.4"
+
+[settings]
+trusted_config_paths = [
+    "~/work",
+]

--- a/dot_config/nvim/lua/core/keymaps.lua
+++ b/dot_config/nvim/lua/core/keymaps.lua
@@ -2,17 +2,35 @@
 vim.g.mapleader = ","
 
 -- ウィンドウ最大化/もとに戻す関数
-vim.g.toggle_window_size = 0
+local saved_window_layouts = {}
+
 local function toggle_window_size()
-  if vim.g.toggle_window_size == 1 then
-    vim.cmd("normal! \\<C-w>=")
-    vim.g.toggle_window_size = 0
-  else
-    vim.cmd("resize")
-    vim.cmd("vertical resize")
-    vim.g.toggle_window_size = 1
+  local tabid = vim.api.nvim_get_current_tabpage()
+  local saved_layout = saved_window_layouts[tabid]
+
+  if saved_layout then
+    saved_window_layouts[tabid] = nil
+
+    if vim.api.nvim_win_is_valid(saved_layout.current_win) then
+      vim.api.nvim_set_current_win(saved_layout.current_win)
+    end
+    vim.cmd(saved_layout.restore_cmd)
+    return
   end
+
+  saved_window_layouts[tabid] = {
+    current_win = vim.api.nvim_get_current_win(),
+    restore_cmd = vim.fn.winrestcmd(),
+  }
+  vim.cmd("resize")
+  vim.cmd("vertical resize")
 end
+
+vim.api.nvim_create_autocmd({ "WinNew", "WinClosed" }, {
+  callback = function()
+    saved_window_layouts = {}
+  end,
+})
 
 -- g1からg9のキーバインドで1-9のタブに移動するキーバインド追加
 local function go_to_nth_tab(n)
@@ -129,8 +147,8 @@ keymap("v", "/", [[<ESC>/\%V]], { noremap = true })
 keymap("v", "?", [[<ESC>?\%V]], { noremap = true })
 
 
-keymap("n", "<leader>z", toggle_window_size, { noremap = true })
-keymap("n", "<A-z>", toggle_window_size, { noremap = true })
+keymap("n", "<leader>z", toggle_window_size, { noremap = true, silent = true, desc = "ウィンドウ最大化/復元" })
+keymap("n", "<A-z>", toggle_window_size, { noremap = true, silent = true, desc = "ウィンドウ最大化/復元" })
 
 -- g1-g9 mappings
 for i = 1, 9 do

--- a/dot_config/nvim/lua/core/keymaps.lua
+++ b/dot_config/nvim/lua/core/keymaps.lua
@@ -28,7 +28,8 @@ end
 
 vim.api.nvim_create_autocmd({ "WinNew", "WinClosed" }, {
   callback = function()
-    saved_window_layouts = {}
+    local tabid = vim.api.nvim_get_current_tabpage()
+    saved_window_layouts[tabid] = nil
   end,
 })
 

--- a/dot_config/nvim/lua/core/keymaps.lua
+++ b/dot_config/nvim/lua/core/keymaps.lua
@@ -155,6 +155,7 @@ keymap("n", "<A-z>", toggle_window_size, { noremap = true, silent = true, desc =
 for i = 1, 9 do
   keymap("n", "g" .. i, function() go_to_nth_tab(i) end, { noremap = true })
 end
+keymap("n", "gb", ":tabprevious<CR>", { noremap = true, silent = true, desc = "前のタブへ移動" })
 
 -- ジャンプリストを戻る (<C-o>の代替)
 keymap("n", "gh", "<C-o>", { noremap = true, desc = "ジャンプリストを戻る" })

--- a/dot_config/nvim/lua/plugins/fzf.lua
+++ b/dot_config/nvim/lua/plugins/fzf.lua
@@ -117,6 +117,32 @@ return {
       -- :zz で zoxide を起動（タブローカルtcd版）
       vim.api.nvim_create_user_command("Zz", zoxide_tcd, {})
       vim.cmd("cabbr zz <Cmd>Zz<CR>")
+
+      -- 現在ディレクトリ配下のサブディレクトリをinteractiveに選択してtcd
+      local function local_tcd()
+        local cwd = vim.fn.getcwd()
+        local cmd = "find " .. vim.fn.shellescape(cwd) .. " -type d -not -path '*/.git/*'"
+        fzf.fzf_exec(cmd, {
+          prompt = "LocalDir> ",
+          actions = {
+            ["default"] = function(selected)
+              if not selected or not selected[1] then return end
+              local dir = vim.trim(selected[1])
+              if dir == "" then return end
+              vim.cmd("tcd " .. vim.fn.fnameescape(dir))
+              local ok, neo = pcall(require, "neo-tree.command")
+              if ok then
+                neo.execute({ action = "show", source = "filesystem", position = "left", dir = dir })
+              end
+            end,
+          },
+        })
+      end
+
+      keymap("n", "<leader>Z", local_tcd, { noremap = true, silent = true, desc = "ローカルディレクトリ選択（タブローカル）" })
+      -- :zd でローカルディレクトリ選択
+      vim.api.nvim_create_user_command("Zd", local_tcd, {})
+      vim.cmd("cabbr zd <Cmd>Zd<CR>")
     end,
   },
 }

--- a/dot_config/nvim/lua/plugins/fzf.lua
+++ b/dot_config/nvim/lua/plugins/fzf.lua
@@ -144,9 +144,9 @@ return {
           { path = cwd, depth = 0 },
         }
 
-        for name, type in vim.fs.dir(cwd, { depth = 2 }) do
+        for name, entry_type in vim.fs.dir(cwd, { depth = 2 }) do
           local in_git_dir = name == ".git" or name:match("^%.git/") or name:match("/%.git/")
-          if type == "directory" and not in_git_dir then
+          if entry_type == "directory" and not in_git_dir then
             local depth = select(2, name:gsub("/", "")) + 1
             table.insert(dirs, { path = vim.fs.joinpath(cwd, name), depth = depth })
           end
@@ -176,6 +176,8 @@ return {
           },
         })
       end
+
+      keymap("n", "<leader>Z", local_tcd, { noremap = true, silent = true, desc = "ローカルディレクトリ選択（タブローカル）" })
 
       -- :zd でローカルディレクトリ選択
       vim.api.nvim_create_user_command("Zd", local_tcd, {})

--- a/dot_config/nvim/lua/plugins/fzf.lua
+++ b/dot_config/nvim/lua/plugins/fzf.lua
@@ -18,6 +18,16 @@ return {
       local fzf = require("fzf-lua")
       local keymap = vim.keymap.set
 
+      local function command_abbrev(lhs, command)
+        vim.cmd(string.format(
+          [[cabbr <expr> %s getcmdtype() ==# ':' && getcmdline() ==# %s ? "\<Cmd>%s\<CR>" : %s]],
+          lhs,
+          vim.fn.string(lhs),
+          command,
+          vim.fn.string(lhs)
+        ))
+      end
+
       local function change_tab_directory(dir)
         local ok, err = pcall(vim.cmd, "tcd " .. vim.fn.fnameescape(dir))
         if not ok then
@@ -125,21 +135,36 @@ return {
 
       -- :zz で zoxide を起動（タブローカルtcd版）
       vim.api.nvim_create_user_command("Zz", zoxide_tcd, {})
-      vim.cmd("cabbr zz <Cmd>Zz<CR>")
+      command_abbrev("zz", "Zz")
 
       -- 現在ディレクトリ配下のサブディレクトリをinteractiveに選択してtcd
       local function local_tcd()
         local cwd = vim.fn.getcwd()
-        local dirs = { cwd }
+        local dirs = {
+          { path = cwd, depth = 0 },
+        }
 
-        for name, type in vim.fs.dir(cwd, { depth = 5 }) do
+        for name, type in vim.fs.dir(cwd, { depth = 2 }) do
           local in_git_dir = name == ".git" or name:match("^%.git/") or name:match("/%.git/")
           if type == "directory" and not in_git_dir then
-            table.insert(dirs, vim.fs.joinpath(cwd, name))
+            local depth = select(2, name:gsub("/", "")) + 1
+            table.insert(dirs, { path = vim.fs.joinpath(cwd, name), depth = depth })
           end
         end
 
-        fzf.fzf_exec(dirs, {
+        table.sort(dirs, function(a, b)
+          if a.depth ~= b.depth then
+            return a.depth < b.depth
+          end
+
+          return a.path < b.path
+        end)
+
+        local items = vim.tbl_map(function(dir)
+          return dir.path
+        end, dirs)
+
+        fzf.fzf_exec(items, {
           prompt = "LocalDir> ",
           actions = {
             ["default"] = function(selected)
@@ -154,7 +179,7 @@ return {
 
       -- :zd でローカルディレクトリ選択
       vim.api.nvim_create_user_command("Zd", local_tcd, {})
-      vim.cmd("cabbr zd <Cmd>Zd<CR>")
+      command_abbrev("zd", "Zd")
     end,
   },
 }

--- a/dot_config/nvim/lua/plugins/fzf.lua
+++ b/dot_config/nvim/lua/plugins/fzf.lua
@@ -17,6 +17,20 @@ return {
 
       local fzf = require("fzf-lua")
       local keymap = vim.keymap.set
+
+      local function change_tab_directory(dir)
+        local ok, err = pcall(vim.cmd, "tcd " .. vim.fn.fnameescape(dir))
+        if not ok then
+          vim.notify("ディレクトリの移動に失敗しました: " .. err, vim.log.levels.ERROR)
+          return
+        end
+
+        local has_neo_tree, neo_tree = pcall(require, "neo-tree.command")
+        if has_neo_tree then
+          neo_tree.execute({ action = "show", source = "filesystem", position = "left", dir = dir })
+        end
+      end
+
       local function select_tabpage()
         local tabs = vim.api.nvim_list_tabpages()
         local current_tab = vim.api.nvim_get_current_tabpage()
@@ -103,17 +117,12 @@ return {
               if not selected or not selected[1] then return end
               local dir = vim.trim(selected[1])
               if dir == "" then return end
-              vim.cmd("tcd " .. vim.fn.fnameescape(dir))
-              local ok, neo = pcall(require, "neo-tree.command")
-              if ok then
-                neo.execute({ action = "show", source = "filesystem", position = "left", dir = dir })
-              end
+              change_tab_directory(dir)
             end,
           },
         })
       end
 
-      keymap("n", "<leader>Z", zoxide_tcd, { noremap = true, silent = true, desc = "Zoxide ディレクトリ検索（タブローカル）" })
       -- :zz で zoxide を起動（タブローカルtcd版）
       vim.api.nvim_create_user_command("Zz", zoxide_tcd, {})
       vim.cmd("cabbr zz <Cmd>Zz<CR>")
@@ -121,25 +130,28 @@ return {
       -- 現在ディレクトリ配下のサブディレクトリをinteractiveに選択してtcd
       local function local_tcd()
         local cwd = vim.fn.getcwd()
-        local cmd = "find " .. vim.fn.shellescape(cwd) .. " -type d -not -path '*/.git/*'"
-        fzf.fzf_exec(cmd, {
+        local dirs = { cwd }
+
+        for name, type in vim.fs.dir(cwd, { depth = 5 }) do
+          local in_git_dir = name == ".git" or name:match("^%.git/") or name:match("/%.git/")
+          if type == "directory" and not in_git_dir then
+            table.insert(dirs, vim.fs.joinpath(cwd, name))
+          end
+        end
+
+        fzf.fzf_exec(dirs, {
           prompt = "LocalDir> ",
           actions = {
             ["default"] = function(selected)
               if not selected or not selected[1] then return end
               local dir = vim.trim(selected[1])
               if dir == "" then return end
-              vim.cmd("tcd " .. vim.fn.fnameescape(dir))
-              local ok, neo = pcall(require, "neo-tree.command")
-              if ok then
-                neo.execute({ action = "show", source = "filesystem", position = "left", dir = dir })
-              end
+              change_tab_directory(dir)
             end,
           },
         })
       end
 
-      keymap("n", "<leader>Z", local_tcd, { noremap = true, silent = true, desc = "ローカルディレクトリ選択（タブローカル）" })
       -- :zd でローカルディレクトリ選択
       vim.api.nvim_create_user_command("Zd", local_tcd, {})
       vim.cmd("cabbr zd <Cmd>Zd<CR>")

--- a/dot_config/nvim/lua/plugins/github.lua
+++ b/dot_config/nvim/lua/plugins/github.lua
@@ -131,9 +131,14 @@ return {
                     actions = {
                       ["default"] = function(sel)
                         if not sel or not sel[1] then return end
-                        for idx, d in ipairs(display) do
-                          if d == sel[1] then
-                            local pr = prs[idx]
+                        local selected_no = sel[1]:match("^%s*(%d+)")
+                        if not selected_no then
+                          vim.notify("選択したPR番号を解析できませんでした", vim.log.levels.ERROR)
+                          return
+                        end
+
+                        for _, pr in ipairs(prs) do
+                          if tostring(pr.number) == selected_no then
                             vim.system(
                               { "gh", "pr", "checkout", tostring(pr.number) },
                               { text = true },
@@ -151,6 +156,8 @@ return {
                             return
                           end
                         end
+
+                        vim.notify("対応するPRが見つかりませんでした", vim.log.levels.ERROR)
                       end,
                     },
                   })

--- a/dot_config/nvim/lua/plugins/github.lua
+++ b/dot_config/nvim/lua/plugins/github.lua
@@ -214,6 +214,8 @@ return {
             add_review_suggestion = { lhs = "s", desc = "サジェスト追加", mode = { "n", "x" } },
             submit_review         = { lhs = "S", desc = "レビュー送信" },
             goto_file             = { lhs = "O", desc = "ファイルを開く" },
+            select_next_entry     = { lhs = "gl", desc = "次の変更ファイルへ移動" },
+            select_prev_entry     = { lhs = "gh", desc = "前の変更ファイルへ移動" },
             close_review_tab      = { lhs = "q", desc = "diff viewを閉じる" },
           },
           review_thread = {

--- a/dot_config/nvim/lua/plugins/github.lua
+++ b/dot_config/nvim/lua/plugins/github.lua
@@ -32,9 +32,138 @@ return {
             end)
           end
 
+          local function format_gh_datetime(value)
+            if type(value) ~= "string" then return "-" end
+            local year, month, day, hour, min, sec = value:match("^(%d+)%-(%d+)%-(%d+)T(%d+):(%d+):(%d+)Z$")
+            if not year then return value end
+            return string.format("%s/%s/%s %s:%s:%s", year, month, day, hour, min, sec)
+          end
+
+          local function truncate_display(value, width)
+            value = tostring(value or "")
+            local result = ""
+            for i = 0, vim.fn.strchars(value) - 1 do
+              local next_result = result .. vim.fn.strcharpart(value, i, 1)
+              if vim.fn.strdisplaywidth(next_result) > width then break end
+              result = next_result
+            end
+            return result
+          end
+
+          local function pad_display(value, width)
+            value = tostring(value or "")
+            return value .. string.rep(" ", math.max(width - vim.fn.strdisplaywidth(value), 0))
+          end
+
+          local function format_pr_rows(prs)
+            local rows = vim.tbl_map(function(pr)
+              local author = pr.author and pr.author.login or "-"
+              return {
+                tostring(pr.number),
+                truncate_display(pr.title or "", 50),
+                author,
+                pr.state or "-",
+                pr.isDraft and "◯" or "☓",
+                format_gh_datetime(pr.updatedAt),
+                format_gh_datetime(pr.createdAt),
+                pr.headRefName or "-",
+              }
+            end, prs)
+
+            local header = { "no", "title", "author", "state", "draft", "updatedAt", "createdAt", "branch" }
+            local widths = vim.tbl_map(function(value) return vim.fn.strdisplaywidth(value) end, header)
+            for _, row in ipairs(rows) do
+              for idx, value in ipairs(row) do
+                widths[idx] = math.max(widths[idx], vim.fn.strdisplaywidth(tostring(value)))
+              end
+            end
+
+            local function format_row(row)
+              local formatted = {}
+              for idx, value in ipairs(row) do
+                formatted[idx] = pad_display(value, widths[idx])
+              end
+              return table.concat(formatted, "  ")
+            end
+
+            return vim.tbl_map(format_row, rows), format_row(header)
+          end
+
+          local function checkout_and_open_pr()
+            vim.system(
+              {
+                "gh",
+                "pr",
+                "list",
+                "--search",
+                "user-review-requested:@me",
+                "--limit",
+                "100",
+                "--json",
+                "number,title,author,state,isDraft,updatedAt,createdAt,headRefName",
+              },
+              { text = true },
+              function(result)
+                vim.schedule(function()
+                  if result.code ~= 0 then
+                    vim.notify("PR一覧の取得に失敗: " .. (result.stderr or ""), vim.log.levels.ERROR)
+                    return
+                  end
+
+                  local ok, prs = pcall(vim.json.decode, result.stdout or "[]")
+                  if not ok or type(prs) ~= "table" then
+                    vim.notify("PR一覧の解析に失敗", vim.log.levels.ERROR)
+                    return
+                  end
+                  if #prs == 0 then
+                    vim.notify("レビュー依頼されたPRがありません", vim.log.levels.INFO)
+                    return
+                  end
+
+                  local display, header = format_pr_rows(prs)
+
+                  require("fzf-lua").fzf_exec(display, {
+                    prompt = "PR checkout + open> ",
+                    fzf_opts = {
+                      ["--no-sort"] = true,
+                      ["--header"] = header,
+                    },
+                    actions = {
+                      ["default"] = function(sel)
+                        if not sel or not sel[1] then return end
+                        for idx, d in ipairs(display) do
+                          if d == sel[1] then
+                            local pr = prs[idx]
+                            vim.system(
+                              { "gh", "pr", "checkout", tostring(pr.number) },
+                              { text = true },
+                              function(checkout_result)
+                                vim.schedule(function()
+                                  if checkout_result.code ~= 0 then
+                                    vim.notify("PR checkoutに失敗: " .. (checkout_result.stderr or ""), vim.log.levels.ERROR)
+                                    return
+                                  end
+                                  vim.notify("PR checkout完了: #" .. pr.number, vim.log.levels.INFO)
+                                  vim.cmd("Octo pr edit " .. pr.number)
+                                end)
+                              end
+                            )
+                            return
+                          end
+                        end
+                      end,
+                    },
+                  })
+                end)
+              end
+            )
+          end
+
           local items = {
             { label = "PR一覧",                    cmd = "Octo pr list" },
+            { label = "PRを開いてcheckout",        cmd = "gh pr checkout + Octo pr edit", fn = checkout_and_open_pr },
             { label = "PR作成",                    cmd = "Octo pr create" },
+            { label = "今開いているPRをcheckout",  cmd = "Octo pr checkout" },
             { label = "PR差分を見る",              cmd = "Octo review diff" },
             { label = "チェックステータス",        cmd = "Octo pr checks" },
             { label = "PRをブラウザで開く",        cmd = "Octo pr browser" },

--- a/dot_config/nvim/lua/plugins/lsp.lua
+++ b/dot_config/nvim/lua/plugins/lsp.lua
@@ -324,7 +324,7 @@ return {
           return
         end
 
-        if vim.fn.has("nvim-0.10") == 1 and client.supports_method("textDocument/inlayHint") then
+        if vim.fn.has("nvim-0.10") == 1 and client:supports_method("textDocument/inlayHint") then
           vim.lsp.inlay_hint.enable(vim.g.inlay_hints_enabled, { bufnr = bufnr })
         end
 

--- a/dot_config/vim/dot_vimrc
+++ b/dot_config/vim/dot_vimrc
@@ -161,21 +161,6 @@ cabbr <leader>P :set paste!
 " :s で%s//(置換後)/gを呼び出し
 cabbr <expr> s getcmdtype() .. getcmdline() ==# ':s' ? [getchar(), ''][1] .. "%s//" : 's'
 
-" ウィンドウ最大化/もとに戻す関数
-let g:toggle_window_size = 0
-function! ToggleWindowSize()
-  if g:toggle_window_size == 1
-    exec "normal \<C-w>="
-    let g:toggle_window_size = 0
-  else
-    :resize
-    :vertical resize
-    let g:toggle_window_size = 1
-  endif
-endfunction
-nnoremap <leader>z :call ToggleWindowSize()<CR>
-nnoremap <A-z> :call ToggleWindowSize()<CR>
-
 " g1からg9のキーバインドで1-9のタブに移動するキーバインド追加
 function! GoToNthTab(n)
   " 目的のタブ番号を計算

--- a/dot_config/zabrze/git-worktree.toml
+++ b/dot_config/zabrze/git-worktree.toml
@@ -14,6 +14,12 @@ snippet = "gwq add -b"
 trigger = "gwaa"
 
 [[snippets]]
+cursor  = "👇"
+name    = "wt switch --create"
+snippet = "wt switch --create 👇 --base"
+trigger = "gwaaa"
+
+[[snippets]]
 name    = "gwq cd"
 snippet = "gwq cd"
 trigger = "gwc"


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Neovim’s window maximize toggle per tab, adds a tab-local directory picker with a `<leader>Z` shortcut, and streamlines GitHub PR checkout+edit flows. Also adds a `lazygit` key to open/create PRs.

- **New Features**
  - Tab-local directory tools: `:Zd` (abbr `zd`) and `<leader>Z` for local dirs, `:Zz` (abbr `zz`) for `zoxide`; sets tab-local cwd and auto-opens `neo-tree` via `fzf-lua`.
  - GitHub PR flow in Neovim: select review-requested PRs, run `gh pr checkout`, then open `Octo pr edit`; added menu entries and `gl`/`gh` diff navigation.
  - Tooling: `lazygit` key `o` opens an existing PR or creates one for the current branch; `zabrze` snippet `gwaaa`; `gb` to go to the previous tab.

- **Bug Fixes**
  - Window maximize toggle now saves/restores layout per tab and clears state on window changes; mappings updated (silent + desc) and the old Vimscript removed.
  - LSP: use `client:supports_method` for inlay hints on Neovim 0.10 to remove warnings.
  - Config: added `trusted_config_paths` in `mise` to load settings safely.

<sup>Written for commit 7399b35b2280fb3bc91865e88c52f7a1dea72194. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更内容概要
- **Neovimのウィンドウ最大化/復元をタブ単位で保存・復元**するよう変更（タブごとの `saved_window_layouts` を保持し、`WinNew`/`WinClosed` で状態をリセット）。`<leader>z` / `<A-z>` のキーマップに `silent=true` と説明文を追加。
- **ローカルディレクトリ選択**を追加し、サブディレクトリを `fzf` で選んでタブローカル`cwd`を設定し、可能なら `neo-tree` も表示。ユーザーコマンド `:Zd`（`zd`）を追加。
- **zoxide連携のタブ移動ディレクトリ**を `:Zz`（`zz`）として追加（`cabbr` を `<expr>` 化して呼び出しを統一）。
- **Vimscript版の `ToggleWindowSize()` と関連キーバインドを削除**（Neovim Lua側へ統一）。
- **zabrze worktree snippet 拡張**：`wt switch --create 👇 --base` を `gwaaa` で展開可能に。
- **LSPのinlay hints警告対策**：`client.supports_method(...)` を `client:supports_method(...)` に修正（Neovim 0.10互換）。
- **各種設定/連携の追加・調整**
  - lazygit：現在ブランチのPRを `gh pr view --web` →失敗時は `gh pr create --web` で開くカスタムコマンド追加。
  - Octo/GitHub：PRリスト整形、PR checkout→編集フローの実装、差分系ピッカーのキー割り当て追加。
  - mise：`trusted_config_paths` を追加（`config.toml`/`config.work2.toml`）。

## 変更理由
- 複数タブでの**ウィンドウ復元精度と使い勝手**を上げ、最大化トグルを**タブ単位のレイアウト保持**へ改善。
- `zoxide` のみでは補いにくい**ローカル配下のサブディレクトリ移動**を高速化し、`neo-tree` 連携で導線を整理。
- Neovim 0.10で発生し得る **LSP inlay hints の互換性問題を回避**するための修正。
- lazygit / Octo / mise などの外部連携をより実用的にし、操作フローと安全な設定読み込みを強化。

## 確認した項目
- タブをまたいだ状態で `toggle_window_size()` が**正しく保存・復元**され、`WinNew`/`WinClosed` で状態が適切にリセットされること。
- `:Zd` 実行時に選択したサブディレクトリへ **タブローカル`cwd`が設定**され、必要に応じて `neo-tree` が表示されること（`.git` 配下が除外されること）。
- `:Zz`（`zz`）で **zoxideのタブ移動ディレクトリ**が期待通りに動作すること。
- 旧Vimscriptの `ToggleWindowSize()` が削除されても、必要な機能が**Neovim Lua側で置き換わっている**こと。
- LSP inlay hints が **Neovim 0.10で警告なく動作**すること。
- lazygitの新規コマンドで **既存PR表示/新規PR作成が**切り替わり、Webで開けること。
- OctoのPRピッカー/checkout→editフローと、追加したキー割り当てが **期待通りに動く**こと。
- miseの `trusted_config_paths` が **意図通り反映**されること。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves Neovim's window maximize toggle to work per-tab (saving/restoring layout with `winrestcmd()`), adds a local subdirectory picker (`:Zd`) alongside the existing zoxide integration, and extends the GitHub PR workflow with a fzf-powered checkout+Octo-open flow. It also fixes the Neovim 0.10 inlay-hints warning by switching to the colon-method call syntax, removes the now-redundant Vimscript `ToggleWindowSize()`, and adds miscellaneous quality-of-life improvements.

- **Window maximize**: replaced global `vim.g` flag with a per-tab `saved_window_layouts` table; `WinNew`/`WinClosed` autocmds clear the saved state so stale layouts are never applied after the window topology changes.
- **Directory navigation**: new `local_tcd` function enumerates the CWD up to depth 2 (filtering `.git`), presents results via fzf, and calls the shared `change_tab_directory` helper; `<leader>Z` is re-bound from `zoxide_tcd` to `local_tcd`, and both `:Zd`/`:Zz` user-commands are exposed via idiomatic `<expr>`-based `cabbr`.
- **GitHub workflow**: `checkout_and_open_pr` fetches review-requested PRs as JSON, formats them into an aligned fzf table, and chains `gh pr checkout` → `Octo pr edit`; `gl`/`gh` are added as `review_diff` navigation keys.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive or replace equivalent Vimscript logic with Lua equivalents, with no shared state outside Neovim's session.

The window-restore rewrite is careful (per-tab table, validity check before nvim_set_current_win, explicit reset on topology changes). The GitHub flow handles error codes from gh and validates JSON before use. The LSP fix is a one-character colon change that matches the Neovim 0.10 API. The only edge case found is the .git subdirectory filter missing the subdir/.git pattern, which has no functional impact for typical project layouts.

dot_config/nvim/lua/plugins/fzf.lua — the .git subdirectory filter in local_tcd

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| dot_config/nvim/lua/core/keymaps.lua | Tab-local window layout save/restore with WinNew/WinClosed reset autocmd; adds gb for previous tab and silent/desc to existing mappings |
| dot_config/nvim/lua/plugins/fzf.lua | Adds local_tcd directory picker with depth-2 traversal and .git filtering; extracts change_tab_directory helper; replaces old leader+Z/zoxide keymap with new local-dir keymap; .git filter misses subdir/.git pattern |
| dot_config/nvim/lua/plugins/github.lua | Adds PR checkout+open workflow with fzf picker, formatted PR list helpers, and gl/gh diff navigation keys for Octo review_diff |
| dot_config/nvim/lua/plugins/lsp.lua | Fixes inlay hints method call from dot to colon syntax (client:supports_method) for Neovim 0.10 compatibility |
| dot_config/lazygit/config.yml | Adds o key to open existing PR or create a new one via gh pr view --web with fallback to gh pr create --web |
| dot_config/vim/dot_vimrc | Removes the Vimscript ToggleWindowSize() function and its keymaps, superseded by the Lua implementation in keymaps.lua |
| dot_config/mise/config.toml | Adds trusted_config_paths to allow chezmoi and worktree directories to be auto-trusted by mise |
| dot_config/zabrze/git-worktree.toml | Adds gwaaa snippet for wt switch --create with cursor placeholder and --base flag |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["leader+z / Alt+z"] --> B{saved layout for current tab?}
    B -- Yes --> C[Restore window focus]
    C --> D[Apply restore_cmd and clear saved layout]
    B -- No --> E[Save win + winrestcmd]
    E --> F[Maximize window]
    G[WinNew or WinClosed] --> H[Clear saved layout for current tab]
    I["leader+Z / :Zd"] --> J[local_tcd via fzf]
    J --> K[WinNew fires - clears layout]
    J --> L[User picks subdir]
    L --> M[change_tab_directory]
    M --> N[tcd to dir]
    N --> O[Show neo-tree]
    P["leader+gm PR menu"] --> Q[checkout_and_open_pr]
    Q --> R[gh pr list - review requested]
    R --> S[fzf picker]
    S --> T[gh pr checkout]
    T --> U[Octo pr edit]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["leader+z / Alt+z"] --> B{saved layout for current tab?}
    B -- Yes --> C[Restore window focus]
    C --> D[Apply restore_cmd and clear saved layout]
    B -- No --> E[Save win + winrestcmd]
    E --> F[Maximize window]
    G[WinNew or WinClosed] --> H[Clear saved layout for current tab]
    I["leader+Z / :Zd"] --> J[local_tcd via fzf]
    J --> K[WinNew fires - clears layout]
    J --> L[User picks subdir]
    L --> M[change_tab_directory]
    M --> N[tcd to dir]
    N --> O[Show neo-tree]
    P["leader+gm PR menu"] --> Q[checkout_and_open_pr]
    Q --> R[gh pr list - review requested]
    R --> S[fzf picker]
    S --> T[gh pr checkout]
    T --> U[Octo pr edit]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Fix review comments for PR tools"](https://github.com/ryo246912/dotfiles/commit/7399b35b2280fb3bc91865e88c52f7a1dea72194) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37407591)</sub>

<!-- /greptile_comment -->