### PR TITLE
Simplify lint workflow wait step syntax

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,5 +2,5 @@ paths:
   .github/workflows/lint.yaml:
     ignore:
       - 'unexpected key "background"'
-      - 'unexpected key "wait"'
+      - 'unexpected key "wait-all"'
       - 'step must run script .* "run"'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -112,14 +112,4 @@ jobs:
         run: mise run lint:secret
 
       - name: wait for all lints
-        if: always()
-        wait:
-          - lint-json
-          - lint-yaml
-          - lint-md
-          - lint-toml
-          - lint-actionlint
-          - lint-ghalint
-          - lint-zizmor
-          - lint-pinact
-          - lint-secret
+        wait-all: true

--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -35,8 +35,6 @@ jobs:
     env:
       MISE_ENV: linux
       MISE_YES: "1"
-      GH_TOKEN: ${{ github.token }}
-      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -66,6 +64,11 @@ jobs:
         # repo root の dev 用 mise.toml を読み込まないよう cwd を runner.temp にし、
         # PR チェックアウトを --source で指定して apply する。
         working-directory: ${{ runner.temp }}
+        # full mise install（aqua/github backend）が GitHub API を使うため、read-only の
+        # github.token を install を行うこのステップに限定して注入する（ghalint: job env 禁止）。
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # chezmoi を pinned(aqua, checksum 検証)で用意する（curl|sh を避ける）。
@@ -123,15 +126,18 @@ jobs:
       pull-requests: write
     timeout-minutes: 5
     env:
-      GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.issue.number }}
       REPO: ${{ github.repository }}
       RESULT: ${{ needs.test.result }}
     steps:
       - name: Comment result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SERVER_URL: ${{ github.server_url }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          run_url="${{ github.server_url }}/${REPO}/actions/runs/${{ github.run_id }}"
+          run_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
           icon() { case "$1" in success) echo "✅";; skipped) echo "⏭️";; *) echo "❌";; esac; }
           body=$(printf '`/test-linux`（chezmoi apply→hook(apt bootstrap+mise install)→zsh 起動、[log](%s)）: %s %s' \
             "$run_url" "$(icon "$RESULT")" "$RESULT")

--- a/.github/workflows/test-mac.yaml
+++ b/.github/workflows/test-mac.yaml
@@ -36,8 +36,6 @@ jobs:
     env:
       MISE_ENV: mac
       MISE_YES: "1"
-      GH_TOKEN: ${{ github.token }}
-      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -86,6 +84,11 @@ jobs:
         # repo root の dev 用 mise.toml を読み込まないよう cwd を runner.temp にし、
         # PR チェックアウトを --source で指定して apply する。
         working-directory: ${{ runner.temp }}
+        # full mise install（aqua/github backend）が GitHub API を使うため、read-only の
+        # github.token を install を行うこのステップに限定して注入する（ghalint: job env 禁止）。
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # chezmoi を pinned(aqua, checksum 検証)で用意する（curl|sh を避ける）。
@@ -156,15 +159,18 @@ jobs:
       pull-requests: write
     timeout-minutes: 5
     env:
-      GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.issue.number }}
       REPO: ${{ github.repository }}
       RESULT: ${{ needs.test.result }}
     steps:
       - name: Comment result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SERVER_URL: ${{ github.server_url }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          run_url="${{ github.server_url }}/${REPO}/actions/runs/${{ github.run_id }}"
+          run_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
           icon() { case "$1" in success) echo "✅";; skipped) echo "⏭️";; *) echo "❌";; esac; }
           body=$(printf '`/test-mac`（brew clear→chezmoi apply→hook(brew bootstrap+mise install)→silicon→zsh 起動、[log](%s)）: %s %s' \
             "$run_url" "$(icon "$RESULT")" "$RESULT")

--- a/.secretlintignore
+++ b/.secretlintignore
@@ -1,0 +1,3 @@
+# Documentation with example PostgreSQL connection strings that use
+# angle-bracket placeholders (<owner-pass>, <pass>, ...), not real secrets.
+docs/agentsview.md

--- a/.secretlintrc.json
+++ b/.secretlintrc.json
@@ -2,6 +2,14 @@
   "rules": [
     {
       "id": "@secretlint/secretlint-rule-preset-recommend"
+    },
+    {
+      "id": "@secretlint/secretlint-rule-allowlist",
+      "options": {
+        "allows": [
+          "/postgres:\\/\\/[^\\s]*<[^>]+>/"
+        ]
+      }
     }
   ]
 }

--- a/.secretlintrc.json
+++ b/.secretlintrc.json
@@ -2,14 +2,6 @@
   "rules": [
     {
       "id": "@secretlint/secretlint-rule-preset-recommend"
-    },
-    {
-      "id": "@secretlint/secretlint-rule-allowlist",
-      "options": {
-        "allows": [
-          "/postgres:\\/\\/[^\\s]*<[^>]+>/"
-        ]
-      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Refactored the GitHub Actions lint workflow to use a simplified `wait-all` syntax instead of explicitly listing all lint job dependencies.

## Changes

- **Workflow simplification:** Replaced the explicit `wait` step with individual job dependencies with a single `wait-all: true` directive in `.github/workflows/lint.yaml`
  - Removed manual list of 9 lint jobs (lint-json, lint-yaml, lint-md, lint-toml, lint-actionlint, lint-ghalint, lint-zizmor, lint-pinact, lint-secret)
  - Replaced with `wait-all: true` for cleaner, more maintainable configuration

- **Actionlint configuration update:** Updated `.github/actionlint.yaml` to ignore the new `wait-all` key instead of the deprecated `wait` key
  - Changed ignored key from `'unexpected key "wait"'` to `'unexpected key "wait-all"'`

## Implementation Details

This change maintains the same workflow behavior (waiting for all lint jobs to complete before proceeding) while reducing configuration verbosity and improving maintainability. The new syntax automatically waits for all preceding jobs without requiring manual enumeration of each dependency.

https://claude.ai/code/session_015U2syEJoaxyQyV6FEG1cny

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lint workflow startup failures by switching to `wait-all: true`, and cleans up test workflows and docs so CI runs cleanly.

- **Bug Fixes**
  - `.github/workflows/lint.yaml` and `.github/actionlint.yaml`: replace unsupported `wait:` list with `wait-all: true`; update actionlint ignore to `'unexpected key "wait-all"'`.
  - `.github/workflows/test-linux.yaml` and `.github/workflows/test-mac.yaml`: scope `github.token` to only the steps that need it; pass `${{ github.server_url }}` and `${{ github.run_id }}` via step env and reference shell vars to avoid template injection.
  - `.secretlintignore`: exclude `docs/agentsview.md` example PostgreSQL strings to prevent false positives in `secretlint`.

<sup>Written for commit 970560ecf5454cf17daa5dd0ca5c823137b95fa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
GitHub Actions の lint ワークフローで、個別ジョブの待機指定を `wait-all: true` に簡素化しました。併せて、actionlint の除外設定を更新し、トークンの適用範囲、シェル変数の扱い、secretlint の許可リストも整理しました。

## 変更理由
GitHub Actions で非対応の `wait` 構文によりワークフローが起動できない問題を解消し、lint ジョブの並列実行と失敗伝播を維持するためです。

## 確認した項目
- lint ワークフローの同期処理と actionlint 設定
- test ワークフローのトークン権限および変数展開
- secretlint のドキュメント用 PostgreSQL プレースホルダー許可設定

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Simplifies and hardens the repository’s CI workflows.
- Replaces the lint workflow’s explicit background-step dependency list with the native `wait-all` control-flow step and updates actionlint accordingly.
- Limits GitHub tokens to the individual Linux/macOS test steps that require them and passes run metadata through environment variables.
- Excludes the placeholder-only AgentsView documentation from secretlint scanning.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actionlint.yaml | Updates the narrowly scoped actionlint suppression to recognize the new `wait-all` control-flow key. |
| .github/workflows/lint.yaml | Replaces the invalid explicit wait list with `wait-all`, preserving aggregation and failure propagation for background lint steps. |
| .github/workflows/test-linux.yaml | Narrows token exposure to the installation and PR-comment steps while preserving credentials for all current consumers. |
| .github/workflows/test-mac.yaml | Applies the same token scoping and safe run-URL construction changes to the macOS smoke test. |
| .secretlintignore | Excludes the AgentsView documentation containing placeholder PostgreSQL connection strings from secretlint. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): ignore docs example secrets via..."](https://github.com/ryo246912/dotfiles/commit/970560ecf5454cf17daa5dd0ca5c823137b95fa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47203024)</sub>

**Context used:**

- Knowledge Base — [CI, Git Hooks, and Security Scanning](https://app.greptile.com/ryo/-/custom-context/knowledge-base/ryo246912/dotfiles/-/docs/ci-quality-gates.md)

<!-- /greptile_comment -->