### PR TITLE
feat(nvim): add leaf markdown previewer integration

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -83,6 +83,7 @@ ASDF_FFMPEG_ENABLE = "gpl libx264"
 "github:seachicken/gh-poi"                                  = { version = "0.18.1", bin = "gh-poi" }
 "github:shazow/wifitui"                                     = "0.13.0"
 "github:skanehira/ghost"                                    = "0.3.1"
+"github:rivolink/leaf"                                      = { version = "1.25.0", bin = "leaf" }
 "github:trasta298/keifu"                                    = "0.3.0"
 "github:wesm/agentsview"                                    = "0.31.1"
 "go:github.com/air-verse/air"                               = "1.65.3"

--- a/dot_config/nvim/lua/plugins/terminal.lua
+++ b/dot_config/nvim/lua/plugins/terminal.lua
@@ -138,10 +138,53 @@ return {
         filetree:toggle()
       end
 
+      local leaf_terminal = nil
+      local leaf_terminal_file = nil
+
+      local function toggle_leaf()
+        local filepath = vim.fn.expand("%:p")
+        if filepath == "" or vim.bo.filetype ~= "markdown" then
+          vim.notify("Markdownファイルを開いている必要があります。", vim.log.levels.WARN)
+          return
+        end
+        if not command_exists("leaf") then
+          vim.notify("leaf が見つかりません。`mise install` を実行してください。", vim.log.levels.WARN)
+          return
+        end
+        if leaf_terminal and leaf_terminal_file ~= filepath then
+          leaf_terminal:shutdown()
+          leaf_terminal = nil
+          leaf_terminal_file = nil
+        end
+        if not leaf_terminal then
+          leaf_terminal = Terminal:new({
+            cmd = "leaf -w " .. vim.fn.shellescape(filepath),
+            direction = "vertical",
+            hidden = true,
+            close_on_exit = false,
+            on_exit = function(t)
+              if leaf_terminal == t then
+                leaf_terminal = nil
+                leaf_terminal_file = nil
+              end
+            end,
+          })
+          leaf_terminal_file = filepath
+        end
+        local prev_win = vim.api.nvim_get_current_win()
+        leaf_terminal:toggle()
+        vim.schedule(function()
+          if vim.api.nvim_win_is_valid(prev_win) then
+            vim.api.nvim_set_current_win(prev_win)
+          end
+        end)
+      end
+
       keymap({ "n", "t" }, "<leader>t", toggle_terminal, { noremap = true, silent = true, desc = "ターミナル開閉" })
       keymap({ "n", "t" }, "<leader>H", open_popup_command_picker, { noremap = true, silent = true, desc = "コマンド履歴・実行ポップアップ" })
 keymap({ "n", "t" }, "<leader>gk", toggle_keifu, { noremap = true, silent = true, desc = "keifu を開閉" })
       keymap({ "n", "t" }, "<leader>E", toggle_filetree, { noremap = true, silent = true, desc = "filetree(ft) を開閉" })
+      keymap({ "n" }, "<leader>md", toggle_leaf, { noremap = true, silent = true, desc = "Markdownプレビュー(leaf)" })
     end,
   },
 }


### PR DESCRIPTION
## Summary

- `mise.toml` に `@rivolink/leaf@1.24.2` を追加（バージョン明示固定）
- `terminal.lua` に toggleterm.nvim を使った leaf 統合を追加
- `,md` (`<leader>md`) でvertical splitのMarkdownプレビューをトグル

## 変更内容

### `mise.toml`
- `"npm:@rivolink/leaf" = "1.24.2"` を追加

### `dot_config/nvim/lua/plugins/terminal.lua`
- `toggle_leaf()` 関数を追加（既存の `keifu` / `filetree` と同スタイル）
- Markdownファイル以外では警告通知
- `leaf` バイナリ未インストール時は警告通知
- ファイルを切り替えた場合は既存ターミナルをシャットダウンして再生成
- `on_exit` コールバックでターミナル状態をリセット

## キーバインド

| キー | 動作 |
|------|------|
| `<leader>md` (= `,md`) | 現在のMarkdownファイルをleafでvertical splitプレビュー（トグル） |

## セットアップ

```bash
mise install   # leaf をインストール
chezmoi apply  # nvim 設定をデプロイ
```

## Test plan

- [ ] `mise install` で leaf 1.24.2 がインストールされること
- [ ] Markdownファイルを開いた状態で `,md` を押すとvertical splitでプレビューが開くこと
- [ ] 再度 `,md` でプレビューが閉じること
- [ ] Markdown以外のファイルで `,md` を押すと警告が表示されること
- [ ] 別のMarkdownファイルに切り替えて `,md` を押すと新しいプレビューが開くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVTjWWLzG5W6QyDcpXMQCf

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVTjWWLzG5W6QyDcpXMQCf)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `leaf` Markdown previewer to Neovim via `toggleterm.nvim`. Press `<leader>md` to toggle a vertical preview; handles non-Markdown files, missing binary, file switches, keeps error output, and preserves editor focus.

- New Features
  - Adds `toggle_leaf()` and `<leader>md` for vertical split Markdown preview.
  - Pins `github:rivolink/leaf@1.25.0` in `dot_config/mise/config.toml`.

- Bug Fixes
  - Guards `on_exit` with terminal identity to prevent races on file switch.
  - Sets `close_on_exit = false` so error output remains visible.
  - Restores focus to the original window after opening the preview.

<sup>Written for commit 12b25b42f2eb0f4f573f23aa96eeafc947d1182f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更内容概要

Leaf Markdown プレビューアーを Neovim に統合しました。主な変更は以下の通りです。

- **mise.toml**: `@rivolink/leaf@1.24.2` を tools セクションに追加し、`leaf` のインストール管理を揃えました。
- **terminal.lua**: `toggle_leaf()` を追加し、`filetype == markdown` のときだけ `leaf` を使ってプレビューを **縦分割で表示/非表示**できるようにしました（`toggleterm.nvim` 経由）。
- **キーバインディング**: `<leader>md` に `toggle_leaf` を割り当てました。
- **挙動の制御**:
  - Markdown ではない場所で実行した場合は警告を表示します。
  - `leaf` バイナリが未インストールの場合は警告を表示します。
  - 別の Markdown ファイルに切り替えたときは、既存のターミナルを `shutdown` して作り直し、`on_exit` で参照している端末状態をリセットします。

## 変更理由

Neovim 内で Markdown の内容確認を素早く行えるようにするため、Leaf のプレビュー機能を `toggleterm.nvim` でトグル統合し、ファイル切り替え時も状態が破綻しない運用にしました。

## 確認した項目

- `leaf`（Leaf 1.24.2）がインストール可能であること
- `toggle_leaf()` によるプレビューの表示/非表示トグルが動作すること
- Markdown ではない場合の警告表示が行われること
- `leaf` バイナリ未インストール時の警告表示が行われること
- 別 Markdown ファイルに切り替えた際に、既存ターミナルが `shutdown` されて再生成されること
- `on_exit` によりターミナル状態がクリーンアップされること
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR integrates the `leaf` Markdown previewer into Neovim via `toggleterm.nvim`, pinning version `1.25.0` in `mise.toml` and exposing a `<leader>md` keymap for a vertical-split live preview toggle.

- Adds `toggle_leaf()` following the same guard pattern as `keifu`/`filetree`: filetype check, binary existence check, file-switch detection, and `on_exit`-based state cleanup — with the stale-closure race condition from the previous review thread already fixed via identity guard (`if leaf_terminal == t`).
- Sets `close_on_exit = false` so error output from `leaf` remains visible in the split, and restores editor focus via `vim.schedule` after opening the preview.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new toggle_leaf integration is self-contained, follows established patterns in the file, and handles all edge cases correctly.

The on_exit race condition flagged in the previous review round is already resolved with an identity guard. File-switch handling, binary checks, filetype guards, and window-focus restoration all work correctly. The mise pin is explicit and the binary name aligns with the Lua check.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| dot_config/mise/config.toml | Adds github:rivolink/leaf at version 1.25.0 with bin = "leaf" — matches the binary name checked in Lua code. |
| dot_config/nvim/lua/plugins/terminal.lua | Adds toggle_leaf() with filetype guard, binary guard, file-switch detection with shutdown/recreate, identity-guarded on_exit cleanup, and window-focus restoration. Logic is sound and consistent with existing patterns in the file. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant toggle_leaf
    participant leaf_terminal
    participant leaf_process

    User->>toggle_leaf: "<leader>md"
    toggle_leaf->>toggle_leaf: "check filetype == markdown"
    toggle_leaf->>toggle_leaf: check command_exists("leaf")
    alt "file changed (leaf_terminal_file != filepath)"
        toggle_leaf->>leaf_terminal: shutdown()
        toggle_leaf->>toggle_leaf: "leaf_terminal = nil"
        leaf_process-->>toggle_leaf: on_exit(t) [async]
        toggle_leaf->>toggle_leaf: "if leaf_terminal == t: reset state"
    end
    alt "leaf_terminal == nil"
        toggle_leaf->>leaf_terminal: "Terminal:new({ cmd = "leaf -w <file>" })"
        toggle_leaf->>toggle_leaf: "leaf_terminal_file = filepath"
    end
    toggle_leaf->>toggle_leaf: "prev_win = current_win"
    toggle_leaf->>leaf_terminal: toggle()
    leaf_terminal->>leaf_process: "start/stop leaf -w <file>"
    toggle_leaf->>toggle_leaf: vim.schedule → set_current_win(prev_win)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant toggle_leaf
    participant leaf_terminal
    participant leaf_process

    User->>toggle_leaf: "<leader>md"
    toggle_leaf->>toggle_leaf: "check filetype == markdown"
    toggle_leaf->>toggle_leaf: check command_exists("leaf")
    alt "file changed (leaf_terminal_file != filepath)"
        toggle_leaf->>leaf_terminal: shutdown()
        toggle_leaf->>toggle_leaf: "leaf_terminal = nil"
        leaf_process-->>toggle_leaf: on_exit(t) [async]
        toggle_leaf->>toggle_leaf: "if leaf_terminal == t: reset state"
    end
    alt "leaf_terminal == nil"
        toggle_leaf->>leaf_terminal: "Terminal:new({ cmd = "leaf -w <file>" })"
        toggle_leaf->>toggle_leaf: "leaf_terminal_file = filepath"
    end
    toggle_leaf->>toggle_leaf: "prev_win = current_win"
    toggle_leaf->>leaf_terminal: toggle()
    leaf_terminal->>leaf_process: "start/stop leaf -w <file>"
    toggle_leaf->>toggle_leaf: vim.schedule → set_current_win(prev_win)
```

</a>

<sub>Reviews (8): Last reviewed commit: ["feat: add leaf markdown previewer integr..."](https://github.com/ryo246912/dotfiles/commit/12b25b42f2eb0f4f573f23aa96eeafc947d1182f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38873147)</sub>

<!-- /greptile_comment -->