### PR TITLE
Add rulesync:generate hook to chezmoi apply workflow

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -62,6 +62,32 @@ if [ "$(cat "$state_dir/mise-config-hash" 2>/dev/null)" != "$mise_hash" ]; then
   GITHUB_TOKEN=$github_token mise install --jobs=2 || exit 1
   echo "$mise_hash" > "$state_dir/mise-config-hash"
 fi
+# 3) rulesync generate: AI エージェント設定（このリポジトリの CLAUDE.md と
+#    ~/.claude, ~/.codex, ~/.copilot 等）を再生成する。グローバル側は
+#    ~/.config/rulesync/.rulesync/ が chezmoi apply 済みであることが前提のため、
+#    apply 直後のこの位置で実行する。毎回の apply で無駄に generate しないよう、
+#    rulesync のソース（プロジェクト直下の .rulesync/ + rulesync.jsonc、および
+#    グローバルの ~/.config/rulesync/）に差分があるときだけハッシュマーカーで判定して走らせる。
+#    hook は chezmoi を再帰呼び出しせず済むよう source ディレクトリは CHEZMOI_SOURCE_DIR を使う。
+source_dir="${CHEZMOI_SOURCE_DIR:-$HOME/.local/share/chezmoi}"
+rulesync_hash=$(
+  {
+    find "$source_dir/.rulesync" "$HOME/.config/rulesync/.rulesync" -type f 2>/dev/null | sort | while IFS= read -r f; do
+      echo "$f"
+      cat "$f"
+    done
+    cat "$source_dir/rulesync.jsonc" "$HOME/.config/rulesync/rulesync.jsonc" 2>/dev/null
+  } | (command -v sha1sum >/dev/null && sha1sum || shasum -a 1)
+)
+if [ "$(cat "$state_dir/rulesync-hash" 2>/dev/null)" != "$rulesync_hash" ]; then
+  echo "Running mise run rulesync:generate..."
+  if mise run rulesync:generate; then
+    echo "$rulesync_hash" > "$state_dir/rulesync-hash"
+  else
+    # 再生成は必須ではないため apply は中断しない。マーカー未更新で次回 apply 時に再試行される。
+    echo "warning: 'mise run rulesync:generate' に失敗しました。次回 chezmoi apply 時に再試行します"
+  fi
+fi
 """,
 ]
 command = "bash"

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -68,21 +68,31 @@ fi
 #    apply 直後のこの位置で実行する。毎回の apply で無駄に generate しないよう、
 #    rulesync のソース（プロジェクト直下の .rulesync/ + rulesync.jsonc、および
 #    グローバルの ~/.config/rulesync/）に差分があるときだけハッシュマーカーで判定して走らせる。
-#    hook は chezmoi を再帰呼び出しせず済むよう source ディレクトリは CHEZMOI_SOURCE_DIR を使う。
-source_dir="${CHEZMOI_SOURCE_DIR:-$HOME/.local/share/chezmoi}"
+#    source ディレクトリは generate タスク（cd "$(chezmoi source-path)"）と同じ解決方法に
+#    そろえる。CHEZMOI_SOURCE_DIR と source-path が食い違う（例: apply --source）と、
+#    別チェックアウトのハッシュを保存して生成物が stale になり再試行も抑止されるため。
+source_dir=$(chezmoi source-path 2>/dev/null || echo "${CHEZMOI_SOURCE_DIR:-$HOME/.local/share/chezmoi}")
+hash_cmd() { if command -v sha1sum >/dev/null; then sha1sum; else shasum -a 1; fi; }
 rulesync_hash=$(
   {
-    find "$source_dir/.rulesync" "$HOME/.config/rulesync/.rulesync" -type f 2>/dev/null | sort | while IFS= read -r f; do
-      echo "$f"
-      cat "$f"
+    find "$source_dir/.rulesync" "$HOME/.config/rulesync/.rulesync" -type f 2>/dev/null
+    for f in "$source_dir/rulesync.jsonc" "$HOME/.config/rulesync/rulesync.jsonc"; do
+      [ -f "$f" ] && echo "$f"
     done
-    cat "$source_dir/rulesync.jsonc" "$HOME/.config/rulesync/rulesync.jsonc" 2>/dev/null
-  } | (command -v sha1sum >/dev/null && sha1sum || shasum -a 1)
+  } | sort | while IFS= read -r f; do
+    # 「パス + 内容ハッシュ」を1行にすることでファイル境界を曖昧にせず（連結衝突を防ぎ）、
+    # 追加/削除/リネーム/内容変更のいずれも検知する。
+    echo "$f $(hash_cmd < "$f")"
+  done | hash_cmd
 )
 if [ "$(cat "$state_dir/rulesync-hash" 2>/dev/null)" != "$rulesync_hash" ]; then
   echo "Running mise run rulesync:generate..."
   if mise run rulesync:generate; then
-    echo "$rulesync_hash" > "$state_dir/rulesync-hash"
+    # マーカー書き込み失敗（state_dir が書込み不可/容量不足）も検知して警告する。
+    # 未検知だと毎回の apply で無駄に再生成され続けるため。
+    if ! printf '%s' "$rulesync_hash" > "$state_dir/rulesync-hash" 2>/dev/null; then
+      echo "warning: rulesync-hash マーカーの書き込みに失敗しました（次回 apply で再生成されます）"
+    fi
   else
     # 再生成は必須ではないため apply は中断しない。マーカー未更新で次回 apply 時に再試行される。
     echo "warning: 'mise run rulesync:generate' に失敗しました。次回 chezmoi apply 時に再試行します"

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -62,15 +62,9 @@ if [ "$(cat "$state_dir/mise-config-hash" 2>/dev/null)" != "$mise_hash" ]; then
   GITHUB_TOKEN=$github_token mise install --jobs=2 || exit 1
   echo "$mise_hash" > "$state_dir/mise-config-hash"
 fi
-# 3) rulesync generate: AI エージェント設定（このリポジトリの CLAUDE.md と
-#    ~/.claude, ~/.codex, ~/.copilot 等）を再生成する。グローバル側は
-#    ~/.config/rulesync/.rulesync/ が chezmoi apply 済みであることが前提のため、
-#    apply 直後のこの位置で実行する。毎回の apply で無駄に generate しないよう、
+# 3) rulesync generate:
 #    rulesync のソース（プロジェクト直下の .rulesync/ + rulesync.jsonc、および
 #    グローバルの ~/.config/rulesync/）に差分があるときだけハッシュマーカーで判定して走らせる。
-#    source ディレクトリは generate タスク（cd "$(chezmoi source-path)"）と同じ解決方法に
-#    そろえる。CHEZMOI_SOURCE_DIR と source-path が食い違う（例: apply --source）と、
-#    別チェックアウトのハッシュを保存して生成物が stale になり再試行も抑止されるため。
 source_dir=$(chezmoi source-path 2>/dev/null || echo "${CHEZMOI_SOURCE_DIR:-$HOME/.local/share/chezmoi}")
 hash_cmd() { if command -v sha1sum >/dev/null; then sha1sum; else shasum -a 1; fi; }
 rulesync_hash=$(
@@ -94,7 +88,6 @@ if [ "$(cat "$state_dir/rulesync-hash" 2>/dev/null)" != "$rulesync_hash" ]; then
       echo "warning: rulesync-hash マーカーの書き込みに失敗しました（次回 apply で再生成されます）"
     fi
   else
-    # 再生成は必須ではないため apply は中断しない。マーカー未更新で次回 apply 時に再試行される。
     echo "warning: 'mise run rulesync:generate' に失敗しました。次回 chezmoi apply 時に再試行します"
   fi
 fi


### PR DESCRIPTION
## Summary

Add automatic AI agent configuration regeneration to the chezmoi apply workflow via a new `rulesync:generate` hook. This ensures that AI agent rules and skills (CLAUDE.md, ~/.claude, ~/.codex, ~/.copilot, etc.) are kept in sync with their source definitions whenever chezmoi is applied.

## Key Changes

- **Added rulesync:generate hook** to `.chezmoi.toml.tmpl` that runs after mise install
  - Regenerates AI agent configurations from source files in `.rulesync/` and `~/.config/rulesync/`
  - Uses hash-based change detection to avoid unnecessary regeneration on every apply
  - Gracefully handles failures without interrupting the chezmoi apply process
  
- **Implementation details:**
  - Computes SHA1 hash of all rulesync source files and configuration
  - Compares against stored hash marker in state directory
  - Only runs `mise run rulesync:generate` when sources have changed
  - Uses `CHEZMOI_SOURCE_DIR` environment variable to avoid recursive chezmoi calls
  - Logs warnings on failure but allows apply to continue (non-blocking)
  - Retries on next apply if generation fails

## Notes

This follows the established pattern used for mise configuration updates and aligns with the repository's infrastructure-as-code philosophy. The hook ensures that AI agent configurations stay synchronized with their source definitions as documented in `docs/rulesync.md`.

https://claude.ai/code/session_01SoWPsSN8TprxPPgKPwyczg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `rulesync:generate` post-apply hook to `chezmoi` to regenerate agent configs only when inputs change. Runs after `mise install`, hashes project and global rulesync sources (incl. `rulesync.jsonc`), and stays non-blocking with retry on next apply.

- **Bug Fixes**
  - Resolve sources via `chezmoi source-path` to match the generate task and avoid stale outputs when using an alternate `--source`.
  - Compute the hash from “path + per-file content hash” to detect renames/additions and prevent boundary collisions.
  - Detect and warn on marker write failures; skip marker update so the next apply retries generation.

<sup>Written for commit bf41ef92f98d81c689f2c06b567d427225cbc60d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
chezmoi apply の後処理に `rulesync:generate` を追加し、rulesync 関連ファイルのハッシュが前回から変わった場合のみ AI エージェント設定を再生成するようにしました。生成成功時のみハッシュを更新し、失敗時は警告を記録して次回適用時に再試行します。

## 変更理由
不要な再生成を避けつつ、設定変更を確実に AI エージェント設定へ反映するためです。また、生成失敗で `chezmoi apply` 全体が中断されないようにしています。

## 確認した項目
- `CHEZMOI_SOURCE_DIR` を利用した再帰呼び出しの防止
- ローカル／グローバルの rulesync 設定およびソースファイルの変更検知
- 生成成功時のみ状態ハッシュを更新
- 生成失敗時の警告出力と次回適用時の再試行

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic rulesync regeneration to the chezmoi apply workflow. The main changes are:

- Hashes project and global rulesync source files.
- Runs `rulesync:generate` only when inputs change.
- Aligns hashing and generation with `chezmoi source-path`.
- Retries generation after command or marker-write failures.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The updated source lookup resolves the previously reported mismatch.
- Hashing and generation now select the source through `chezmoi source-path`.
- No blocking issues were found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .chezmoi.toml.tmpl | Adds change-triggered rulesync generation and uses the same source-path resolution for hashing and generation. |

<sub>Reviews (3): Last reviewed commit: ["Update .chezmoi.toml.tmpl"](https://github.com/ryo246912/dotfiles/commit/bf41ef92f98d81c689f2c06b567d427225cbc60d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46659898)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/ryo/github/ryo246912/dotfiles/-/custom-context?memory=56ca1037-b626-4c46-a579-6fd3c3e6a2f8))

<!-- /greptile_comment -->