### PR TITLE
Fix regex escaping in git secrets AWS patterns

### DIFF
--- a/dot_config/git/config.tmpl
+++ b/dot_config/git/config.tmpl
@@ -57,5 +57,5 @@
 [secrets]
 	providers = git secrets --aws-provider
 	patterns = (A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}
-	patterns = \"?aws_secret_access_key\"?[[:space:]]*[:=][[:space:]]*\"?[A-Za-z0-9/\+=]{40}\"?
-	patterns = \"?aws_session_token\"?[[:space:]]*[:=][[:space:]]*\"?[A-Za-z0-9/\+=]{16,}\"?
+	patterns = \"?aws_secret_access_key\"?[[:space:]]*[:=][[:space:]]*\"?[A-Za-z0-9/+=]{40}\"?
+	patterns = \"?aws_session_token\"?[[:space:]]*[:=][[:space:]]*\"?[A-Za-z0-9/+=]{16,}\"?


### PR DESCRIPTION
## Summary
Fixed incorrect escape sequences in the git secrets configuration patterns for detecting AWS credentials.

## Changes
- Removed unnecessary backslash escaping from `+=` character class in two AWS secret detection patterns
  - `aws_secret_access_key` pattern: `[A-Za-z0-9/\+=]` → `[A-Za-z0-9/+=]`
  - `aws_session_token` pattern: `[A-Za-z0-9/\+=]` → `[A-Za-z0-9/+=]`

## Details
The backslash before `+` in the character class was unnecessary and could cause regex matching issues. Within a character class `[]`, the `+` character does not need escaping as it has no special meaning in that context. This fix ensures the patterns correctly match AWS secret keys and session tokens that may contain `+` characters.

https://claude.ai/code/session_01MzeRbCDEXNiWmF3LDmbPe3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed invalid escaping in the AWS secret detection patterns in dot_config/git/config.tmpl by removing the backslash before `+` in the `[A-Za-z0-9/+=]` character class for `aws_secret_access_key` and `aws_session_token`. This prevents "bad config line" parse errors and ensures keys/tokens with `+` are matched correctly.

<sup>Written for commit c94f6b3a8a9cc2dac22af27ca8bd1f8fb3721b88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
AWS認証情報検出用の2つの正規表現から、文字クラス内の不要な `\` を削除しました。

## 変更理由
git-configで不正なエスケープとして解釈され、「bad config line」エラーになる問題を修正するためです。

## 確認した項目
- `aws_secret_access_key` の検出パターン
- `aws_session_token` の検出パターン

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two AWS credential detection patterns in the Git secrets configuration by removing invalid backslash escapes before literal `+` characters.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The updated character classes preserve literal `+` matching while avoiding the invalid `\+` escape in the Git configuration values.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| dot_config/git/config.tmpl | Corrects the AWS secret-access-key and session-token regex character classes without changing their intended accepted character set. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(git): remove invalid escape in git-s..."](https://github.com/ryo246912/dotfiles/commit/c94f6b3a8a9cc2dac22af27ca8bd1f8fb3721b88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47348472)</sub>

<!-- /greptile_comment -->