### PR TITLE
chore: agentview

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -90,6 +90,14 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["dot_config/agentsview/fly.toml"],
+      "matchStrings": [
+        "image\\s*=\\s*\"(?<depName>ghcr\\.io/wesm/agentsview):(?<currentValue>v?[^\"]+)\""
+      ],
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["dot_config/brew/brew.json"],
       "matchStrings": ["\"(?<depName>[^\"]+)\": \"(?<currentValue>[^\"]+)\""],
       "datasourceTemplate": "custom.brew-formula"

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -53,7 +53,7 @@ SSH 認証が通っても、macOS 側で通知の表示が許可されていな�
 - **システム設定 > 通知** で `macos-notify-mcp`（`macos-notify-cli` が通知配信に使うアプリ）の
   「通知を許可」を ON にし、スタイルを「バナー」または「通知パネル」にする
 - ホスト上で直接 `macos-notify-cli --title test --message hello` を実行し、`Notification sent
-  successfully` だけでなく**実際にバナーが表示される**ことを確認する
+successfully` だけでなく**実際にバナーが表示される**ことを確認する
 
 **設定後の動作:**
 

--- a/dot_config/mise/tasks/agentsview.toml
+++ b/dot_config/mise/tasks/agentsview.toml
@@ -1,7 +1,6 @@
 ["agentsview:setup:db-roles"]
 description = "Create/update AgentsView PostgreSQL roles for owner, local push, and read-only viewer"
 # 未設定 env をその場で伏せ字入力できるよう、bash + 端末直結で実行する。
-shell = "bash -c"
 interactive = true
 run = '''
 set -eu
@@ -122,11 +121,11 @@ ALTER DEFAULT PRIVILEGES FOR ROLE agentsview_owner IN SCHEMA agentsview
   GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO agentsview_push_mac;
 SQL
 '''
+shell = "bash -c"
 
 ["agentsview:setup:migrate"]
 description = "Start flyctl proxy, run initial AgentsView schema migration with the owner PostgreSQL role, then stop proxy"
 # 未設定 env をその場で伏せ字入力できるよう、bash + 端末直結で実行する。
-shell = "bash -c"
 interactive = true
 run = '''
 set -eu
@@ -192,6 +191,7 @@ else
   agentsview pg push
 fi
 '''
+shell = "bash -c"
 
 ["agentsview:fly:tokens"]
 description = "Generate AgentsView auth_token and cursor_secret values for secret manager storage"
@@ -205,7 +205,6 @@ printf 'AGENTSVIEW_CURSOR_SECRET=%s\n' "$(openssl rand -base64 32)"
 ["agentsview:fly:secrets"]
 description = "Set Fly secrets for the public AgentsView viewer with a read-only PostgreSQL role"
 # 未設定 env をその場で伏せ字入力できるよう、bash + 端末直結で実行する。
-shell = "bash -c"
 interactive = true
 run = '''
 set -eu
@@ -237,6 +236,7 @@ printf 'AGENTSVIEW_PG_URL=%s\nAGENTSVIEW_CONFIG_TOML=%s\n' \
   "$AGENTSVIEW_READ_PG_URL" "$CONFIG_B64" \
   | flyctl secrets import -a ryo-agentsview
 '''
+shell = "bash -c"
 
 ["agentsview:deploy"]
 description = "Deploy the AgentsView public viewer to Fly.io"
@@ -245,7 +245,6 @@ run         = "flyctl deploy --app ryo-agentsview -c dot_config/agentsview/fly.t
 ["agentsview:pg:status"]
 description = "Start flyctl proxy, show AgentsView PostgreSQL sync status, then stop proxy"
 # 未設定 env をその場で伏せ字入力できるよう、bash + 端末直結で実行する。
-shell = "bash -c"
 interactive = true
 run = '''
 set -eu
@@ -307,11 +306,11 @@ export AGENTSVIEW_PG_MACHINE="${AGENTSVIEW_PG_MACHINE:-$(hostname)}"
 
 agentsview pg status
 '''
+shell = "bash -c"
 
 ["agentsview:pg:push"]
 description = "Start flyctl proxy, push local AgentsView sessions to PostgreSQL, then stop proxy"
 # 未設定 env をその場で伏せ字入力できるよう、bash + 端末直結で実行する。
-shell = "bash -c"
 interactive = true
 run = '''
 set -eu
@@ -373,6 +372,7 @@ export AGENTSVIEW_PG_MACHINE="${AGENTSVIEW_PG_MACHINE:-$(hostname)}"
 
 agentsview pg push "$@"
 '''
+shell = "bash -c"
 
 ["agentsview:serve"]
 description = "Start local AgentsView server"


### PR DESCRIPTION
- **chore: upgrade renovate**
- **fix: format**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Renovate support to auto-bump the `ghcr.io/wesm/agentsview` image tag in the Fly config. Also tidy `mise` task shells and fix a tiny docs formatting issue.

- **Dependencies**
  - Add a regex manager in `renovate.json` to track and update the Docker image tag in `dot_config/agentsview/fly.toml` for `ghcr.io/wesm/agentsview`.

- **Refactors**
  - Standardize `shell = "bash -c"` placement in `dot_config/mise/tasks/agentsview.toml` (no behavior change).
  - Fix a stray line break in `docs/devcontainer.md`.

<sup>Written for commit 697493087ccee1da99a5bb41548b5bfe2f0fdcd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends Renovate coverage and applies formatting-only cleanup.
- Adds a regex manager for the `ghcr.io/wesm/agentsview` image in the AgentsView Fly configuration.
- Corrects Markdown line wrapping in the devcontainer notification instructions.
- Reorders `shell` fields in AgentsView mise tasks to match TOML formatting rules.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the changed configuration, documentation, or task definitions.

The Renovate manager matches the existing AgentsView image declaration and follows an established sibling pattern, while the remaining edits preserve semantics and only normalize formatting.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/renovate.json | Adds an AgentsView Docker image regex manager consistent with the existing Atuin manager and the target Fly configuration. |
| docs/devcontainer.md | Removes unintended indentation from a wrapped sentence without changing its meaning. |
| dot_config/mise/tasks/agentsview.toml | Reorders keys within the same TOML task tables without changing task definitions or execution behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: format"](https://github.com/ryo246912/dotfiles/commit/697493087ccee1da99a5bb41548b5bfe2f0fdcd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47201373)</sub>

<!-- /greptile_comment -->