### PR TITLE
docs: Extract devcontainer setup to dedicated guide

### DIFF
--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,0 +1,89 @@
+# devcontainer
+
+AI エージェントを devcontainer 内で実行するための共通基盤に関する設定をまとめます。
+devcontainer 定義は `dot_config/devcontainer/` を参照してください。
+
+`multi-worktree` や `crit`（docs/crit.md）など、この base template から起動する
+devcontainer はいずれもここに書かれた仕組みを共有します。
+
+## devcontainer からホストへの通知設定（macOS のみ）
+
+devcontainer 内から macOS ホストに通知を送る場合、SSH 経由で通知を行います。
+通知経路は「コンテナ → SSH → ホストで `macos-notify-cli` 実行 → 通知センター」で、
+コンテナは `host.docker.internal`（SSH config 上の `mac-host`）へ接続し、ホスト上の
+`macos-notify-cli` を実行します。初回セットアップ時に以下の設定が必要です：
+
+```bash
+# 1. devcontainer 専用の SSH 鍵を生成（既に存在する場合はスキップ）
+if [ ! -f ~/.ssh/id_docker_devcontainer ]; then
+  ssh-keygen -t ed25519 -N "" -f ~/.ssh/id_docker_devcontainer
+fi
+
+# 2. 公開鍵を authorized_keys に追加（重複チェック付き）
+#    ※ 公開鍵は + や / を含むため、grep は必ず -F（固定文字列）で照合する
+if ! grep -Fq "$(cat ~/.ssh/id_docker_devcontainer.pub)" ~/.ssh/authorized_keys 2>/dev/null; then
+  cat ~/.ssh/id_docker_devcontainer.pub >> ~/.ssh/authorized_keys
+fi
+
+# 3. 権限設定（~/.ssh が 700・authorized_keys が 600 でないと sshd は公開鍵を無視する）
+chmod 700 ~/.ssh
+chmod 600 ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/id_docker_devcontainer
+
+# 4. リモートログイン（SSH サーバ）を有効化
+#    「システム設定 > 一般 > 共有 > リモートログイン」でも可
+sudo systemsetup -setremotelogin on
+sudo systemsetup -getremotelogin          # → Remote Login: On
+
+# 5. 確認
+#    鍵の「中身」で照合すること。ファイル名の docker_devcontainer は鍵のコメント
+#    (例: user@host.local) には含まれないため、`grep docker_devcontainer` ではヒットしない
+ls -la ~/.ssh/id_docker_devcontainer*
+grep -Fq "$(cat ~/.ssh/id_docker_devcontainer.pub)" ~/.ssh/authorized_keys \
+  && echo "REGISTERED" || echo "MISSING"
+```
+
+## 通知の表示許可（macOS のみ・初回のみ）
+
+SSH 認証が通っても、macOS 側で通知の表示が許可されていないと画面に通知は出ません。
+`macos-notify-cli` は表示が抑制されていても `Notification sent successfully` を返すため、
+**成功メッセージだけでは表示可否を判断できない**点に注意してください。
+
+- **集中モード / おやすみモード（Focus / Do Not Disturb）を OFF** にする
+- **システム設定 > 通知** で `macos-notify-mcp`（`macos-notify-cli` が通知配信に使うアプリ）の
+  「通知を許可」を ON にし、スタイルを「バナー」または「通知パネル」にする
+- ホスト上で直接 `macos-notify-cli --title test --message hello` を実行し、`Notification sent
+  successfully` だけでなく**実際にバナーが表示される**ことを確認する
+
+**設定後の動作:**
+
+- コンテナ起動時に自動的に SSH 設定が行われます
+- Claude Code の hooks（Notification、Stop）が macOS の通知センターに表示されます
+- コンテナを再作成しても設定は永続化されます
+
+**注意事項:**
+
+- macOS の「システム設定 > 一般 > 共有 > リモートログイン」が有効になっている必要があります
+- `authorized_keys` へは公開鍵の追加のみで、既存の鍵は保持されます（rename 不要）
+- `~/.ssh` は 700、`~/.ssh/authorized_keys` は 600 でないと sshd が公開鍵認証を拒否します
+
+## 通知が届かないときの切り分け
+
+`post-start.sh` などは `BatchMode=yes` / `2>/dev/null` / `|| true` でエラーを握りつぶすため、
+どこかで失敗しても静かに無通知になります。各段を手動で確認して原因を切り分けます。
+
+```bash
+# ① ホスト自身に鍵で SSH できるか（authorized_keys 登録・権限・リモートログインの確認）
+ssh -i ~/.ssh/id_docker_devcontainer -o BatchMode=yes "$USER@localhost" "echo ok"
+
+# ② コンテナ内から mac-host 経由で疎通するか（エラーを握りつぶさずに実行）
+ssh -F ~/.config/ssh/config mac-host "echo ok; which macos-notify-cli"
+
+# ③ コンテナ内からホストの通知を直接鳴らせるか
+ssh -F ~/.config/ssh/config mac-host \
+  "macos-notify-cli --title 'test' --message 'from container' --sound Glass"
+```
+
+- ①が失敗 → 公開鍵の未登録 / `~/.ssh` の権限 / リモートログイン無効を疑う
+- ①は通るが②の `which` が空 → 非対話 SSH シェルの PATH に mise の shim が無い
+- ③まで通るのに画面に出ない → 上記「通知の表示許可」（集中モード・通知許可）を確認

--- a/docs/multi-worktree.md
+++ b/docs/multi-worktree.md
@@ -56,83 +56,9 @@ autoload -Uz compinit && compinit
 
 ### devcontainer からホストへの通知設定（macOS のみ）
 
-devcontainer 内から macOS ホストに通知を送る場合、SSH 経由で通知を行います。初回セットアップ時に以下の設定が必要です：
-
-```bash
-# 1. devcontainer 専用の SSH 鍵を生成（既に存在する場合はスキップ）
-if [ ! -f ~/.ssh/id_docker_devcontainer ]; then
-  ssh-keygen -t ed25519 -N "" -f ~/.ssh/id_docker_devcontainer
-fi
-
-# 2. 公開鍵を authorized_keys に追加（重複チェック付き）
-#    ※ 公開鍵は + や / を含むため、grep は必ず -F（固定文字列）で照合する
-if ! grep -Fq "$(cat ~/.ssh/id_docker_devcontainer.pub)" ~/.ssh/authorized_keys 2>/dev/null; then
-  cat ~/.ssh/id_docker_devcontainer.pub >> ~/.ssh/authorized_keys
-fi
-
-# 3. 権限設定（~/.ssh が 700・authorized_keys が 600 でないと sshd は公開鍵を無視する）
-chmod 700 ~/.ssh
-chmod 600 ~/.ssh/authorized_keys
-chmod 600 ~/.ssh/id_docker_devcontainer
-
-# 4. リモートログイン（SSH サーバ）を有効化
-#    「システム設定 > 一般 > 共有 > リモートログイン」でも可
-sudo systemsetup -setremotelogin on
-sudo systemsetup -getremotelogin          # → Remote Login: On
-
-# 5. 確認
-#    鍵の「中身」で照合すること。ファイル名の docker_devcontainer は鍵のコメント
-#    (例: user@host.local) には含まれないため、`grep docker_devcontainer` ではヒットしない
-ls -la ~/.ssh/id_docker_devcontainer*
-grep -Fq "$(cat ~/.ssh/id_docker_devcontainer.pub)" ~/.ssh/authorized_keys \
-  && echo "REGISTERED" || echo "MISSING"
-```
-
-### 通知の表示許可（macOS のみ・初回のみ）
-
-SSH 認証が通っても、macOS 側で通知の表示が許可されていないと画面に通知は出ません。
-`macos-notify-cli` は表示が抑制されていても `Notification sent successfully` を返すため、
-**成功メッセージだけでは表示可否を判断できない**点に注意してください。
-
-- **集中モード / おやすみモード（Focus / Do Not Disturb）を OFF** にする
-- **システム設定 > 通知** で `macos-notify-mcp`（`macos-notify-cli` が通知配信に使うアプリ）の
-  「通知を許可」を ON にし、スタイルを「バナー」または「通知パネル」にする
-- ホスト上で直接 `macos-notify-cli --title test --message hello` を実行し、`Notification sent
-  successfully` だけでなく**実際にバナーが表示される**ことを確認する
-
-**設定後の動作:**
-
-- コンテナ起動時に自動的に SSH 設定が行われます
-- Claude Code の hooks（Notification、Stop）が macOS の通知センターに表示されます
-- コンテナを再作成しても設定は永続化されます
-
-**注意事項:**
-
-- macOS の「システム設定 > 一般 > 共有 > リモートログイン」が有効になっている必要があります
-- `authorized_keys` へは公開鍵の追加のみで、既存の鍵は保持されます（rename 不要）
-- `~/.ssh` は 700、`~/.ssh/authorized_keys` は 600 でないと sshd が公開鍵認証を拒否します
-
-### 通知が届かないときの切り分け
-
-通知経路は「コンテナ → SSH → ホストで `macos-notify-cli` 実行 → 通知センター」です。
-`post-start.sh` などは `BatchMode=yes` / `2>/dev/null` / `|| true` でエラーを握りつぶすため、
-どこかで失敗しても静かに無通知になります。各段を手動で確認して原因を切り分けます。
-
-```bash
-# ① ホスト自身に鍵で SSH できるか（authorized_keys 登録・権限・リモートログインの確認）
-ssh -i ~/.ssh/id_docker_devcontainer -o BatchMode=yes "$USER@localhost" "echo ok"
-
-# ② コンテナ内から mac-host 経由で疎通するか（エラーを握りつぶさずに実行）
-ssh -F ~/.config/ssh/config mac-host "echo ok; which macos-notify-cli"
-
-# ③ コンテナ内からホストの通知を直接鳴らせるか
-ssh -F ~/.config/ssh/config mac-host \
-  "macos-notify-cli --title 'test' --message 'from container' --sound Glass"
-```
-
-- ①が失敗 → 公開鍵の未登録 / `~/.ssh` の権限 / リモートログイン無効を疑う
-- ①は通るが②の `which` が空 → 非対話 SSH シェルの PATH に mise の shim が無い
-- ③まで通るのに画面に出ない → 上記「通知の表示許可」（集中モード・通知許可）を確認
+devcontainer 内から macOS ホストへ SSH 経由で通知を送るための初回セットアップが必要です。
+この仕組みは `multi-worktree` 固有ではなく、この base template から起動する devcontainer 共通の
+ものなので、手順とトラブルシューティングは [docs/devcontainer.md](./devcontainer.md) にまとめています。
 
 ## 設定ファイル
 

--- a/dot_config/multi-worktree/README.md
+++ b/dot_config/multi-worktree/README.md
@@ -65,18 +65,40 @@ if [ ! -f ~/.ssh/id_docker_devcontainer ]; then
 fi
 
 # 2. 公開鍵を authorized_keys に追加（重複チェック付き）
-if ! grep -q "$(cat ~/.ssh/id_docker_devcontainer.pub)" ~/.ssh/authorized_keys 2>/dev/null; then
+#    ※ 公開鍵は + や / を含むため、grep は必ず -F（固定文字列）で照合する
+if ! grep -Fq "$(cat ~/.ssh/id_docker_devcontainer.pub)" ~/.ssh/authorized_keys 2>/dev/null; then
   cat ~/.ssh/id_docker_devcontainer.pub >> ~/.ssh/authorized_keys
 fi
 
-# 3. 権限設定
+# 3. 権限設定（~/.ssh が 700・authorized_keys が 600 でないと sshd は公開鍵を無視する）
+chmod 700 ~/.ssh
 chmod 600 ~/.ssh/authorized_keys
 chmod 600 ~/.ssh/id_docker_devcontainer
 
-# 4. 確認
+# 4. リモートログイン（SSH サーバ）を有効化
+#    「システム設定 > 一般 > 共有 > リモートログイン」でも可
+sudo systemsetup -setremotelogin on
+sudo systemsetup -getremotelogin          # → Remote Login: On
+
+# 5. 確認
+#    鍵の「中身」で照合すること。ファイル名の docker_devcontainer は鍵のコメント
+#    (例: user@host.local) には含まれないため、`grep docker_devcontainer` ではヒットしない
 ls -la ~/.ssh/id_docker_devcontainer*
-grep docker_devcontainer ~/.ssh/authorized_keys
+grep -Fq "$(cat ~/.ssh/id_docker_devcontainer.pub)" ~/.ssh/authorized_keys \
+  && echo "REGISTERED" || echo "MISSING"
 ```
+
+### 通知の表示許可（macOS のみ・初回のみ）
+
+SSH 認証が通っても、macOS 側で通知の表示が許可されていないと画面に通知は出ません。
+`macos-notify-cli` は表示が抑制されていても `Notification sent successfully` を返すため、
+**成功メッセージだけでは表示可否を判断できない**点に注意してください。
+
+- **集中モード / おやすみモード（Focus / Do Not Disturb）を OFF** にする
+- **システム設定 > 通知** で `macos-notify-mcp`（`macos-notify-cli` が通知配信に使うアプリ）の
+  「通知を許可」を ON にし、スタイルを「バナー」または「通知パネル」にする
+- ホスト上で直接 `macos-notify-cli --title test --message hello` を実行し、`Notification sent
+  successfully` だけでなく**実際にバナーが表示される**ことを確認する
 
 **設定後の動作:**
 
@@ -88,6 +110,29 @@ grep docker_devcontainer ~/.ssh/authorized_keys
 
 - macOS の「システム設定 > 一般 > 共有 > リモートログイン」が有効になっている必要があります
 - `authorized_keys` へは公開鍵の追加のみで、既存の鍵は保持されます（rename 不要）
+- `~/.ssh` は 700、`~/.ssh/authorized_keys` は 600 でないと sshd が公開鍵認証を拒否します
+
+### 通知が届かないときの切り分け
+
+通知経路は「コンテナ → SSH → ホストで `macos-notify-cli` 実行 → 通知センター」です。
+`post-start.sh` などは `BatchMode=yes` / `2>/dev/null` / `|| true` でエラーを握りつぶすため、
+どこかで失敗しても静かに無通知になります。各段を手動で確認して原因を切り分けます。
+
+```bash
+# ① ホスト自身に鍵で SSH できるか（authorized_keys 登録・権限・リモートログインの確認）
+ssh -i ~/.ssh/id_docker_devcontainer -o BatchMode=yes "$USER@localhost" "echo ok"
+
+# ② コンテナ内から mac-host 経由で疎通するか（エラーを握りつぶさずに実行）
+ssh -F ~/.config/ssh/config mac-host "echo ok; which macos-notify-cli"
+
+# ③ コンテナ内からホストの通知を直接鳴らせるか
+ssh -F ~/.config/ssh/config mac-host \
+  "macos-notify-cli --title 'test' --message 'from container' --sound Glass"
+```
+
+- ①が失敗 → 公開鍵の未登録 / `~/.ssh` の権限 / リモートログイン無効を疑う
+- ①は通るが②の `which` が空 → 非対話 SSH シェルの PATH に mise の shim が無い
+- ③まで通るのに画面に出ない → 上記「通知の表示許可」（集中モード・通知許可）を確認
 
 ## 設定ファイル
 


### PR DESCRIPTION
## Summary

Extracted the devcontainer notification setup documentation from `docs/multi-worktree.md` into a new dedicated guide at `docs/devcontainer.md`. This reflects that the SSH-based macOS notification mechanism is a shared base feature used by all devcontainers launched from the base template, not specific to multi-worktree.

## Key Changes

- **New file: `docs/devcontainer.md`**
  - Comprehensive guide for devcontainer setup and configuration
  - Detailed SSH key generation and authorization steps with security considerations
  - macOS notification display permission requirements
  - Troubleshooting section with step-by-step diagnostics for common issues
  - Enhanced documentation with better explanations of the notification flow and permission model

- **Updated: `docs/multi-worktree.md`**
  - Removed duplicate devcontainer setup instructions
  - Added cross-reference to `docs/devcontainer.md` for the shared setup procedure
  - Clarified that notification setup is a base template feature, not multi-worktree specific

## Notable Details

- The new guide includes improved setup instructions with:
  - Explicit `grep -F` usage for public key matching (handles special characters like `+` and `/`)
  - `chmod 700 ~/.ssh` permission setting (previously missing)
  - Clearer distinction between file name and key comment
  - Comprehensive troubleshooting with three diagnostic steps
  - Explanation of why error messages alone don't indicate successful notification display

https://claude.ai/code/session_01V8MEfg5uAeZuRPG73J7VMe

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves shared devcontainer notification guidance into a dedicated document. The main changes are:

- Adds SSH setup, macOS permission, and troubleshooting instructions.
- Moves the multi-worktree guide into `docs/`.
- Replaces duplicated setup steps with a relative link to the shared guide.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed documentation.
- The new relative link resolves to the added guide.
- No runtime configuration depends on the former documentation path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/devcontainer.md | Adds shared setup and troubleshooting guidance for SSH-based macOS notifications. |
| docs/multi-worktree.md | Moves the guide into `docs/` and links to the new shared devcontainer documentation. |

<sub>Reviews (1): Last reviewed commit: ["docs: multi-worktree README を docs/ へ移動し..."](https://github.com/ryo246912/dotfiles/commit/5db0f2a3a666943aaeb46f8562c788578f1a10ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46679405)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/ryo/github/ryo246912/dotfiles/-/custom-context?memory=56ca1037-b626-4c46-a579-6fd3c3e6a2f8))

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the shared SSH-based macOS notification setup out of `docs/multi-worktree.md` into a dedicated `docs/devcontainer.md`. This clarifies it’s a base template feature and improves the setup’s reliability.

- **Refactors**
  - Added `docs/devcontainer.md` with end-to-end setup, macOS notification permission notes, and troubleshooting.
  - Updated `docs/multi-worktree.md` to remove duplicate steps and link to the new guide.
  - Hardened steps: use `grep -F` for public key matching, set `~/.ssh` to 700, enable Remote Login, and note that `macos-notify-cli` success messages don’t guarantee visible notifications.

<sup>Written for commit 5db0f2a3a666943aaeb46f8562c788578f1a10ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

