### PR TITLE
refactor: improve lefthook installation safety in mise hooks

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -132,4 +132,7 @@ bun = true
 uvx = true
 
 [hooks]
-enter = "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && lefthook install -f || true"
+enter = """
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+lefthook install
+"""

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -132,4 +132,4 @@ bun = true
 uvx = true
 
 [hooks]
-enter = "lefthook install -f"
+enter = "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && lefthook install -f || true"

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -133,6 +133,6 @@ uvx = true
 
 [hooks]
 enter = """
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+[ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] || exit 0
 lefthook install
 """

--- a/mise.toml
+++ b/mise.toml
@@ -20,4 +20,4 @@ includes = ["tasks/*.toml"]
 "npm:oxlint"                     = "1.74.0"
 
 [hooks]
-enter = "lefthook install -f"
+enter = "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && lefthook install -f || true"

--- a/mise.toml
+++ b/mise.toml
@@ -21,6 +21,6 @@ includes = ["tasks/*.toml"]
 
 [hooks]
 enter = """
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+[ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] || exit 0
 lefthook install
 """

--- a/mise.toml
+++ b/mise.toml
@@ -20,4 +20,7 @@ includes = ["tasks/*.toml"]
 "npm:oxlint"                     = "1.74.0"
 
 [hooks]
-enter = "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && lefthook install -f || true"
+enter = """
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+lefthook install
+"""


### PR DESCRIPTION
## Summary

Updated the `enter` hook configuration in both `dot_config/mise/config.toml` and `mise.toml` to safely handle lefthook installation across different contexts, including non-git directories.

## Changes

- **Conditional git repository check**: Added `git rev-parse --is-inside-work-tree` check that gracefully exits if not in a git repository, preventing errors in non-git contexts
- **Removed force flag**: Changed from `lefthook install -f` to `lefthook install` for cleaner installation behavior
- **Multi-line hook format**: Converted single-line hook to multi-line string format for better readability and maintainability

## Implementation Details

The hook now:
1. Checks if the current directory is inside a git work tree
2. Silently exits (exit code 0) if not in a git repository, allowing mise to continue without errors
3. Proceeds with standard lefthook installation if in a git repository

This change ensures that mise's `enter` hook doesn't fail when used in non-git contexts while maintaining proper lefthook setup in git repositories.

https://claude.ai/code/session_01QzvMLLHdTqw3mEsRfHPPpH

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Safely install `lefthook` from the `mise` enter hook only in real git work trees, avoiding errors in non-git and bare repositories. Also removes the forced install for cleaner behavior.

- **Bug Fixes**
  - Use output check: `[ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] || exit 0`
  - Replace `lefthook install -f` with `lefthook install`
  - Switch to multi-line hook; applied in `dot_config/mise/config.toml` and `mise.toml`

<sup>Written for commit 587c0da35e220fdd2355b6f1bf163aaeeb37acb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
`enter` フックをマルチライン化し、Git ワークツリー内でのみ `lefthook install` を実行するよう変更しました。

## 変更理由
Git リポジトリ外での不要なインストール処理や強制実行を避け、さまざまなコンテキストで安全に動作させるためです。

## 確認した項目
- Git リポジトリ外では正常終了してインストールしない
- Git リポジトリ内では `lefthook install` を実行する
- 強制オプション `-f` を削除
- `dot_config/mise/config.toml` と `mise.toml` の設定を統一

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the mise enter hooks skip Lefthook installation outside Git work trees. The main changes are:

- Adds a Git work-tree check to both mise configurations.
- Converts both hooks to multiline commands.
- Runs `lefthook install` without the force flag.

<h3>Confidence Score: 5/5</h3>

No additional blocking issue qualifies for this follow-up review.

- The changed hooks now skip installation outside Git work trees.
- No separate failure remains after the existing installation-conflict concern is addressed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| dot_config/mise/config.toml | Adds the work-tree guard and switches the deployed mise hook to unforced Lefthook installation. |
| mise.toml | Applies the same guarded Lefthook installation behavior to the repository-level mise configuration. |

<sub>Reviews (2): Last reviewed commit: ["fix: bare repositoryでもlefthook installが実..."](https://github.com/ryo246912/dotfiles/commit/587c0da35e220fdd2355b6f1bf163aaeeb37acb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45847718)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/ryo/github/ryo246912/dotfiles/-/custom-context?memory=56ca1037-b626-4c46-a579-6fd3c3e6a2f8))

<!-- /greptile_comment -->