### PR TITLE
Replace less color config with colored-man-pages-plus plugin

### DIFF
--- a/dot_config/zsh/lazy/main.zsh
+++ b/dot_config/zsh/lazy/main.zsh
@@ -17,15 +17,6 @@ export LESSHISTFILE="$XDG_STATE_HOME/less/.lesshst"
 mkdir -p "$XDG_STATE_HOME/zsh" 2>/dev/null
 export HISTFILE="$XDG_STATE_HOME/zsh/.zsh_history"
 
-# less
-export LESS_TERMCAP_mb=$'\e[1;32m'
-export LESS_TERMCAP_md=$'\e[1;32m'
-export LESS_TERMCAP_me=$'\e[0m'
-export LESS_TERMCAP_se=$'\e[0m'
-export LESS_TERMCAP_so=$'\e[01;33m'
-export LESS_TERMCAP_ue=$'\e[0m'
-export LESS_TERMCAP_us=$'\e[1;4;31m'
-
 # slack
 export SLACK_DEVELOPER_MENU=true
 

--- a/dot_config/zsh/lazy/plugin.zsh
+++ b/dot_config/zsh/lazy/plugin.zsh
@@ -79,7 +79,7 @@ zinit wait lucid light-mode blockf for \
 zinit wait lucid light-mode blockf for \
     @'azu/ni.zsh'
 
-zinit wait lucid light-mode blockf for \
+zinit wait lucid light-mode for \
     @'diverdale/colored-man-pages-plus'
 
 ### completion ###

--- a/dot_config/zsh/lazy/plugin.zsh
+++ b/dot_config/zsh/lazy/plugin.zsh
@@ -79,6 +79,9 @@ zinit wait lucid light-mode blockf for \
 zinit wait lucid light-mode blockf for \
     @'azu/ni.zsh'
 
+zinit wait lucid light-mode blockf for \
+    @'diverdale/colored-man-pages-plus'
+
 ### completion ###
 zinit wait lucid light-mode blockf for \
     as"completion" \


### PR DESCRIPTION
## Summary

Migrated manual LESS_TERMCAP color configuration to the `colored-man-pages-plus` zinit plugin, simplifying the zsh configuration while maintaining colored man page output.

## Changes

- **Removed** manual LESS_TERMCAP environment variable exports from `dot_config/zsh/lazy/main.zsh`
  - Deleted 7 lines of ANSI color code configuration for less pager
  
- **Added** `diverdale/colored-man-pages-plus` plugin to `dot_config/zsh/lazy/plugin.zsh`
  - Installed via zinit with standard lazy-loading parameters (`wait lucid light-mode blockf`)
  - Positioned after the `azu/ni.zsh` plugin in the plugin list

## Implementation Details

The `colored-man-pages-plus` plugin provides the same colored man page functionality as the manual LESS_TERMCAP configuration, but with better maintenance and additional features. This reduces configuration boilerplate while achieving the same visual result.

https://claude.ai/code/session_01QcYHxpyE3775qtjHZUTLAS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced manual `LESS_TERMCAP_*` color exports with the `diverdale/colored-man-pages-plus` plugin via `zinit` to keep colored man pages and simplify the zsh setup. Added the plugin after `azu/ni.zsh` and removed the unnecessary `blockf` flag.

<sup>Written for commit 0c97a8d7c1e6b897e7fdf8be61bd9a545f1492c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
`less` の色設定に使っていた `LESS_TERMCAP_*` の手動 `export` を削除し、代わりに `diverdale/colored-man-pages-plus` を zinit の遅延読み込みプラグインとして追加しました。

## 変更理由
man ページの色付き表示を維持しつつ、個別の環境変数設定をやめて zsh 設定をシンプルにするためです。プラグインベースに置き換えることで、管理対象をまとめられます。

## 確認した項目
- `LESS_TERMCAP_*` の手動設定が削除されていること
- `colored-man-pages-plus` が zinit の lazy load 設定に追加されていること
- 既存の man ページ色付けの意図が保たれる構成になっていること

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces seven manually exported `LESS_TERMCAP_*` environment variables with the `diverdale/colored-man-pages-plus` zinit plugin, delegating man-page colorization to a maintained plugin instead of hand-rolled ANSI codes.

- Removes `LESS_TERMCAP_mb/md/me/se/so/ue/us` exports from `dot_config/zsh/lazy/main.zsh`, eliminating ~7 lines of boilerplate.
- Adds `zinit wait lucid light-mode for @'diverdale/colored-man-pages-plus'` in `dot_config/zsh/lazy/plugin.zsh`, loaded consistently with other lazy plugins; `blockf` is correctly omitted since this plugin adds no completions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a clean removal of hand-rolled LESS_TERMCAP exports in favour of a dedicated plugin with no functional regressions expected.

The change removes a small block of environment variable exports and replaces them with a well-scoped plugin. The plugin is loaded with the same lazy-loading ices as the rest of the plugin list, and blockf is correctly omitted. No other configuration is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| dot_config/zsh/lazy/main.zsh | Removed 7 LESS_TERMCAP_* export lines; no other changes. Straightforward deletion with no side effects. |
| dot_config/zsh/lazy/plugin.zsh | Added colored-man-pages-plus plugin block after azu/ni.zsh; uses correct wait/lucid/light-mode ices and appropriately omits blockf since the plugin does not modify fpath. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Shell as zsh startup
    participant Main as main.zsh (before)
    participant Plugin as plugin.zsh (after)
    participant Zinit as zinit (async)
    participant Man as man command

    Note over Shell,Main: Before this PR
    Shell->>Main: source main.zsh
    Main->>Shell: "export LESS_TERMCAP_* (7 vars, immediately)"
    Shell->>Man: man page → colored via global env

    Note over Shell,Plugin: After this PR
    Shell->>Plugin: source plugin.zsh
    Plugin->>Zinit: zinit wait lucid light-mode for diverdale/colored-man-pages-plus
    Zinit-->>Shell: "(async) plugin loaded, LESS_TERMCAP_* set by plugin"
    Shell->>Man: man page → colored via plugin
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Shell as zsh startup
    participant Main as main.zsh (before)
    participant Plugin as plugin.zsh (after)
    participant Zinit as zinit (async)
    participant Man as man command

    Note over Shell,Main: Before this PR
    Shell->>Main: source main.zsh
    Main->>Shell: "export LESS_TERMCAP_* (7 vars, immediately)"
    Shell->>Man: man page → colored via global env

    Note over Shell,Plugin: After this PR
    Shell->>Plugin: source plugin.zsh
    Plugin->>Zinit: zinit wait lucid light-mode for diverdale/colored-man-pages-plus
    Zinit-->>Shell: "(async) plugin loaded, LESS_TERMCAP_* set by plugin"
    Shell->>Man: man page → colored via plugin
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: remove blockf from colored-man-page..."](https://github.com/ryo246912/dotfiles/commit/0c97a8d7c1e6b897e7fdf8be61bd9a545f1492c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40977964)</sub>

<!-- /greptile_comment -->