### PR TITLE
feat: add character count to nvim statusline

### DIFF
--- a/dot_config/nvim/lua/core/options.lua
+++ b/dot_config/nvim/lua/core/options.lua
@@ -47,6 +47,15 @@ vim.opt.ruler = true
 vim.opt.laststatus = 2
 -- 入力したコマンドが右下に表示
 vim.opt.showcmd = true
+
+-- ステータスラインの右側に文字数カウント（カーソル位置/全体）を表示
+_G.MyCharCount = function()
+  local wc = vim.fn.wordcount()
+  local cursor_pos = (wc.cursor_chars or wc.chars) + 1
+  return cursor_pos .. "/" .. wc.chars .. " chars"
+end
+
+vim.opt.statusline = "%f %h%m%r%=%{v:lua.MyCharCount()} %-14.(%l,%c%V%) %P"
 -- タイトルを表示
 vim.opt.title = true
 


### PR DESCRIPTION
## Summary
Enhanced the Neovim statusline to display a real-time character count alongside the existing line and column information.

## Changes
- Added a Lua function `MyCharCount()` that retrieves the character count from `vim.fn.wordcount()`
- Configured a custom statusline that displays:
  - Current filename and buffer status (`%f %h%m%r`)
  - Character count on the right side (`{v:lua.MyCharCount()}`)
  - Line, column, and virtual column position (`%l,%c%V`)
  - File position percentage (`%P`)

## Implementation Details
- Uses Neovim's Lua API to access wordcount data
- Character count is displayed in the format "X chars" on the right side of the statusline
- Maintains existing statusline information while adding the new metric
- Follows the existing code style and configuration patterns in the options file

https://claude.ai/code/session_01FUwSgPmdrH7d2JEBGvMgaD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a live character count to the Neovim statusline. Shows "current/total chars" on the right while keeping filename and position info unchanged.

<sup>Written for commit 994bf2073ea760224ed9b9051fd2c80f13259791. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更内容概要
- Neovimのステータスライン右側に、カーソル位置/全体の文字数をリアルタイム表示する `MyCharCount()`（`v:lua.MyCharCount()`）を追加しました。
- 表示形式は `"<cursor>/<total> chars"` で、従来のファイル名、バッファ状態、行・列位置、仮想列、ファイル位置割合といったステータス情報は維持したまま、右側に文字数表示を追加しています。

## 変更理由
- 編集中の文字数（カーソル位置と全体）を常に把握できるようにするためです。

## 確認した項目
- 文字数取得に `vim.fn.wordcount()` を利用し、`chars` を `MyCharCount()` の戻り値としてステータスラインに反映していること。
- ステータスラインの既存表示項目が崩れず、文字数表示が右側に追加され、編集に応じて更新されること。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a character count to the Neovim statusline. The main changes are:

- A global Lua helper that reads `vim.fn.wordcount()`.
- A custom statusline showing filename, character count, cursor position, and file percentage.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| dot_config/nvim/lua/core/options.lua | Adds the character-count helper and wires it into the Neovim statusline. |

<sub>Reviews (2): Last reviewed commit: ["feat(nvim): add character count display ..."](https://github.com/ryo246912/dotfiles/commit/994bf2073ea760224ed9b9051fd2c80f13259791) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43640345)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/ryo/github/ryo246912/dotfiles/-/custom-context?memory=56ca1037-b626-4c46-a579-6fd3c3e6a2f8))

<!-- /greptile_comment -->