### PR TITLE
ci: add test-mac/test-linux workflows with workflow_dispatch

### DIFF
--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -1,0 +1,68 @@
+name: test-linux
+
+# `/test-linux` コメント、または Actions UI からの workflow_dispatch で発火する。
+# 現時点では最小限のスキャフォールドのみ（トリガー・権限分離・結果コメントの型を用意）。
+# 実際の検証内容（dot_config/mise/config.linux.toml の bootstrap.packages(apt) 検証等）は
+# それらの設定ファイルを追加する PR がマージされ次第、ここに実装する。
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+  group: test-linux-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    # workflow_dispatch は常に許可（Actions 実行権限で既にアクセス制御されているため）。
+    # issue_comment は PR への `/test-linux`（完全一致 or `/test-linux <args>`）コメントのみ、
+    # 権限のあるユーザーに限定する。
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request &&
+      (github.event.comment.body == '/test-linux' || startsWith(github.event.comment.body, '/test-linux ')) &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    # PR のコードを実行するため read-only 権限に絞る（write トークンを PR コードに晒さない）。
+    permissions:
+      contents: read
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
+          persist-credentials: false
+
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          version: "2026.7.0"
+          install: false
+
+      - name: mise sanity check
+        run: mise --version
+
+  comment:
+    # PR コードを一切実行しない信頼ジョブ。ここだけ write 権限でコメントする。
+    needs: test
+    if: ${{ always() && github.event_name == 'issue_comment' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.issue.number }}
+      REPO: ${{ github.repository }}
+      RESULT: ${{ needs.test.result }}
+    steps:
+      - name: Comment result
+        run: |
+          set -euo pipefail
+          run_url="${{ github.server_url }}/${REPO}/actions/runs/${{ github.run_id }}"
+          icon() { case "$1" in success) echo "✅";; skipped) echo "⏭️";; *) echo "❌";; esac; }
+          body=$(printf '`/test-linux`（[log](%s)）: %s %s' "$run_url" "$(icon "$RESULT")" "$RESULT")
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body"

--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -1,9 +1,5 @@
 name: test-linux
 
-# `/test-linux` コメント、または Actions UI からの workflow_dispatch で発火する。
-# 現時点では最小限のスキャフォールドのみ（トリガー・権限分離・結果コメントの型を用意）。
-# 実際の検証内容（dot_config/mise/config.linux.toml の bootstrap.packages(apt) 検証等）は
-# それらの設定ファイルを追加する PR がマージされ次第、ここに実装する。
 on:
   issue_comment:
     types:
@@ -18,16 +14,12 @@ concurrency:
 
 jobs:
   test:
-    # workflow_dispatch は常に許可（Actions 実行権限で既にアクセス制御されているため）。
-    # issue_comment は PR への `/test-linux`（完全一致 or `/test-linux <args>`）コメントのみ、
-    # 権限のあるユーザーに限定する。
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.issue.pull_request &&
       (github.event.comment.body == '/test-linux' || startsWith(github.event.comment.body, '/test-linux ')) &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
-    # PR のコードを実行するため read-only 権限に絞る（write トークンを PR コードに晒さない）。
     permissions:
       contents: read
     timeout-minutes: 20
@@ -46,7 +38,6 @@ jobs:
         run: mise --version
 
   comment:
-    # PR コードを一切実行しない信頼ジョブ。ここだけ write 権限でコメントする。
     needs: test
     if: ${{ always() && github.event_name == 'issue_comment' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test-mac.yaml
+++ b/.github/workflows/test-mac.yaml
@@ -1,9 +1,5 @@
 name: test-mac
 
-# `/test-mac` コメント、または Actions UI からの workflow_dispatch で発火する。
-# 現時点では最小限のスキャフォールドのみ（トリガー・権限分離・結果コメントの型を用意）。
-# 実際の検証内容（dot_config/mise/config.mac.toml の bootstrap.packages(brew) 検証等）は
-# それらの設定ファイルを追加する PR がマージされ次第、ここに実装する。
 on:
   issue_comment:
     types:
@@ -18,17 +14,12 @@ concurrency:
 
 jobs:
   test:
-    # workflow_dispatch は常に許可（Actions 実行権限で既にアクセス制御されているため）。
-    # issue_comment は PR への `/test-mac`（完全一致 or `/test-mac <args>`）コメントのみ、
-    # 権限のあるユーザーに限定する。
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.issue.pull_request &&
       (github.event.comment.body == '/test-mac' || startsWith(github.event.comment.body, '/test-mac ')) &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
-    # public repo なので macOS ランナーは無料・分数無制限。
     runs-on: macos-latest
-    # PR のコードを実行するため read-only 権限に絞る（write トークンを PR コードに晒さない）。
     permissions:
       contents: read
     timeout-minutes: 40
@@ -47,7 +38,6 @@ jobs:
         run: mise --version
 
   comment:
-    # PR コードを一切実行しない信頼ジョブ。ここだけ write 権限でコメントする。
     needs: test
     if: ${{ always() && github.event_name == 'issue_comment' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test-mac.yaml
+++ b/.github/workflows/test-mac.yaml
@@ -1,0 +1,69 @@
+name: test-mac
+
+# `/test-mac` コメント、または Actions UI からの workflow_dispatch で発火する。
+# 現時点では最小限のスキャフォールドのみ（トリガー・権限分離・結果コメントの型を用意）。
+# 実際の検証内容（dot_config/mise/config.mac.toml の bootstrap.packages(brew) 検証等）は
+# それらの設定ファイルを追加する PR がマージされ次第、ここに実装する。
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+  group: test-mac-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    # workflow_dispatch は常に許可（Actions 実行権限で既にアクセス制御されているため）。
+    # issue_comment は PR への `/test-mac`（完全一致 or `/test-mac <args>`）コメントのみ、
+    # 権限のあるユーザーに限定する。
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request &&
+      (github.event.comment.body == '/test-mac' || startsWith(github.event.comment.body, '/test-mac ')) &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    # public repo なので macOS ランナーは無料・分数無制限。
+    runs-on: macos-latest
+    # PR のコードを実行するため read-only 権限に絞る（write トークンを PR コードに晒さない）。
+    permissions:
+      contents: read
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
+          persist-credentials: false
+
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          version: "2026.7.0"
+          install: false
+
+      - name: mise sanity check
+        run: mise --version
+
+  comment:
+    # PR コードを一切実行しない信頼ジョブ。ここだけ write 権限でコメントする。
+    needs: test
+    if: ${{ always() && github.event_name == 'issue_comment' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.issue.number }}
+      REPO: ${{ github.repository }}
+      RESULT: ${{ needs.test.result }}
+    steps:
+      - name: Comment result
+        run: |
+          set -euo pipefail
+          run_url="${{ github.server_url }}/${REPO}/actions/runs/${{ github.run_id }}"
+          icon() { case "$1" in success) echo "✅";; skipped) echo "⏭️";; *) echo "❌";; esac; }
+          body=$(printf '`/test-mac`（[log](%s)）: %s %s' "$run_url" "$(icon "$RESULT")" "$RESULT")
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body"


### PR DESCRIPTION
## Summary

- `/test-mac` と `/test-linux` をそれぞれ個別に実行できるワークフローとして分離
- 各ワークフローに `workflow_dispatch` トリガーを追加し、Actions UI からも単体で手動実行可能に

## Background

PR #1113 (`Migrate tig and colordiff to mise bootstrap packages`) で `/test` コメント1本で mac/linux 両方を実行する `install-check.yaml` を追加していたが、以下の理由で本 PR として切り出した:

- mac/linux をそれぞれ個別に再実行できるようにしたい（`/test-mac` / `/test-linux`）
- `workflow_dispatch` で Actions UI からも実行したい
- ワークフローのトリガー整備自体は PR #1113 のコア変更（mise bootstrap.packages 移行）と独立しているため、先にマージしたい

## Note

現時点では `dot_config/mise/config.mac.toml` の `[bootstrap.packages]` や `.chezmoi.toml.tmpl` などの検証対象ファイルがまだ `main` に存在しないため（PR #1113 で追加予定）、本 PR の2ワークフローはトリガー・権限分離・結果コメントの型のみを持つ最小スキャフォールドです。実際の bootstrap.packages 検証ステップは PR #1113 のマージ後、別途追加します。

## Test plan

- [ ] マージ後、Actions UI から `test-linux` / `test-mac` をそれぞれ `workflow_dispatch` で手動実行して動作確認
- [ ] 任意の PR に `/test-linux` / `/test-mac` とコメントして individually 発火することを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2neRf3YFZt2Vynftu9dBN)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the install check into two independent GitHub Actions workflows, `test-mac` and `test-linux`, each runnable via `/test-mac` and `/test-linux` comments or `workflow_dispatch` in the Actions UI. Includes a minimal `mise` sanity check; full validation steps will be added after PR #1113 lands.

- **New Features**
  - Added `.github/workflows/test-mac.yaml` (runs on `macos-latest`) and `.github/workflows/test-linux.yaml` (runs on `ubuntu-latest`).
  - Triggers: `issue_comment` for `/test-mac` and `/test-linux` (supports optional args; restricted to `OWNER`/`MEMBER`/`COLLABORATOR`) and `workflow_dispatch`.
  - Concurrency groups per PR/run with cancel-in-progress.
  - Test job uses read-only permissions; a separate comment job uses `pull-requests: write` to post status with a log link.

<sup>Written for commit cb10c6ed78de89359efce92354bf299b7900e3bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

- macOS/Linux 向けの GitHub Actions ワークフローを分離して追加
- `/test-mac`・`/test-linux` コメントおよび手動実行に対応
- テスト実行と結果コメント投稿を分離し、権限を最小化
- 実行の競合を抑止し、Actions ログへのリンク付き結果コメントを投稿

## 変更理由

OS ごとのテストを個別に実行できるようにし、PR コメントからの実行性とセキュリティを改善するためです。`mise bootstrap.packages` の検証は、必要な設定ファイルが追加される別 PR 後に導入予定です。

## 確認した項目

- `workflow_dispatch` による手動実行
- 信頼できる投稿者による `/test-mac`・`/test-linux` コメント実行
- `mise` のバージョン確認
- テスト結果に応じた PR コメント投稿
- ワークフローごとの権限分離と同時実行制御

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new GitHub Actions workflows — `test-linux.yaml` and `test-mac.yaml` — as minimal scaffolds that can be triggered individually via `/test-linux` / `/test-mac` PR comments or through `workflow_dispatch` in the Actions UI. Each workflow has a `test` job (read-only permissions) and a separate `comment` job that posts the result back to the PR.

- Both workflows pin action SHAs, use `persist-credentials: false`, and scope permissions correctly (test: `contents: read`, comment: `pull-requests: write`), which are solid security practices.
- Both `comment` jobs have a condition bug: `always() && github.event_name == 'issue_comment'` fires even when `test` was skipped, meaning any comment on any PR will trigger this workflow and post a spurious \"⏭️ skipped\" reply. Adding `&& needs.test.result != 'skipped'` to the condition fixes this in both files.
- The workflows are intentionally minimal scaffolds; actual bootstrap validation steps are deferred to a follow-up PR.

<h3>Confidence Score: 4/5</h3>

The workflows are safe to merge after the comment-job condition fix; without it, every PR comment in the repo will receive an unwanted skipped reply from both workflows.

Both new workflows share the same condition logic that causes the comment job to post on every issue_comment event — including ordinary PR conversations — whenever the test job is skipped. This produces noisy, confusing comments on PRs that have nothing to do with /test-linux or /test-mac. The fix is a one-line change in each file. Everything else — pinned SHAs, minimal permissions, persist-credentials: false, concurrency groups, and author-association gating — is implemented correctly.

Both .github/workflows/test-linux.yaml and .github/workflows/test-mac.yaml need the comment job condition updated before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/test-linux.yaml | New workflow triggered by issue_comment + workflow_dispatch; comment job will post spurious "skipped" notices on every PR comment, not just /test-linux ones |
| .github/workflows/test-mac.yaml | New workflow triggered by issue_comment + workflow_dispatch; same spurious comment bug as test-linux.yaml — comment job condition does not guard against skipped test runs |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant GitHub
    participant test_job as test job (ubuntu/macos)
    participant comment_job as comment job (ubuntu)

    User->>GitHub: Comment "/test-linux" on PR
    GitHub->>test_job: Trigger (issue_comment, author is OWNER/MEMBER/COLLABORATOR)
    test_job->>test_job: checkout PR head ref
    test_job->>test_job: setup mise-action
    test_job->>test_job: mise --version
    test_job-->>comment_job: result (success/failure)
    comment_job->>GitHub: gh pr comment with status + log URL

    User->>GitHub: Any other PR comment (e.g. "LGTM")
    GitHub->>test_job: Trigger (issue_comment)
    test_job-->>test_job: condition false → skipped
    test_job-->>comment_job: "result = skipped"
    Note over comment_job: Bug: comment job still runs, posts skipped on unrelated comment

    User->>GitHub: workflow_dispatch
    GitHub->>test_job: Trigger (manual)
    test_job->>test_job: checkout default ref
    test_job->>test_job: mise --version
    Note over comment_job: comment job skipped (not issue_comment)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant GitHub
    participant test_job as test job (ubuntu/macos)
    participant comment_job as comment job (ubuntu)

    User->>GitHub: Comment "/test-linux" on PR
    GitHub->>test_job: Trigger (issue_comment, author is OWNER/MEMBER/COLLABORATOR)
    test_job->>test_job: checkout PR head ref
    test_job->>test_job: setup mise-action
    test_job->>test_job: mise --version
    test_job-->>comment_job: result (success/failure)
    comment_job->>GitHub: gh pr comment with status + log URL

    User->>GitHub: Any other PR comment (e.g. "LGTM")
    GitHub->>test_job: Trigger (issue_comment)
    test_job-->>test_job: condition false → skipped
    test_job-->>comment_job: "result = skipped"
    Note over comment_job: Bug: comment job still runs, posts skipped on unrelated comment

    User->>GitHub: workflow_dispatch
    GitHub->>test_job: Trigger (manual)
    test_job->>test_job: checkout default ref
    test_job->>test_job: mise --version
    Note over comment_job: comment job skipped (not issue_comment)
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.github%2Fworkflows%2Ftest-linux.yaml%3A43%0A**Spurious%20%22skipped%22%20comment%20on%20every%20PR%20comment**%0A%0AThe%20%60comment%60%20job%20condition%20is%20%60always%28%29%20%26%26%20github.event_name%20%3D%3D%20'issue_comment'%60%2C%20but%20the%20%60issue_comment%60%20trigger%20fires%20for%20**every**%20comment%20on%20every%20issue%20and%20PR%20%E2%80%94%20not%20just%20%60%2Ftest-linux%60%20ones.%20When%20the%20%60test%60%20job%20is%20skipped%20%28i.e.%2C%20any%20comment%20that%20isn't%20%60%2Ftest-linux%60%20from%20an%20authorized%20user%29%2C%20the%20%60comment%60%20job%20still%20runs%20and%20posts%20a%20%22%E2%8F%AD%EF%B8%8F%20skipped%22%20message%20on%20the%20PR.%20Add%20a%20%60needs.test.result%20!%3D%20'skipped'%60%20guard%20so%20the%20comment%20job%20only%20fires%20when%20the%20test%20actually%20ran.%0A%0AThe%20same%20problem%20exists%20in%20%60test-mac.yaml%60%20line%2043.%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Ftest-linux.yaml%3A42%0AAdding%20%60needs.test.result%20!%3D%20'skipped'%60%20to%20the%20condition%20prevents%20the%20job%20from%20posting%20a%20%22%E2%8F%AD%EF%B8%8F%20skipped%22%20comment%20whenever%20any%20unrelated%20comment%20is%20made%20on%20any%20PR%20or%20issue.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%3A%20%24%7B%7B%20always%28%29%20%26%26%20github.event_name%20%3D%3D%20'issue_comment'%20%26%26%20needs.test.result%20!%3D%20'skipped'%20%7D%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Ftest-mac.yaml%3A42%0ASame%20spurious-comment%20bug%20as%20in%20%60test-linux.yaml%60%20%E2%80%94%20the%20%60comment%60%20job%20fires%20on%20any%20%60issue_comment%60%20event%2C%20including%20those%20where%20the%20test%20was%20skipped.%20Adding%20%60needs.test.result%20!%3D%20'skipped'%60%20limits%20posting%20to%20runs%20where%20%60%2Ftest-mac%60%20actually%20executed.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%3A%20%24%7B%7B%20always%28%29%20%26%26%20github.event_name%20%3D%3D%20'issue_comment'%20%26%26%20needs.test.result%20!%3D%20'skipped'%20%7D%7D%0A%60%60%60%0A%0A&repo=ryo246912%2Fdotfiles&pr=1145&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ryo246912%2Fdotfiles%22%20on%20the%20existing%20branch%20%22claude%2Fgithub-actions-workflow-dispatch-he2bkh%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fgithub-actions-workflow-dispatch-he2bkh%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.github%2Fworkflows%2Ftest-linux.yaml%3A43%0A**Spurious%20%22skipped%22%20comment%20on%20every%20PR%20comment**%0A%0AThe%20%60comment%60%20job%20condition%20is%20%60always%28%29%20%26%26%20github.event_name%20%3D%3D%20'issue_comment'%60%2C%20but%20the%20%60issue_comment%60%20trigger%20fires%20for%20**every**%20comment%20on%20every%20issue%20and%20PR%20%E2%80%94%20not%20just%20%60%2Ftest-linux%60%20ones.%20When%20the%20%60test%60%20job%20is%20skipped%20%28i.e.%2C%20any%20comment%20that%20isn't%20%60%2Ftest-linux%60%20from%20an%20authorized%20user%29%2C%20the%20%60comment%60%20job%20still%20runs%20and%20posts%20a%20%22%E2%8F%AD%EF%B8%8F%20skipped%22%20message%20on%20the%20PR.%20Add%20a%20%60needs.test.result%20!%3D%20'skipped'%60%20guard%20so%20the%20comment%20job%20only%20fires%20when%20the%20test%20actually%20ran.%0A%0AThe%20same%20problem%20exists%20in%20%60test-mac.yaml%60%20line%2043.%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Ftest-linux.yaml%3A42%0AAdding%20%60needs.test.result%20!%3D%20'skipped'%60%20to%20the%20condition%20prevents%20the%20job%20from%20posting%20a%20%22%E2%8F%AD%EF%B8%8F%20skipped%22%20comment%20whenever%20any%20unrelated%20comment%20is%20made%20on%20any%20PR%20or%20issue.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%3A%20%24%7B%7B%20always%28%29%20%26%26%20github.event_name%20%3D%3D%20'issue_comment'%20%26%26%20needs.test.result%20!%3D%20'skipped'%20%7D%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Ftest-mac.yaml%3A42%0ASame%20spurious-comment%20bug%20as%20in%20%60test-linux.yaml%60%20%E2%80%94%20the%20%60comment%60%20job%20fires%20on%20any%20%60issue_comment%60%20event%2C%20including%20those%20where%20the%20test%20was%20skipped.%20Adding%20%60needs.test.result%20!%3D%20'skipped'%60%20limits%20posting%20to%20runs%20where%20%60%2Ftest-mac%60%20actually%20executed.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%3A%20%24%7B%7B%20always%28%29%20%26%26%20github.event_name%20%3D%3D%20'issue_comment'%20%26%26%20needs.test.result%20!%3D%20'skipped'%20%7D%7D%0A%60%60%60%0A%0A&repo=ryo246912%2Fdotfiles&pr=1145&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Update test-mac.yaml"](https://github.com/ryo246912/dotfiles/commit/cb10c6ed78de89359efce92354bf299b7900e3bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45445902)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->