### PR TITLE
chore: Add rulesync guide and enhance crit

### DIFF
--- a/.rulesync/rules/CLAUDE.md
+++ b/.rulesync/rules/CLAUDE.md
@@ -209,6 +209,8 @@ This repository treats personal development environment as code:
 ## Useful References
 
 - **docs/setup.md** - Detailed step-by-step setup instructions
+- **docs/rulesync.md** - How this repo's own `CLAUDE.md` and the global AI agent rules/skills (`~/.claude`, `~/.codex`, `~/.copilot`) are generated with rulesync
+- **docs/crit.md** - crit-based code review workflow inside the devcontainer
 - **README.md** - Repository overview and quick start
 - **mise.toml** - Complete list of managed tools and available tasks
 - **dot_config/zabrze/\*.toml** - All available command abbreviations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,8 @@ This repository treats personal development environment as code:
 ## Useful References
 
 - **docs/setup.md** - Detailed step-by-step setup instructions
+- **docs/rulesync.md** - How this repo's own `CLAUDE.md` and the global AI agent rules/skills (`~/.claude`, `~/.codex`, `~/.copilot`) are generated with rulesync
+- **docs/crit.md** - crit-based code review workflow inside the devcontainer
 - **README.md** - Repository overview and quick start
 - **mise.toml** - Complete list of managed tools and available tasks
 - **dot_config/zabrze/\*.toml** - All available command abbreviations

--- a/docs/crit.md
+++ b/docs/crit.md
@@ -7,13 +7,17 @@
 
 ## 構成
 
-| 項目         | 設定                                                    | 場所                                                      |
-| ------------ | ------------------------------------------------------- | --------------------------------------------------------- |
-| バイナリ     | `github:tomasz-tomczyk/crit` を mise で導入             | `dot_config/devcontainer/mise.toml`                       |
-| バインド先   | `CRIT_HOST=0.0.0.0` / `CRIT_PORT=7842`                  | `dot_config/devcontainer/devcontainer.json` (`remoteEnv`) |
-| ポート公開   | `appPort: 127.0.0.1:7842:7842` でホストへ publish       | `dot_config/devcontainer/devcontainer.json`               |
-| 自動起動抑止 | `CRIT_NO_UPDATE_CHECK=1`                                | `dot_config/devcontainer/devcontainer.json`               |
-| 動作設定     | `~/.crit.config.json` を生成（`no_open` / `agent_cmd`） | `dot_config/devcontainer/scripts/post-create.sh`          |
+| 項目         | 設定                                                        | 場所                                                      |
+| ------------ | ------------------------------------------------------------ | --------------------------------------------------------- |
+| バイナリ     | `github:tomasz-tomczyk/crit` を mise で導入                 | `dot_config/devcontainer/mise.toml`                       |
+| バインド先   | `CRIT_HOST=0.0.0.0` / `CRIT_PORT=7842`（デフォルト値）      | `dot_config/devcontainer/devcontainer.json` (`remoteEnv`) |
+| ポート公開   | `appPort: 127.0.0.1:7842:7842` でホストへ publish（デフォルト値） | `dot_config/devcontainer/devcontainer.json`               |
+| 自動起動抑止 | `CRIT_NO_UPDATE_CHECK=1`                                    | `dot_config/devcontainer/devcontainer.json`               |
+| 動作設定     | `~/.crit.config.json` を生成（`no_open` / `agent_cmd`）     | `dot_config/devcontainer/scripts/post-create.sh`          |
+
+`dot_config/devcontainer/devcontainer.json` はベーステンプレートで、`7842` は初期値。
+`multi-worktree create` / `recreate` でタスク用の devcontainer.json を生成する際は、
+このテンプレートをそのまま使わず、後述のとおり **タスクごとに空いているポートを動的に割り当てる**。
 
 `~/.crit.config.json` の内容:
 
@@ -36,17 +40,40 @@ crit            # git の変更を自動検出してレビュー
 crit plan.md    # 特定ファイルをレビュー
 ```
 
-起動すると `http://0.0.0.0:7842` で待ち受けます。`appPort` によりホストの `127.0.0.1:7842` へ
-publish されるため、ホストのブラウザから `http://localhost:7842` を開いてレビュー・コメントできます。
+起動すると `CRIT_PORT`（コンテナ内）で待ち受けます。`appPort` によりホストの同じポート番号へ
+publish されるため、ホストのブラウザから `http://localhost:<port>` を開いてレビュー・コメントできます。
 コメントを送るとエージェントへフィードバックされ、修正ループが回ります。
 
 > [!IMPORTANT]
 > ポート公開には **`appPort` を使う**。`forwardPorts` は VS Code 拡張専用で、`multi-worktree` の
 > `devcontainer up`（devcontainer CLI）では解釈されず publish されない（これが当初ホストから
 > 開けなかった原因）。
-> ホストポート `7842` を固定しているため、**devcontainer を同時に 2 つ以上起動するとポート衝突で
-> 2 つ目の `devcontainer up` が失敗**する。crit は 1 度に 1 レビューのため通常は単一コンテナ運用で問題ない。
-> 並列でタスクを回す場合は、対象タスクのコンテナだけを起動する。
+
+## タスクごとのポート割り当て（衝突回避）
+
+ホストポートを `7842` に固定していると、devcontainer を同時に2つ以上起動したときに
+`Bind for 127.0.0.1:7842 failed: port is already allocated` でぶつかる。これを避けるため、
+`multi-worktree create` / `recreate`（`generate_devcontainer` 関数）はタスクごとに
+**空いているポートを動的に探して割り当てる**。
+
+- `dot_config/devcontainer/devcontainer.json` の `appPort` (`127.0.0.1:7842:7842`) を
+  ベースに、`7842` から順に `/dev/tcp/<host>/<port>` で疎通確認しながら空きポートを探索する
+  （`find_free_host_port` 関数、`dot_local/bin/executable_multi-worktree`）
+- 見つかった port を **host 側・container 側の両方**、および `remoteEnv.CRIT_PORT` に反映する
+  （host port と container port を揃えることで、crit が出力する URL がそのままホストから開ける
+  ようにしている）
+- 生成時に `devcontainer.json を生成しました: ... (crit port: <port>)` とログ表示されるので、
+  タスクごとの実際のポートはそこ、または生成された `.devcontainer/devcontainer.json` の
+  `appPort` / `remoteEnv.CRIT_PORT` で確認できる
+- crit 単体を手動起動する場合（ベーステンプレートをそのまま使う単一コンテナ運用など）は、
+  従来どおり `7842` 固定のまま
+
+既存タスクが port 衝突で起動できない場合は、次のコマンドで devcontainer.json を再生成すれば
+新しい空きポートが割り当てられる。
+
+```bash
+multi-worktree recreate <task-name>
+```
 
 ## `/crit` skill（rulesync で配布）
 

--- a/docs/crit.md
+++ b/docs/crit.md
@@ -66,3 +66,16 @@ Claude Code では `/crit`、Codex では `$crit` で呼び出せます。
 > `crit` skill は `allowed-tools` に `Bash(crit:*)` を宣言しているため、`blockUnlistedCommands` 環境でも
 > skill 実行中は `crit` コマンドが許可されます。`user-invocable` / `argument-hint` は rulesync が
 > claudecode skill へ変換する際に落とされますが、動作には影響しません。
+
+## 再レビュー待ち通知
+
+1 ラウンド分のレビューコメントにエージェントが対応し終え、次の `crit` 呼び出しで再レビュー待ち
+（次の "Finish Review" 待ち）に入る直前、devcontainer からホストへ SSH 経由で通知を送ります。
+
+- 通知コマンド: `ssh -F ~/.config/ssh/config ... mac-host "macos-notify-cli --title 'crit' --message '再レビュー待ちです' ..."`
+- 使う SSH 接続は `dot_config/devcontainer/scripts/post-start.sh` が生成する `mac-host`
+  （`multi-worktree` のホスト通知と同じ仕組み・同じ鍵 `~/.ssh/id_docker_devcontainer` を利用）
+- 手順は `crit` skill（`dot_config/rulesync/exact_dot_rulesync/skills/crit/SKILL.md` の Step 5）に
+  記載。`allowed-tools` に `Bash(ssh:*)` を追加してあるため `blockUnlistedCommands` 環境でも実行できる
+- devcontainer 外（ホスト上で直接 `crit` を実行した場合など）では `mac-host` に SSH できず失敗するが、
+  レビューループを止めないようエラーは無視する

--- a/docs/crit.md
+++ b/docs/crit.md
@@ -7,13 +7,14 @@
 
 ## 構成
 
-| 項目         | 設定                                                    | 場所                                                      |
-| ------------ | ------------------------------------------------------- | --------------------------------------------------------- |
-| バイナリ     | `github:tomasz-tomczyk/crit` を mise で導入             | `dot_config/devcontainer/mise.toml`                       |
-| バインド先   | `CRIT_HOST=0.0.0.0` / `CRIT_PORT=7842`                  | `dot_config/devcontainer/devcontainer.json` (`remoteEnv`) |
-| ポート公開   | `appPort: 127.0.0.1:7842:7842` でホストへ publish       | `dot_config/devcontainer/devcontainer.json`               |
-| 自動起動抑止 | `CRIT_NO_UPDATE_CHECK=1`                                | `dot_config/devcontainer/devcontainer.json`               |
-| 動作設定     | `~/.crit.config.json` を生成（`no_open` / `agent_cmd`） | `dot_config/devcontainer/scripts/post-create.sh`          |
+| 項目         | 設定                                                        | 場所                                                      |
+| ------------ | ------------------------------------------------------------ | --------------------------------------------------------- |
+| バイナリ     | `github:tomasz-tomczyk/crit` を mise で導入                 | `dot_config/devcontainer/mise.toml`                       |
+| バインド先   | `CRIT_HOST=0.0.0.0` / `CRIT_PORT=7842`（コンテナ内は固定）  | `dot_config/devcontainer/devcontainer.json` (`remoteEnv`) |
+| ポート公開   | `appPort: 127.0.0.1::7842` でホストへ publish（host port は自動採番） | `dot_config/devcontainer/devcontainer.json`               |
+| 自動起動抑止 | `CRIT_NO_UPDATE_CHECK=1`                                    | `dot_config/devcontainer/devcontainer.json`               |
+| 動作設定     | `~/.crit.config.json` を生成（`no_open` / `agent_cmd`）     | `dot_config/devcontainer/scripts/post-create.sh`          |
+| ポート通知   | 割り当てられた host port を `~/.crit-host-port` に記録し、mac-host へ通知 | `dot_config/devcontainer/scripts/post-start.sh`           |
 
 `~/.crit.config.json` の内容:
 
@@ -36,17 +37,40 @@ crit            # git の変更を自動検出してレビュー
 crit plan.md    # 特定ファイルをレビュー
 ```
 
-起動すると `http://0.0.0.0:7842` で待ち受けます。`appPort` によりホストの `127.0.0.1:7842` へ
-publish されるため、ホストのブラウザから `http://localhost:7842` を開いてレビュー・コメントできます。
-コメントを送るとエージェントへフィードバックされ、修正ループが回ります。
+起動すると（コンテナ内は固定の）`http://0.0.0.0:7842` で待ち受けます。`appPort` によりホストへ
+publish されますが、host port は **`127.0.0.1::7842` として Docker に自動採番させている**ため、
+devcontainer を複数同時に起動してもポート衝突は起きません。実際に割り当てられた host port は
+`~/.crit-host-port` に記録されるので、ホストのブラウザではその番号で `http://localhost:<port>` を
+開いてレビュー・コメントします。コメントを送るとエージェントへフィードバックされ、修正ループが回ります。
 
 > [!IMPORTANT]
 > ポート公開には **`appPort` を使う**。`forwardPorts` は VS Code 拡張専用で、`multi-worktree` の
 > `devcontainer up`（devcontainer CLI）では解釈されず publish されない（これが当初ホストから
 > 開けなかった原因）。
-> ホストポート `7842` を固定しているため、**devcontainer を同時に 2 つ以上起動するとポート衝突で
-> 2 つ目の `devcontainer up` が失敗**する。crit は 1 度に 1 レビューのため通常は単一コンテナ運用で問題ない。
-> 並列でタスクを回す場合は、対象タスクのコンテナだけを起動する。
+
+## ポートの自動採番と通知
+
+以前は host port を `7842` に固定していたため、devcontainer を同時に2つ以上起動すると
+`Bind for 127.0.0.1:7842 failed: port is already allocated` で衝突していた。これを避けるため、
+`appPort` の host 側は指定せず(`127.0.0.1::7842`)、Docker に自動採番させている
+（`postCreateCommand` / `postStartCommand` が実行される**前**に Docker がポートを確定するため、
+コンテナ内のスクリプトから host port 自体を選ぶことはできない）。
+
+自動採番なので、実際に割り当てられた host port はコンテナの外（ホスト側）からしか分からない。
+そこで `post-start.sh` が起動のたびに次を行う。
+
+1. コンテナの `$HOSTNAME`（Docker のデフォルトで short container ID と一致）を使い、
+   `mac-host` へ SSH して `docker port "$HOSTNAME" 7842/tcp` を実行し、割り当てられた host port を取得
+2. 取得できたら `~/.crit-host-port` に書き込む
+3. `macos-notify-cli` でホストへ `crit UI: http://localhost:<port>` を通知する
+
+`multi-worktree` に限らず、この base template (`dot_config/devcontainer/devcontainer.json`) から
+起動する devcontainer であればどの経路（devcontainer CLI 直接、VS Code など）でも同じ仕組みが働く。
+devcontainer 外（`mac-host` に SSH できない環境）では静かにスキップされる。
+
+`/crit` skill（Step 2）は crit 自身が出力する URL をそのまま relay せず、`~/.crit-host-port` が
+あればそちらの port を優先して使う（crit が出力するのはコンテナ内固定の `7842` であり、ホストから
+実際に開ける port とは異なるため）。
 
 ## `/crit` skill（rulesync で配布）
 

--- a/docs/crit.md
+++ b/docs/crit.md
@@ -7,17 +7,13 @@
 
 ## 構成
 
-| 項目         | 設定                                                        | 場所                                                      |
-| ------------ | ------------------------------------------------------------ | --------------------------------------------------------- |
-| バイナリ     | `github:tomasz-tomczyk/crit` を mise で導入                 | `dot_config/devcontainer/mise.toml`                       |
-| バインド先   | `CRIT_HOST=0.0.0.0` / `CRIT_PORT=7842`（デフォルト値）      | `dot_config/devcontainer/devcontainer.json` (`remoteEnv`) |
-| ポート公開   | `appPort: 127.0.0.1:7842:7842` でホストへ publish（デフォルト値） | `dot_config/devcontainer/devcontainer.json`               |
-| 自動起動抑止 | `CRIT_NO_UPDATE_CHECK=1`                                    | `dot_config/devcontainer/devcontainer.json`               |
-| 動作設定     | `~/.crit.config.json` を生成（`no_open` / `agent_cmd`）     | `dot_config/devcontainer/scripts/post-create.sh`          |
-
-`dot_config/devcontainer/devcontainer.json` はベーステンプレートで、`7842` は初期値。
-`multi-worktree create` / `recreate` でタスク用の devcontainer.json を生成する際は、
-このテンプレートをそのまま使わず、後述のとおり **タスクごとに空いているポートを動的に割り当てる**。
+| 項目         | 設定                                                    | 場所                                                      |
+| ------------ | ------------------------------------------------------- | --------------------------------------------------------- |
+| バイナリ     | `github:tomasz-tomczyk/crit` を mise で導入             | `dot_config/devcontainer/mise.toml`                       |
+| バインド先   | `CRIT_HOST=0.0.0.0` / `CRIT_PORT=7842`                  | `dot_config/devcontainer/devcontainer.json` (`remoteEnv`) |
+| ポート公開   | `appPort: 127.0.0.1:7842:7842` でホストへ publish       | `dot_config/devcontainer/devcontainer.json`               |
+| 自動起動抑止 | `CRIT_NO_UPDATE_CHECK=1`                                | `dot_config/devcontainer/devcontainer.json`               |
+| 動作設定     | `~/.crit.config.json` を生成（`no_open` / `agent_cmd`） | `dot_config/devcontainer/scripts/post-create.sh`          |
 
 `~/.crit.config.json` の内容:
 
@@ -40,40 +36,17 @@ crit            # git の変更を自動検出してレビュー
 crit plan.md    # 特定ファイルをレビュー
 ```
 
-起動すると `CRIT_PORT`（コンテナ内）で待ち受けます。`appPort` によりホストの同じポート番号へ
-publish されるため、ホストのブラウザから `http://localhost:<port>` を開いてレビュー・コメントできます。
+起動すると `http://0.0.0.0:7842` で待ち受けます。`appPort` によりホストの `127.0.0.1:7842` へ
+publish されるため、ホストのブラウザから `http://localhost:7842` を開いてレビュー・コメントできます。
 コメントを送るとエージェントへフィードバックされ、修正ループが回ります。
 
 > [!IMPORTANT]
 > ポート公開には **`appPort` を使う**。`forwardPorts` は VS Code 拡張専用で、`multi-worktree` の
 > `devcontainer up`（devcontainer CLI）では解釈されず publish されない（これが当初ホストから
 > 開けなかった原因）。
-
-## タスクごとのポート割り当て（衝突回避）
-
-ホストポートを `7842` に固定していると、devcontainer を同時に2つ以上起動したときに
-`Bind for 127.0.0.1:7842 failed: port is already allocated` でぶつかる。これを避けるため、
-`multi-worktree create` / `recreate`（`generate_devcontainer` 関数）はタスクごとに
-**空いているポートを動的に探して割り当てる**。
-
-- `dot_config/devcontainer/devcontainer.json` の `appPort` (`127.0.0.1:7842:7842`) を
-  ベースに、`7842` から順に `/dev/tcp/<host>/<port>` で疎通確認しながら空きポートを探索する
-  （`find_free_host_port` 関数、`dot_local/bin/executable_multi-worktree`）
-- 見つかった port を **host 側・container 側の両方**、および `remoteEnv.CRIT_PORT` に反映する
-  （host port と container port を揃えることで、crit が出力する URL がそのままホストから開ける
-  ようにしている）
-- 生成時に `devcontainer.json を生成しました: ... (crit port: <port>)` とログ表示されるので、
-  タスクごとの実際のポートはそこ、または生成された `.devcontainer/devcontainer.json` の
-  `appPort` / `remoteEnv.CRIT_PORT` で確認できる
-- crit 単体を手動起動する場合（ベーステンプレートをそのまま使う単一コンテナ運用など）は、
-  従来どおり `7842` 固定のまま
-
-既存タスクが port 衝突で起動できない場合は、次のコマンドで devcontainer.json を再生成すれば
-新しい空きポートが割り当てられる。
-
-```bash
-multi-worktree recreate <task-name>
-```
+> ホストポート `7842` を固定しているため、**devcontainer を同時に 2 つ以上起動するとポート衝突で
+> 2 つ目の `devcontainer up` が失敗**する。crit は 1 度に 1 レビューのため通常は単一コンテナ運用で問題ない。
+> 並列でタスクを回す場合は、対象タスクのコンテナだけを起動する。
 
 ## `/crit` skill（rulesync で配布）
 

--- a/docs/crit.md
+++ b/docs/crit.md
@@ -14,7 +14,7 @@
 | ポート公開   | `appPort: 127.0.0.1::7842` でホストへ publish（host port は自動採番） | `dot_config/devcontainer/devcontainer.json`               |
 | 自動起動抑止 | `CRIT_NO_UPDATE_CHECK=1`                                    | `dot_config/devcontainer/devcontainer.json`               |
 | 動作設定     | `~/.crit.config.json` を生成（`no_open` / `agent_cmd`）     | `dot_config/devcontainer/scripts/post-create.sh`          |
-| ポート通知   | 割り当てられた host port を `~/.crit-host-port` に記録し、mac-host へ通知 | `dot_config/devcontainer/scripts/post-start.sh`           |
+| ポート通知   | 割り当てられた host port を `~/.crit-host-port` に記録し、mac-host へ通知 | `dot_config/devcontainer/scripts/executable_post-start.sh`（適用後: `post-start.sh`） |
 
 `~/.crit.config.json` の内容:
 

--- a/docs/rulesync.md
+++ b/docs/rulesync.md
@@ -1,0 +1,70 @@
+# rulesync
+
+[rulesync](https://github.com/dyoshikawa/rulesync) は、ルール・スキル・フック・MCP設定を単一のソースから
+Claude Code / Codex CLI / Copilot など複数の AI エージェント向け設定ファイルへ変換して配布する CLI ツールです。
+
+このリポジトリには **2つの独立した rulesync 設定** があります。混同すると `generate` が失敗するので、
+役割の違いを区別してください。
+
+## 2つのスコープ
+
+| スコープ         | 設定ファイル                          | ソース (`.rulesync` 相当)                       | 生成先                                                                | 用途                                                       |
+| ---------------- | -------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------- | ------------------------------------------------------------ |
+| プロジェクト単位 | `rulesync.jsonc`（リポジトリ直下）      | `.rulesync/`（リポジトリ直下）                    | リポジトリ直下（`outputRoots: ["."]`）                                  | **このリポジトリ自身**の `CLAUDE.md` を生成する自己参照的な設定 |
+| グローバル       | `dot_config/rulesync/rulesync.jsonc`   | `dot_config/rulesync/exact_dot_rulesync/`         | `~/.claude/`, `~/.codex/`, `~/.copilot/` など（`global: true` により実ホームへ書き込み） | どのプロジェクトでも使える skill / rule / hooks / MCP 設定の配布 |
+
+- プロジェクト単位の設定が生成するのは、あなたが今読んでいる **この `CLAUDE.md` そのもの**です。
+  ソースは `.rulesync/rules/CLAUDE.md` で、ここを編集して `rulesync generate` すると `CLAUDE.md` に反映されます。
+  `CLAUDE.md` を直接編集しても次の `generate` で上書きされるので注意してください。
+- グローバル設定は chezmoi で `~/.config/rulesync/` 配下に配布されます。
+  - `dot_config/rulesync/rulesync.jsonc` → `~/.config/rulesync/rulesync.jsonc`
+  - `dot_config/rulesync/exact_dot_rulesync/` → `~/.config/rulesync/.rulesync/`
+    （`exact_` のため、chezmoi 管理外のファイルは `apply` 時に削除される）
+  - `rulesync.jsonc` の `"global": true` により、`~/.config/rulesync` から実行しても出力は
+    カレントディレクトリではなく実際の `$HOME` 配下（`~/.claude/skills/...` 等）に書き込まれる
+  - ここに `/crit` などの skill（`dot_config/rulesync/exact_dot_rulesync/skills/`）や
+    共通ルール（`dot_config/rulesync/exact_dot_rulesync/rules/COMMON.md`）、hooks
+    （`dot_config/rulesync/exact_dot_rulesync/hooks.json`）が入っている
+
+## 生成コマンド
+
+```bash
+mise run rulesync:generate
+```
+
+`dot_config/mise/tasks/dev.toml` で以下の2ステップを実行します。
+
+```toml
+run = [
+    "cd \"$(chezmoi source-path)\" && rulesync generate",
+    "cd ~/.config/rulesync && rulesync generate",
+]
+```
+
+1. **プロジェクト単位**: `chezmoi source-path`（= このリポジトリのソースディレクトリ）へ `cd` してから実行。
+   `mise run` をどのディレクトリから叩いても解決できるよう明示的に `cd` している。
+2. **グローバル**: `~/.config/rulesync` へ `cd` してから実行。
+
+> [!IMPORTANT]
+> グローバル側は **`chezmoi apply` 済みであること**が前提です。`~/.config/rulesync/.rulesync/`
+> は chezmoi が生成するディレクトリなので、`chezmoi apply` 前は存在せず
+> `.rulesync directory not found. Run 'rulesync init' first.` で失敗します。
+> 新しいマシンや `dot_config/rulesync/` を編集した直後は、先に `chezmoi apply` してから
+> `mise run rulesync:generate` を実行してください。
+
+## トラブルシューティング
+
+### `.rulesync directory not found. Run 'rulesync init' first.`
+
+`rulesync generate` は **カレントディレクトリ**の `rulesync.jsonc` / `.rulesync/` しか見ません。
+以下のいずれかが原因です。
+
+- `~/.config/rulesync/.rulesync/` が存在しない → `chezmoi apply` を実行する
+- `mise run rulesync:generate` 以外の方法（直接 `rulesync generate` をどこかのディレクトリで実行）で
+  呼び出した → プロジェクト単位なら `chezmoi cd`、グローバルなら `cd ~/.config/rulesync` してから実行する
+
+### `'baseDirs' config field is deprecated; use 'outputRoots' instead.`
+
+`rulesync.jsonc` に古い `baseDirs` フィールドが残っている場合に出る警告です。このリポジトリの
+`rulesync.jsonc` / `dot_config/rulesync/rulesync.jsonc` は `outputRoots` へ移行済みなので、
+この警告が出る場合はリポジトリが最新でない（`chezmoi apply` 前、または `git pull` 前）可能性が高いです。

--- a/dot_config/devcontainer/devcontainer.json
+++ b/dot_config/devcontainer/devcontainer.json
@@ -23,8 +23,11 @@
   // crit のレビューUIをホストのブラウザから開けるようにポートを公開する。
   // multi-worktree は devcontainer CLI (`devcontainer up`) で起動するが、CLI は forwardPorts を
   // 解釈しない(VS Code拡張専用)ため、実際に publish される appPort (= docker run -p) を使う。
-  // ホストの loopback のみに束縛する。
-  "appPort": ["127.0.0.1:7842:7842"],
+  // ホストの loopback のみに束縛する。host port は固定せず Docker に自動採番させる
+  // (devcontainer を複数同時起動してもポート衝突が起きないようにするため)。
+  // 実際に割り当てられた host port は post-start.sh が ~/.crit-host-port に書き出し、
+  // ホストへ通知する（docs/crit.md 参照）。
+  "appPort": ["127.0.0.1::7842"],
   // localWorkspaceFolder: ホスト側の作業ディレクトリ(.git/wk/{project}-{branch})を指す
   // "workspaceFolder": "${localWorkspaceFolder}",
   "mounts": [

--- a/dot_config/devcontainer/scripts/executable_post-start.sh
+++ b/dot_config/devcontainer/scripts/executable_post-start.sh
@@ -21,3 +21,22 @@ fi
 # mise trust を実行
 mise trust
 echo "✓ mise trust を実行しました"
+
+# crit の appPort (127.0.0.1::7842) は host port を Docker に自動採番させているため、
+# 実際に割り当てられた port を mac-host 経由の `docker port` で調べ、
+# ~/.crit-host-port に記録した上でホストへ通知する（devcontainer を複数同時起動しても
+# ポート衝突が起きないようにするため。詳細は docs/crit.md 参照）。
+# HOSTNAME はコンテナの short ID（Docker のデフォルトのホスト名）と一致する。
+CRIT_HOST_PORT_FILE=~/.crit-host-port
+CRIT_HOST_PORT=$(ssh -F ~/.config/ssh/config -o ConnectTimeout=2 -o StrictHostKeyChecking=no mac-host \
+	"docker port '${HOSTNAME}' 7842/tcp" 2>/dev/null | tail -n1 | sed -E 's/.*://') || true
+
+if [ -n "${CRIT_HOST_PORT:-}" ]; then
+	echo "$CRIT_HOST_PORT" >"$CRIT_HOST_PORT_FILE"
+	ssh -F ~/.config/ssh/config -o ConnectTimeout=2 -o StrictHostKeyChecking=no mac-host \
+		"macos-notify-cli --title 'crit' --message 'crit UI: http://localhost:${CRIT_HOST_PORT}' --sound Glass" \
+		2>/dev/null || true
+	echo "✓ crit の host port (${CRIT_HOST_PORT}) を ${CRIT_HOST_PORT_FILE} に記録し、ホストへ通知しました"
+else
+	echo "ℹ️ crit の host port 取得をスキップしました（devcontainer 外、または mac-host に接続できない環境）"
+fi

--- a/dot_config/devcontainer/scripts/executable_post-start.sh
+++ b/dot_config/devcontainer/scripts/executable_post-start.sh
@@ -27,13 +27,30 @@ echo "✓ mise trust を実行しました"
 # ~/.crit-host-port に記録した上でホストへ通知する（devcontainer を複数同時起動しても
 # ポート衝突が起きないようにするため。詳細は docs/crit.md 参照）。
 # HOSTNAME はコンテナの short ID（Docker のデフォルトのホスト名）と一致する。
+#
+# SSH オプションについて:
+# - BatchMode=yes: 鍵認証が使えない場合にパスワード入力待ちで固まらないようにする
+# - StrictHostKeyChecking は指定しない: ~/.config/ssh/config の mac-host 側で
+#   accept-new を設定済みのため、ここで no を指定すると host key の変更検知が無効化されてしまう
+# - timeout でラップ: ConnectTimeout は接続確立までしかカバーしないため、接続後に
+#   リモートコマンドが固まった場合に備える
 CRIT_HOST_PORT_FILE=~/.crit-host-port
-CRIT_HOST_PORT=$(ssh -F ~/.config/ssh/config -o ConnectTimeout=2 -o StrictHostKeyChecking=no mac-host \
-	"docker port '${HOSTNAME}' 7842/tcp" 2>/dev/null | tail -n1 | sed -E 's/.*://') || true
+SSH_OPTS=(-F ~/.config/ssh/config -o BatchMode=yes -o ConnectTimeout=2)
 
-if [ -n "${CRIT_HOST_PORT:-}" ]; then
+# docker port の取得はネットワークの一時的な不調で失敗することがあるため数回リトライする。
+# （再起動直後で docker port さえ引ければ port 番号自体は同一コンテナである限り変わらないため、
+# 一時的な失敗で ~/.crit-host-port を消して有効なキャッシュを失わないようにする）
+CRIT_HOST_PORT=""
+for _ in 1 2; do
+	CRIT_HOST_PORT=$(timeout 5 ssh "${SSH_OPTS[@]}" mac-host \
+		"docker port '${HOSTNAME}' 7842/tcp" 2>/dev/null | tail -n1 | sed -E 's/.*://') || true
+	[ -n "$CRIT_HOST_PORT" ] && break
+	sleep 1
+done
+
+if [ -n "$CRIT_HOST_PORT" ]; then
 	echo "$CRIT_HOST_PORT" >"$CRIT_HOST_PORT_FILE"
-	ssh -F ~/.config/ssh/config -o ConnectTimeout=2 -o StrictHostKeyChecking=no mac-host \
+	timeout 5 ssh "${SSH_OPTS[@]}" mac-host \
 		"macos-notify-cli --title 'crit' --message 'crit UI: http://localhost:${CRIT_HOST_PORT}' --sound Glass" \
 		2>/dev/null || true
 	echo "✓ crit の host port (${CRIT_HOST_PORT}) を ${CRIT_HOST_PORT_FILE} に記録し、ホストへ通知しました"

--- a/dot_config/devcontainer/scripts/executable_post-start.sh
+++ b/dot_config/devcontainer/scripts/executable_post-start.sh
@@ -38,5 +38,6 @@ if [ -n "${CRIT_HOST_PORT:-}" ]; then
 		2>/dev/null || true
 	echo "✓ crit の host port (${CRIT_HOST_PORT}) を ${CRIT_HOST_PORT_FILE} に記録し、ホストへ通知しました"
 else
+	rm -f "$CRIT_HOST_PORT_FILE"
 	echo "ℹ️ crit の host port 取得をスキップしました（devcontainer 外、または mac-host に接続できない環境）"
 fi

--- a/dot_config/mise/tasks/dev.toml
+++ b/dot_config/mise/tasks/dev.toml
@@ -2,7 +2,7 @@
 description = "Generate all rulesync outputs after chezmoi apply"
 # rulesync generate はカレントディレクトリの rulesync.jsonc / .rulesync を見るため、
 # どこから `mise run` しても解決できるよう明示的に cd する。
-# - 1つ目: このリポジトリ自身の CLAUDE.md / AGENTS.md を再生成（chezmoi source-path で解決）
+# - 1つ目: このリポジトリ自身の CLAUDE.md を再生成（chezmoi source-path で解決）
 # - 2つ目: グローバル配布用（~/.claude, ~/.codex, ~/.copilot 等）を再生成
 run = [
     "cd \"$(chezmoi source-path)\" && rulesync generate",

--- a/dot_config/mise/tasks/dev.toml
+++ b/dot_config/mise/tasks/dev.toml
@@ -1,3 +1,10 @@
 ["rulesync:generate"]
 description = "Generate all rulesync outputs after chezmoi apply"
-run         = ["rulesync generate", "cd ~/.config/rulesync && rulesync generate"]
+# rulesync generate はカレントディレクトリの rulesync.jsonc / .rulesync を見るため、
+# どこから `mise run` しても解決できるよう明示的に cd する。
+# - 1つ目: このリポジトリ自身の CLAUDE.md / AGENTS.md を再生成（chezmoi source-path で解決）
+# - 2つ目: グローバル配布用（~/.claude, ~/.codex, ~/.copilot 等）を再生成
+run = [
+    "cd \"$(chezmoi source-path)\" && rulesync generate",
+    "cd ~/.config/rulesync && rulesync generate",
+]

--- a/dot_config/rulesync/exact_dot_rulesync/skills/crit/SKILL.md
+++ b/dot_config/rulesync/exact_dot_rulesync/skills/crit/SKILL.md
@@ -49,7 +49,10 @@ crit               # git mode
 
 If a crit server is already running from earlier in this conversation, `crit` automatically connects to it. Starting from scratch, it spawns the daemon, opens the browser, and blocks until the user clicks "Finish Review".
 
-`crit` prints the review URL on startup (e.g. `Started crit daemon at http://localhost:<port>`). Relay it verbatim:
+`crit` prints the review URL on startup (e.g. `Started crit daemon at http://localhost:<port>`), but inside the devcontainer that port is the **container-internal** port — the host's Docker publishes it on a different, dynamically-assigned port (see `dot_config/devcontainer/devcontainer.json`'s `appPort`). Before relaying the URL, Read `~/.crit-host-port` (written by `post-start.sh`):
+
+- If it exists, use **that** port number instead of the one crit printed.
+- If it doesn't exist (not running in the devcontainer, or on the host directly), relay crit's printed URL as-is.
 
 > **"Crit is open at http://localhost:<port>. Leave inline comments, then click Finish Review."**
 

--- a/dot_config/rulesync/exact_dot_rulesync/skills/crit/SKILL.md
+++ b/dot_config/rulesync/exact_dot_rulesync/skills/crit/SKILL.md
@@ -103,10 +103,10 @@ The finish prompt on stdout includes the command to run again — use it to star
 Before relaunching `crit`, notify the host that a re-review is waiting (crit runs inside a devcontainer, so the reviewer is on the host machine and won't otherwise see that the diff is ready again):
 
 ```bash
-ssh -F ~/.config/ssh/config -o ConnectTimeout=2 -o StrictHostKeyChecking=no mac-host "macos-notify-cli --title 'crit' --message '再レビュー待ちです' --sound Glass"
+timeout 5 ssh -F ~/.config/ssh/config -o BatchMode=yes -o ConnectTimeout=2 mac-host "macos-notify-cli --title 'crit' --message '再レビュー待ちです' --sound Glass" || true
 ```
 
-This only works inside the devcontainer (it relies on the `mac-host` SSH entry from `~/.config/ssh/config`, set up by `post-start.sh`). If it fails — e.g. you're not running in the devcontainer, or the host isn't reachable — ignore the error and continue; it must never block the review loop.
+This only works inside the devcontainer (it relies on the `mac-host` SSH entry from `~/.config/ssh/config`, set up by `post-start.sh`). If it fails — e.g. you're not running in the devcontainer, or the host isn't reachable — ignore the error and continue; it must never block the review loop. The outer `timeout` and `|| true` guard against a hung SSH session or remote command blocking the loop; `ConnectTimeout` alone only bounds the initial connection.
 
 On subsequent calls, `crit` automatically signals round-complete first, then blocks until the next "Finish Review" click.
 

--- a/dot_config/rulesync/exact_dot_rulesync/skills/crit/SKILL.md
+++ b/dot_config/rulesync/exact_dot_rulesync/skills/crit/SKILL.md
@@ -9,6 +9,7 @@ claudecode:
   allowed-tools:
     - "Bash(crit:*)"
     - "Bash(command ls:*)"
+    - "Bash(ssh:*)"
     - Read
     - Edit
     - Glob
@@ -95,6 +96,14 @@ echo '[
 **CRITICAL — you MUST run this step. Do NOT skip it. Do NOT proceed without it.**
 
 The finish prompt on stdout includes the command to run again — use it to start a new round.
+
+Before relaunching `crit`, notify the host that a re-review is waiting (crit runs inside a devcontainer, so the reviewer is on the host machine and won't otherwise see that the diff is ready again):
+
+```bash
+ssh -F ~/.config/ssh/config -o ConnectTimeout=2 -o StrictHostKeyChecking=no mac-host "macos-notify-cli --title 'crit' --message '再レビュー待ちです' --sound Glass"
+```
+
+This only works inside the devcontainer (it relies on the `mac-host` SSH entry from `~/.config/ssh/config`, set up by `post-start.sh`). If it fails — e.g. you're not running in the devcontainer, or the host isn't reachable — ignore the error and continue; it must never block the review loop.
 
 On subsequent calls, `crit` automatically signals round-complete first, then blocks until the next "Finish Review" click.
 

--- a/dot_local/bin/executable_multi-worktree
+++ b/dot_local/bin/executable_multi-worktree
@@ -879,6 +879,26 @@ cmd_create() {
     fi
 }
 
+# 指定ホスト・ポートから開始して、空いているポートを探す（crit の appPort 衝突回避用）
+find_free_host_port() {
+    local host_ip="$1"
+    local start_port="$2"
+    local max_port=$((start_port + 1000))
+
+    local port="$start_port"
+    while [[ $port -le $max_port ]]; do
+        # サブシェル内で開くので fd 3 は親シェルに残らない
+        if ! (exec 3<>"/dev/tcp/${host_ip}/${port}") 2>/dev/null; then
+            echo "$port"
+            return 0
+        fi
+        port=$((port + 1))
+    done
+
+    log_error "空きポートが見つかりませんでした (${start_port}-${max_port})"
+    return 1
+}
+
 # devcontainer.json の生成
 generate_devcontainer() {
     local task_name="$1"
@@ -950,24 +970,45 @@ generate_devcontainer() {
 
     worktree_mounts+="]"
 
-    # jq を使ってベーステンプレートを読み込み、マウント設定を追加
-    # JSONCのコメントを除去してからjqでパース
-    if command -v jq &>/dev/null; then
-        # // で始まる行コメントを除去（文字列内の // は保護）
-        grep -v '^\s*//' "$base_template" | sed 's|^[[:space:]]*//.*||' | \
-        jq --argjson new_mounts "$worktree_mounts" \
-           --arg workspace_folder "/workspaces/${worktree_name}" \
-           --arg task_name "$task_name" \
-           '.mounts += $new_mounts |
-            .workspaceFolder = $workspace_folder |
-            .name = "Multi-worktree: " + $task_name' \
-           > "$devcontainer_file"
-    else
+    if ! command -v jq &>/dev/null; then
         log_error "jq コマンドが見つかりません。インストールしてください: mise install jq"
         return 1
     fi
 
-    log_success "devcontainer.json を生成しました: $devcontainer_file"
+    # JSONCのコメントを除去してからjqでパース
+    local base_template_json
+    base_template_json=$(grep -v '^\s*//' "$base_template" | sed 's|^[[:space:]]*//.*||')
+
+    # ベーステンプレートの appPort (例: "127.0.0.1:7842:7842") から host_ip と探索開始ポートを取得し、
+    # タスクごとに空いている port を割り当てる（複数 devcontainer 同時起動時のポート衝突を回避）。
+    # crit が出力する URL とホストからの接続先を一致させるため、host port と container port は
+    # 同じ値にそろえる（CRIT_PORT もこのポートに合わせて上書きする）。
+    local base_app_port
+    base_app_port=$(echo "$base_template_json" | jq -r '.appPort[0] // empty')
+    local host_ip="127.0.0.1"
+    local start_port="7842"
+    if [[ -n "$base_app_port" ]]; then
+        host_ip="${base_app_port%%:*}"
+        start_port="${base_app_port##*:}"
+    fi
+
+    local port
+    port=$(find_free_host_port "$host_ip" "$start_port") || return 1
+
+    echo "$base_template_json" | \
+    jq --argjson new_mounts "$worktree_mounts" \
+       --arg workspace_folder "/workspaces/${worktree_name}" \
+       --arg task_name "$task_name" \
+       --arg app_port "${host_ip}:${port}:${port}" \
+       --arg crit_port "$port" \
+       '.mounts += $new_mounts |
+        .workspaceFolder = $workspace_folder |
+        .name = "Multi-worktree: " + $task_name |
+        .appPort = [$app_port] |
+        .remoteEnv.CRIT_PORT = $crit_port' \
+       > "$devcontainer_file"
+
+    log_success "devcontainer.json を生成しました: $devcontainer_file (crit port: ${port})"
 }
 
 write_claude_settings_file() {

--- a/dot_local/bin/executable_multi-worktree
+++ b/dot_local/bin/executable_multi-worktree
@@ -879,26 +879,6 @@ cmd_create() {
     fi
 }
 
-# 指定ホスト・ポートから開始して、空いているポートを探す（crit の appPort 衝突回避用）
-find_free_host_port() {
-    local host_ip="$1"
-    local start_port="$2"
-    local max_port=$((start_port + 1000))
-
-    local port="$start_port"
-    while [[ $port -le $max_port ]]; do
-        # サブシェル内で開くので fd 3 は親シェルに残らない
-        if ! (exec 3<>"/dev/tcp/${host_ip}/${port}") 2>/dev/null; then
-            echo "$port"
-            return 0
-        fi
-        port=$((port + 1))
-    done
-
-    log_error "空きポートが見つかりませんでした (${start_port}-${max_port})"
-    return 1
-}
-
 # devcontainer.json の生成
 generate_devcontainer() {
     local task_name="$1"
@@ -970,45 +950,24 @@ generate_devcontainer() {
 
     worktree_mounts+="]"
 
-    if ! command -v jq &>/dev/null; then
+    # jq を使ってベーステンプレートを読み込み、マウント設定を追加
+    # JSONCのコメントを除去してからjqでパース
+    if command -v jq &>/dev/null; then
+        # // で始まる行コメントを除去（文字列内の // は保護）
+        grep -v '^\s*//' "$base_template" | sed 's|^[[:space:]]*//.*||' | \
+        jq --argjson new_mounts "$worktree_mounts" \
+           --arg workspace_folder "/workspaces/${worktree_name}" \
+           --arg task_name "$task_name" \
+           '.mounts += $new_mounts |
+            .workspaceFolder = $workspace_folder |
+            .name = "Multi-worktree: " + $task_name' \
+           > "$devcontainer_file"
+    else
         log_error "jq コマンドが見つかりません。インストールしてください: mise install jq"
         return 1
     fi
 
-    # JSONCのコメントを除去してからjqでパース
-    local base_template_json
-    base_template_json=$(grep -v '^\s*//' "$base_template" | sed 's|^[[:space:]]*//.*||')
-
-    # ベーステンプレートの appPort (例: "127.0.0.1:7842:7842") から host_ip と探索開始ポートを取得し、
-    # タスクごとに空いている port を割り当てる（複数 devcontainer 同時起動時のポート衝突を回避）。
-    # crit が出力する URL とホストからの接続先を一致させるため、host port と container port は
-    # 同じ値にそろえる（CRIT_PORT もこのポートに合わせて上書きする）。
-    local base_app_port
-    base_app_port=$(echo "$base_template_json" | jq -r '.appPort[0] // empty')
-    local host_ip="127.0.0.1"
-    local start_port="7842"
-    if [[ -n "$base_app_port" ]]; then
-        host_ip="${base_app_port%%:*}"
-        start_port="${base_app_port##*:}"
-    fi
-
-    local port
-    port=$(find_free_host_port "$host_ip" "$start_port") || return 1
-
-    echo "$base_template_json" | \
-    jq --argjson new_mounts "$worktree_mounts" \
-       --arg workspace_folder "/workspaces/${worktree_name}" \
-       --arg task_name "$task_name" \
-       --arg app_port "${host_ip}:${port}:${port}" \
-       --arg crit_port "$port" \
-       '.mounts += $new_mounts |
-        .workspaceFolder = $workspace_folder |
-        .name = "Multi-worktree: " + $task_name |
-        .appPort = [$app_port] |
-        .remoteEnv.CRIT_PORT = $crit_port' \
-       > "$devcontainer_file"
-
-    log_success "devcontainer.json を生成しました: $devcontainer_file (crit port: ${port})"
+    log_success "devcontainer.json を生成しました: $devcontainer_file"
 }
 
 write_claude_settings_file() {


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the rulesync configuration system and significantly enhances the crit code review workflow documentation. It also implements automatic host port detection and notification for crit when running multiple devcontainers simultaneously.

## Key Changes

### New Documentation
- **docs/rulesync.md** - Complete guide explaining:
  - Two independent rulesync scopes (project-level and global)
  - How `CLAUDE.md` is generated from `.rulesync/rules/CLAUDE.md`
  - How global AI agent rules/skills are distributed to `~/.claude`, `~/.codex`, `~/.copilot`
  - Generation workflow with `mise run rulesync:generate`
  - Troubleshooting common errors

### Enhanced crit Documentation (docs/crit.md)
- Clarified that container port (7842) is fixed, but host port is dynamically assigned
- Added detailed explanation of port auto-numbering mechanism
- Documented the new `post-start.sh` notification system
- Added section on re-review wait notifications via SSH
- Updated table with new "ポート通知" (port notification) row

### Implementation Changes

**devcontainer Configuration:**
- Changed `appPort` from fixed `127.0.0.1:7842:7842` to dynamic `127.0.0.1::7842`
- Allows multiple devcontainers to run simultaneously without port conflicts

**post-start.sh Script:**
- Added logic to query actual host port via `docker port` command through SSH to mac-host
- Records assigned port in `~/.crit-host-port`
- Sends macOS notification to host with the actual crit UI URL
- Gracefully handles failures when not in devcontainer or mac-host unreachable

**crit Skill (SKILL.md):**
- Added `Bash(ssh:*)` to `allowed-tools` for re-review notifications
- Updated Step 2 to check `~/.crit-host-port` before relaying crit's printed URL
- Added Step 5 documentation for sending re-review wait notifications to host
- Clarified that SSH notifications only work inside devcontainer and should fail gracefully

**mise Task Configuration:**
- Enhanced `rulesync:generate` task with explicit `cd` commands
- Added detailed comments explaining why explicit directory changes are needed
- Ensures task works correctly regardless of where `mise run` is invoked from

### Updated References
- Added links to new docs/rulesync.md and docs/crit.md in CLAUDE.md and .rulesync/rules/CLAUDE.md

https://claude.ai/code/session_01Eih4NiFoRNkVKaPChkYW7M

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a complete `rulesync` guide and upgrades the `crit` review docs. Moves `crit` in the `devcontainer` to a dynamically assigned host port with macOS notifications, and hardens SSH notifications and port discovery to be safe and non-blocking.

- **New Features**
  - Dynamic host port publishing for `crit` (`appPort` → `127.0.0.1::7842`) with auto-discovery in `post-start.sh`; saves to `~/.crit-host-port` and notifies the host with the `crit` URL.
  - Re-review wait notification from the `devcontainer` to the host via SSH; `Bash(ssh:*)` added to `allowed-tools` and used in the `/crit` skill.
  - New `docs/rulesync.md` covering project vs global scopes, `mise run rulesync:generate`, and troubleshooting; cross-links added from `CLAUDE.md`.
  - `docs/crit.md` expanded with dynamic port behavior, the auto-numbering mechanism, and the new notification flow.

- **Bug Fixes**
  - Removes host port collisions when multiple `devcontainer`s run.
  - `mise run rulesync:generate` works from any directory by `cd`-ing to the correct roots before running `rulesync generate`.
  - Host port discovery in `post-start.sh` adds a retry and wraps SSH in `timeout`; uses `-o BatchMode=yes` and drops `-o StrictHostKeyChecking=no` to avoid hangs and keep host key checks intact.
  - Clears stale `~/.crit-host-port` when discovery ultimately fails, ensuring the `/crit` skill falls back to `crit`’s printed URL instead of pointing to an old port.
  - Documentation and comments corrected: reference `executable_post-start.sh` in `docs/crit.md`, and clean up `dev.toml` task comments.

<sup>Written for commit 65a9ff6e65de7b6dd0e06aa5b4f49d5a157463d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
- rulesync の設定スコープ、生成手順、トラブルシューティングを `docs/rulesync.md` に追加
- crit の devcontainer 利用手順、動的ポート割り当て、再レビュー通知を更新
- Docker のホストポート自動割り当てと、割り当てポートの検出・通知処理を追加
- `rulesync:generate` を任意の作業ディレクトリから実行できるよう改善
- 関連する AI エージェント向け参照リンクと crit スキルを更新

## 変更理由
- devcontainer や複数ワークツリー間でのポート競合を避け、crit UI を安定して利用できるようにするため
- rulesync のプロジェクト用・グローバル設定の役割と運用方法を明確化するため
- レビュー再開時のホスト通知を自動化し、レビューループの連携を改善するため

## 確認した項目
- devcontainer のポート設定と起動後のポート検出・通知処理の整合性
- crit スキルの動的ポート利用および再レビュー通知手順
- rulesync の生成手順、設定スコープ、トラブルシューティングの記載
- `CLAUDE.md` と `.rulesync/rules/CLAUDE.md` の参照リンク更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR documents the rulesync and crit workflows and supports multiple concurrent devcontainers. The main changes are:

- Dynamically assigned host ports for the crit UI.
- Host-port discovery, caching, cleanup, and macOS notifications.
- Updated crit skill instructions for host URLs and re-review notifications.
- Explicit working directories for rulesync generation.
- New rulesync documentation and expanded crit documentation.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Failed port lookups now remove the cached value, preventing the crit skill from using an old host port.
- Successful lookups replace the cached value before it is consumed.
- No blocking issue remains in the changed workflow.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| dot_config/devcontainer/scripts/executable_post-start.sh | Adds bounded host-port lookup retries and removes the cached port when lookup fails. |
| dot_config/devcontainer/devcontainer.json | Changes crit from a fixed host port to a dynamically assigned loopback port. |
| dot_config/rulesync/exact_dot_rulesync/skills/crit/SKILL.md | Uses the discovered host port and adds bounded host notifications before re-review. |
| dot_config/mise/tasks/dev.toml | Runs each rulesync generation step from its intended configuration directory. |
| docs/rulesync.md | Documents project and global rulesync scopes, generation, and troubleshooting. |
| docs/crit.md | Documents dynamic port assignment, discovery, and review notifications. |

<sub>Reviews (3): Last reviewed commit: ["fix(devcontainer): SSH通知のハング・セキュリティ・ドキュメ..."](https://github.com/ryo246912/dotfiles/commit/65a9ff6e65de7b6dd0e06aa5b4f49d5a157463d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45863924)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/ryo/github/ryo246912/dotfiles/-/custom-context?memory=56ca1037-b626-4c46-a579-6fd3c3e6a2f8))

<!-- /greptile_comment -->