### PR TITLE
chore: add chezmoi hook

### DIFF
--- a/dot_config/chezmoi/chezmoi.toml
+++ b/dot_config/chezmoi/chezmoi.toml
@@ -7,3 +7,13 @@ APPDATA = "/mnt/c/Users/r-ksk/AppData"
 USERDIR = "/mnt/c/Users/r-ksk"
 [bitwarden]
 unlock = "auto"
+[hooks.apply.post]
+args = [
+    "-c",
+    """
+hash=$(cat "$HOME/.config/mise/config"*.toml 2>/dev/null | sha1sum)
+[ "$(cat /tmp/mise-config-hash 2>/dev/null)" = "$hash" ] && exit 0
+GITHUB_TOKEN=$(gh auth token) mise install --jobs=2 && echo "$hash" > /tmp/mise-config-hash
+""",
+]
+command = "bash"

--- a/dot_config/chezmoi/chezmoi.toml
+++ b/dot_config/chezmoi/chezmoi.toml
@@ -11,9 +11,10 @@ unlock = "auto"
 args = [
     "-c",
     """
-hash=$(cat "$HOME/.config/mise/config"*.toml 2>/dev/null | sha1sum)
-[ "$(cat /tmp/mise-config-hash 2>/dev/null)" = "$hash" ] && exit 0
-GITHUB_TOKEN=$(gh auth token) mise install --jobs=2 && echo "$hash" > /tmp/mise-config-hash
+mise_hash=$(cat "$HOME/.config/mise/config"*.toml 2>/dev/null | (command -v sha1sum >/dev/null && sha1sum || shasum -a 1))
+[ "$(cat /tmp/mise-config-hash 2>/dev/null)" = "$mise_hash" ] && exit 0
+echo "Running mise install..."
+GITHUB_TOKEN=$(gh auth token) mise install --jobs=2 && echo "$mise_hash" > /tmp/mise-config-hash
 """,
 ]
 command = "bash"


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a post-apply `chezmoi` hook to run `mise install` only when `mise` config changes, now portable on macOS and Linux.

- **New Features**
  - Hashes `~/.config/mise/config*.toml` using `sha1sum` or `shasum -a 1` and caches it in `/tmp/mise-config-hash` to skip reinstall when unchanged.
  - On change, runs `mise install --jobs=2` with `GITHUB_TOKEN=$(gh auth token)` and updates the cache.

<sup>Written for commit 84f19c05172d36e0ae827da9cb1b8c581c9749ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
- `chezmoi.toml` に post-apply フックを追加し、`~/.config/mise/config*.toml` の変更時のみ `mise install --jobs=2` を実行するようにしました。
- `mise` 設定ファイル群の SHA1 ハッシュを計算し、`/tmp/mise-config-hash` に保存した前回値と比較して、変更がない場合は処理をスキップします。
- インストール実行時は `gh auth token` で取得したトークンを `GITHUB_TOKEN` に設定し、成功後にハッシュを更新します。

## 変更理由
- `mise` の設定変更時だけ再インストールを行うことで、不要な処理を減らし、`chezmoi apply` 後の実行を効率化するためです。
- `GITHUB_TOKEN` を用意することで、`mise install` 実行時の認証を安定させる意図があります。

## 確認した項目
- ハッシュ比較により、設定変更がない場合は `mise install` が実行されないこと。
- 変更があった場合のみ `mise install --jobs=2` が走り、成功後にキャッシュが更新されること。
- `GITHUB_TOKEN` が `gh auth token` 由来で設定されること。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `[hooks.apply.post]` section to `chezmoi.toml` that runs a bash script after each `chezmoi apply`. The script hashes the deployed mise config files, compares against a cached value in `/tmp/mise-config-hash`, and only runs `mise install --jobs=2` when the config has changed — avoiding redundant installs on every apply.

- The portability concern about `sha1sum` vs `shasum` from a prior review has been addressed with a runtime check, and the `hash` variable has been renamed to `mise_hash`.
- The hash cache file is stored at `/tmp/mise-config-hash` without a user suffix; on a shared machine two users could clobber each other's cache, though this is unlikely for a personal dotfiles setup.
- The hash computation uses `a && b || c` shell logic which runs `shasum -a 1` if `sha1sum` exits non-zero, potentially hashing a partially-consumed pipe.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the hook is additive and only runs after `chezmoi apply`, with no changes to existing config.

The change is a self-contained post-apply hook that skips execution when mise config is unchanged. Prior review concerns (sha1sum portability, variable naming) were already addressed. The one remaining note is a theoretical edge case in the `&&...||` shell idiom that is extremely unlikely to trigger in normal usage.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| dot_config/chezmoi/chezmoi.toml | Adds a post-apply hook that hashes mise config files and conditionally runs `mise install --jobs=2`, with portable sha handling and the `mise_hash` rename already applied from prior review feedback. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[chezmoi apply completes] --> B[post hook: bash -c]
    B --> C["Compute mise_hash\ncat config*.toml | sha1sum / shasum"]
    C --> D{"hash == /tmp/mise-config-hash?"}
    D -- Yes --> E[exit 0 — skip]
    D -- No --> F["GITHUB_TOKEN=$(gh auth token)\nmise install --jobs=2"]
    F -- success --> G["Write mise_hash\nto /tmp/mise-config-hash"]
    F -- failure --> H[Hook exits non-zero\ncache NOT updated]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[chezmoi apply completes] --> B[post hook: bash -c]
    B --> C["Compute mise_hash\ncat config*.toml | sha1sum / shasum"]
    C --> D{"hash == /tmp/mise-config-hash?"}
    D -- Yes --> E[exit 0 — skip]
    D -- No --> F["GITHUB_TOKEN=$(gh auth token)\nmise install --jobs=2"]
    F -- success --> G["Write mise_hash\nto /tmp/mise-config-hash"]
    F -- failure --> H[Hook exits non-zero\ncache NOT updated]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["revert: keep original GITHUB\_TOKEN patte..."](https://github.com/ryo246912/dotfiles/commit/84f19c05172d36e0ae827da9cb1b8c581c9749ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37407587)</sub>

<!-- /greptile_comment -->