### PR TITLE
ci: Add Renovate regex rule for mise min_version tracking

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -110,6 +110,15 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["dot_config/mise/**/*.toml"],
+      "matchStrings": ["min_version\\s*=\\s*\"(?<currentValue>.*?)\""],
+      "depNameTemplate": "jdx/mise",
+      "packageNameTemplate": "jdx/mise",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["dot_config/mise/**/*.toml"],
       "matchStrings": [
         "\"go:github\\.com/atotto/clipboard/cmd/(?:gocopy|gopaste)\"\\s*=\\s*\"(?<currentValue>.*?)\""
       ],


### PR DESCRIPTION
## Summary

Add a new Renovate custom regex configuration to automatically track and update the `min_version` field for the `jdx/mise` tool in mise TOML configuration files.

## Changes

- Added a new custom regex rule in `.github/renovate.json` that:
  - Targets `dot_config/mise/**/*.toml` files
  - Matches `min_version = "..."` patterns
  - Tracks updates to the `jdx/mise` GitHub releases
  - Extracts semantic versions from release tags (strips `v` prefix)

This enables Renovate to automatically detect and propose updates when new versions of mise are released, keeping the minimum required version specification current across the dotfiles configuration.

https://claude.ai/code/session_01JhDPuKtGZhuvoMWryQT3sj

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Renovate regex rule to auto-update the `min_version` in mise TOML files by tracking `jdx/mise` GitHub releases. Keeps dotfiles aligned with the latest supported mise version.

- **New Features**
  - Custom regex in `.github/renovate.json` targets `dot_config/mise/**/*.toml` and matches `min_version = "..."`.
  - Uses `github-releases` for `jdx/mise` and strips the `v` prefix from tags so Renovate can propose updates.

<sup>Written for commit b89d96d04816f6f9f327710a824e26ca1ed65841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a Renovate custom regex manager entry that watches `min_version = "..."` lines in `dot_config/mise/**/*.toml` and maps them to the `jdx/mise` GitHub Releases datasource, enabling automated PRs when a new mise version ships.

- The regex `min_version\\s*=\\s*\"(?<currentValue>.*?)\"` correctly captures the bare CalVer value (`2026.6.6`) already present in `dot_config/mise/config.toml`.
- `extractVersionTemplate: "^v(?<version>.*)$"` strips the `v` prefix from release tags (e.g., `v2026.6.6` → `2026.6.6`) so it aligns with what is stored in the file — this is the right approach.
- No `versioningTemplate` is specified; because mise's CalVer triple (`YYYY.M.D`) is structurally identical to a semver triple, Renovate's default semver versioner will parse and order these releases correctly.

<h3>Confidence Score: 5/5</h3>

The change is limited to a single new entry in the Renovate config; it introduces no runtime code and cannot break the dotfile setup itself.

The regex, extractVersionTemplate, datasource choice, and file glob all align with the actual min_version value in the repo. The change mirrors the pattern used for adjacent rules in the same file and carries no risk of affecting existing rules.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/renovate.json | Adds a new customManagers regex rule to track the min_version field in mise TOML files against jdx/mise GitHub releases; regex and extractVersionTemplate look correct for the CalVer format actually used in the repo. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["jdx/mise GitHub Releases\n(e.g. v2026.6.6)"] -->|"extractVersionTemplate\n^v(?<version>.*)$"| B["Extracted version\n2026.6.6"]
    C["dot_config/mise/**/*.toml\nmin_version = '2026.6.6'"] -->|"matchStrings regex\ncaptures currentValue"| D["currentValue\n2026.6.6"]
    B -->|compare| E{Version diff?}
    D -->|compare| E
    E -->|"newer release found"| F["Renovate opens PR\nto bump min_version"]
    E -->|"up to date"| G["No PR created"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["jdx/mise GitHub Releases\n(e.g. v2026.6.6)"] -->|"extractVersionTemplate\n^v(?<version>.*)$"| B["Extracted version\n2026.6.6"]
    C["dot_config/mise/**/*.toml\nmin_version = '2026.6.6'"] -->|"matchStrings regex\ncaptures currentValue"| D["currentValue\n2026.6.6"]
    B -->|compare| E{Version diff?}
    D -->|compare| E
    E -->|"newer release found"| F["Renovate opens PR\nto bump min_version"]
    E -->|"up to date"| G["No PR created"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat: mise config.tomlのmin\_versionをrenov..."](https://github.com/ryo246912/dotfiles/commit/b89d96d04816f6f9f327710a824e26ca1ed65841) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45639907)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/ryo/github/ryo246912/dotfiles/-/custom-context?memory=56ca1037-b626-4c46-a579-6fd3c3e6a2f8))

<!-- /greptile_comment -->