### PR TITLE
chore: update tmux-resurrect process list

### DIFF
--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -249,7 +249,7 @@ set -g @plugin 'ryo246912/tmux-resurrect'
 set -g @resurrect-capture-pane-contents 'on'
 ## restore process [~:プロセス名が部分一致していたら、そのプロセスを復元する][->:復元の際に、指定したコマンド名で復元する][*:復元の際に、引数は保持した状態でコマンド名で復元する]
 ## https://github.com/tmux-plugins/tmux-resurrect/blob/cff343cf9e81983d3da0c8562b01616f12e8d548/docs/restoring_programs.md#clarifications
-set -g @resurrect-processes '"~vim -> vim" "~nvim -> nvim" "~make" "~docker" "~mise"'
+set -g @resurrect-processes '"~nvim -> nvim" "~make" "~docker" "~mise"'
 ## restore vim session
 set -g @resurrect-strategy-vim 'session'
 set -g @resurrect-strategy-nvim 'session'

--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -249,7 +249,7 @@ set -g @plugin 'ryo246912/tmux-resurrect'
 set -g @resurrect-capture-pane-contents 'on'
 ## restore process [~:プロセス名が部分一致していたら、そのプロセスを復元する][->:復元の際に、指定したコマンド名で復元する][*:復元の際に、引数は保持した状態でコマンド名で復元する]
 ## https://github.com/tmux-plugins/tmux-resurrect/blob/cff343cf9e81983d3da0c8562b01616f12e8d548/docs/restoring_programs.md#clarifications
-set -g @resurrect-processes '"~nvim -> nvim" "~make" "~docker" "~mise"'
+set -g @resurrect-processes '"~nvim -> nvim" "~make" "~docker" "~mise" "~pnpm"'
 ## restore vim session
 set -g @resurrect-strategy-vim 'session'
 set -g @resurrect-strategy-nvim 'session'

--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -249,7 +249,7 @@ set -g @plugin 'ryo246912/tmux-resurrect'
 set -g @resurrect-capture-pane-contents 'on'
 ## restore process [~:プロセス名が部分一致していたら、そのプロセスを復元する][->:復元の際に、指定したコマンド名で復元する][*:復元の際に、引数は保持した状態でコマンド名で復元する]
 ## https://github.com/tmux-plugins/tmux-resurrect/blob/cff343cf9e81983d3da0c8562b01616f12e8d548/docs/restoring_programs.md#clarifications
-set -g @resurrect-processes '"~vim -> vim" "~nvim -> nvim" "~make" "~docker"'
+set -g @resurrect-processes '"~vim -> vim" "~nvim -> nvim" "~make" "~docker" "~mise"'
 ## restore vim session
 set -g @resurrect-strategy-vim 'session'
 set -g @resurrect-strategy-nvim 'session'


### PR DESCRIPTION
## Summary

Updated the tmux-resurrect process restoration configuration to remove vim and add support for mise and pnpm tools.

## Changes

- Removed `"~vim -> vim"` from the resurrect-processes list (nvim is the primary editor)
- Added `"~mise"` to restore mise sessions
- Added `"~pnpm"` to restore pnpm sessions
- Kept `"~nvim -> nvim"`, `"~make"`, and `"~docker"` in the configuration

## Details

The `@resurrect-processes` setting controls which processes tmux-resurrect will restore when recovering a session. This update reflects the current development environment by:
- Removing the legacy vim entry (nvim is now the standard editor)
- Adding mise (version manager) to preserve active tool management sessions
- Adding pnpm (Node.js package manager) to restore package management contexts

https://claude.ai/code/session_014Po4Q9Z12YBbB89GNtMh8B

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the `tmux-resurrect` process restore list to remove `vim` and add `mise` and `pnpm` for better session recovery. `nvim`, `make`, and `docker` remain; `mise run` and `pnpm run` now restore with arguments.

<sup>Written for commit 1e600ab9110eb990860fd47adb35b111e1d7aa35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
tmux-resurrect の復元対象に `mise` と `pnpm` を追加し、旧来の `vim` を削除しました。`nvim`、`make`、`docker` は維持しています。

## 変更理由
現在の開発環境に合わせ、利用中のツールやセッションを tmux 復元対象へ反映するためです。

## 確認した項目
- `mise`、`pnpm` の復元設定が追加されていること
- `vim` の設定が削除され、`nvim` が維持されていること
- `make`、`docker` の設定が維持されていること

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the processes restored by tmux-resurrect.

- Removes the legacy Vim process entry.
- Adds process matching for mise and pnpm.
- Keeps Neovim, Make, and Docker restoration.

<h3>Confidence Score: 4/5</h3>

The mise and pnpm restoration entries need to preserve their original arguments before merging.

- Common commands such as `pnpm run dev` and `mise run <task>` restore as bare executables.
- Removing Vim while retaining Neovim matches the stated configuration change.

dot_config/tmux/tmux.conf

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| dot_config/tmux/tmux.conf | Updates the tmux-resurrect process list, but the new mise and pnpm entries do not preserve task arguments. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adot_config%2Ftmux%2Ftmux.conf%3A252%0A**Restored%20Tasks%20Lose%20Their%20Arguments**%0A%0AWhen%20a%20pane%20runs%20%60pnpm%20run%20dev%60%20or%20%60mise%20run%20%3Ctask%3E%60%2C%20the%20new%20%60~pnpm%60%20and%20%60~mise%60%20entries%20restore%20only%20the%20matched%20executable%20because%20they%20do%20not%20use%20the%20argument-preserving%20form.%20The%20restored%20pane%20runs%20bare%20%60pnpm%60%20or%20%60mise%60%20instead%20of%20restarting%20the%20original%20task.%0A%0A&repo=ryo246912%2Fdotfiles&pr=1153&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ryo246912%2Fdotfiles%22%20on%20the%20existing%20branch%20%22claude%2Ftmux-resurrection-mise-run-ukpha4%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Ftmux-resurrection-mise-run-ukpha4%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adot_config%2Ftmux%2Ftmux.conf%3A252%0A**Restored%20Tasks%20Lose%20Their%20Arguments**%0A%0AWhen%20a%20pane%20runs%20%60pnpm%20run%20dev%60%20or%20%60mise%20run%20%3Ctask%3E%60%2C%20the%20new%20%60~pnpm%60%20and%20%60~mise%60%20entries%20restore%20only%20the%20matched%20executable%20because%20they%20do%20not%20use%20the%20argument-preserving%20form.%20The%20restored%20pane%20runs%20bare%20%60pnpm%60%20or%20%60mise%60%20instead%20of%20restarting%20the%20original%20task.%0A%0A&repo=ryo246912%2Fdotfiles&pr=1153&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(tmux): pnpm runコマンドもresurrect復元対象に追..."](https://github.com/ryo246912/dotfiles/commit/1e600ab9110eb990860fd47adb35b111e1d7aa35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45805929)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/ryo/github/ryo246912/dotfiles/-/custom-context?memory=56ca1037-b626-4c46-a579-6fd3c3e6a2f8))

<!-- /greptile_comment -->