### PR TITLE
Add periodic AgentsView push via mise bootstrap user services

### DIFF
--- a/docs/agentsview.md
+++ b/docs/agentsview.md
@@ -241,7 +241,77 @@ mise run agentsview:serve
 
 恒久運用は、`AGENTSVIEW_PROXY_PG_URL` を fnox（bws）に持たせ、PC ごとに変えたい場合だけ
 `AGENTSVIEW_PG_MACHINE` を実行時に指定し、必要なときに `mise run agentsview:pg:push` を実行する
-形にする。自動常駐 push や `~/.agentsview/config.toml` への DB URL 保存は、この repository では採用しない。
+形にする。手動運用に加えて、下記の「定期 push（15 分ごとの自動 push）」で mise bootstrap の
+LaunchAgent / systemd timer による自動 push も設定できる。いずれの場合も `~/.agentsview/config.toml`
+への DB URL 保存は採用せず、secret は fnox から解決する。
+
+## 定期 push（15 分ごとの自動 push）
+
+手動 `mise run agentsview:pg:push` を都度実行する代わりに、mise bootstrap の user service（macOS: LaunchAgent / Linux: systemd user timer）で 15 分ごとに自動 push する。設定手順は [docs/mise.md の「mise bootstrap で user service（定期 push 等）を設定する」](./mise.md#mise-bootstrap-で-user-service定期-push-等を設定する) にまとめている。ここでは agentsview 固有の設計だけ記す。
+
+AgentsView 本体には `agentsview pg push --watch --interval 5m` の常駐 watch もあるが、その watch は起動中ずっと PostgreSQL への接続（＝ `flyctl proxy` 常駐）を要求する。この repository は proxy を常駐させず task 内で都度起動・停止する構成なので、`--watch` ではなく「15 分間隔で `flyctl proxy` を一時起動して差分 push する task を叩く」形にしている。
+
+### 仕組み
+
+- 実体は非対話 task `agentsview:pg:push:daemon`（`dot_config/mise/tasks/agentsview.toml`）。
+  `flyctl proxy 15432:5432 -a psgl` を一時起動し、push 後に proxy を停止する `agentsview:pg:push` と同じフロー。
+- secret（`AGENTSVIEW_PROXY_PG_URL`）は他 task と同じく fnox（bws/age）から解決する。zsh を経ない
+  起動では env に無いため、task が `fnox exec -- mise run ...` で自身を再実行して補う。
+- `AGENTSVIEW_PG_MACHINE` は launchd/systemd が zsh 起動を経ないため env に無い。task 側で
+  `dot_zshenv.tmpl` と同じく `host-env.map` から導出し、対話 push と同じ machine 名に揃える
+  （導出できなければ `hostname` にフォールバック）。DB 上で同一 PC のセッションが別 machine に
+  分裂しないようにするため。
+- 前回 push がまだ動いている（proxy port が使用中）場合は多重起動せず今回はスキップする。
+  初回の全件 push は数時間かかりうるため、interval と重なっても安全に飛ばす。
+- macOS は `start_interval = 900`（秒）で 15 分ごと、Linux は timer の `on_unit_active_sec = "15min"` で 15 分ごとに起動する。
+
+### 前提
+
+- secret を fnox（bws/age）で解決できること。bws の `BWS_ACCESS_TOKEN` は age で解けるため、
+  `~/.config/fnox/age.txt`（age 秘密鍵）があれば daemon 起動時も非対話で解決できる。
+- 事前に `flyctl auth login` 済みであること（`flyctl proxy` に必要。auth は `~/.fly` に保存される）。
+- `fnox` / `flyctl` / `agentsview` は mise 管理ツールのため、`mise run` 実行時に自動で PATH に載る。
+- `mise` 本体が `~/.local/bin/mise` にあること（launchd/systemd は login shell の PATH を持たないため、
+  bootstrap 側は mise を絶対パスで叩く。別の場所なら下記 config の `program` / `exec_start` を合わせる）。
+
+### 定義と適用
+
+定義は `dot_config/mise/config.mac.toml`（`[bootstrap.macos.launchd.agents.agentsview-push]`）と
+`dot_config/mise/config.linux.toml`（`[bootstrap.linux.systemd.units.agentsview-push]`）。
+`chezmoi apply` で反映後、OS 別に bootstrap を適用する（詳細・オプションは docs/mise.md 参照）。
+
+```sh
+# 反映前に差分だけ確認する
+MISE_ENV=mac   mise bootstrap macos launchd-agents apply --dry-run
+MISE_ENV=linux mise bootstrap linux systemd-units apply --dry-run
+
+# 適用（macOS: launchctl に load / Linux: systemctl --user で .service + .timer を有効化）
+MISE_ENV=mac   mise bootstrap macos launchd-agents apply
+MISE_ENV=linux mise bootstrap linux systemd-units apply
+```
+
+Linux の headless / WSL では、ログインしていない間も timer を動かすため lingering を有効化する:
+
+```sh
+loginctl enable-linger "$USER"
+```
+
+### 動作確認
+
+```sh
+# ログ（macOS。stdout/stderr を ~/.local/state/agentsview/push.log に集約している）
+tail -f ~/.local/state/agentsview/push.log
+
+# 状態確認
+mise bootstrap macos launchd-agents status      # macOS
+mise bootstrap linux systemd-units status        # Linux
+systemctl --user list-timers 'agentsview-push*'  # Linux（次回発火時刻）
+journalctl --user -u agentsview-push -f          # Linux（ログ）
+
+# 手動で 1 回だけ叩いて確認（fnox 解決込み）
+mise run agentsview:pg:push:daemon
+mise run agentsview:pg:status
+```
 
 ### push 時間について（初回が遅い理由）
 

--- a/docs/agentsview.md
+++ b/docs/agentsview.md
@@ -281,6 +281,9 @@ AgentsView 本体には `agentsview pg push --watch --interval 5m` の常駐 wat
 `chezmoi apply` で反映後、OS 別に bootstrap を適用する（詳細・オプションは docs/mise.md 参照）。
 
 ```sh
+# macOS: LaunchAgent のログ出力先ディレクトリを先に作る（launchd は親ディレクトリを作らない）
+mkdir -p ~/.local/state/agentsview
+
 # 反映前に差分だけ確認する
 MISE_ENV=mac   mise bootstrap macos launchd-agents apply --dry-run
 MISE_ENV=linux mise bootstrap linux systemd-units apply --dry-run

--- a/docs/mise.md
+++ b/docs/mise.md
@@ -124,7 +124,7 @@ OS 別 config に書く。`[bootstrap.packages]` と同じく、`MISE_ENV` で�
 
 ```toml
 [bootstrap.macos.launchd.agents.agentsview-push]
-program        = "~/.local/bin/mise"          # launchd の最小 PATH でも辿れるよう絶対パス
+program        = "~/.local/bin/mise"          # 最小 PATH でも辿れるフルパス。~ は mise が展開して plist に書き出す
 args           = ["run", "agentsview:pg:push:daemon"]
 run_at_load    = true                          # load 時にも 1 回走らせる
 start_interval = 900                           # 秒。15 分ごとに起動

--- a/docs/mise.md
+++ b/docs/mise.md
@@ -148,7 +148,6 @@ exec_start         = "%h/.local/bin/mise run agentsview:pg:push:daemon"  # %h �
 type               = "oneshot"
 on_boot_sec        = "5min"     # 起動 5 分後に初回
 on_unit_active_sec = "15min"    # 以後 15 分ごと
-persistent         = true       # 停止中に逃した分を次回起動時に補填
 ```
 
 timer 系フィールド（`on_unit_active_sec` / `on_boot_sec` / `on_calendar` / `persistent` など）を書くと、
@@ -156,9 +155,23 @@ mise が `.service` と `.timer` の両方を生成して timer を有効化す�
 なる（その場合は `restart = "on-failure"` 等を使う）。service 側の主なキー: `description` / `exec_start` /
 `type` / `restart` / `restart_sec` / `environment` / `working_directory` / `wanted_by`。
 
+> **`persistent` は monotonic timer には効かない**: `on_boot_sec` / `on_unit_active_sec` は
+> monotonic timer で、`persistent`（= `Persistent=`。停止中に逃した分を起動時に補填）は
+> `on_calendar`（`OnCalendar=`）のときだけ有効。上記のように 15 分間隔なら次回発火で自然に
+> 追いつくため付けていない。停止中の取りこぼしを必ず補填したい場合は、`on_calendar = "*:0/15"` の
+> ような calendar timer にしたうえで `persistent = true` を併用する。
+
 ## 適用
 
 `chezmoi apply` で config を反映してから、OS 別に bootstrap を適用する。まず `--dry-run` で差分を確認する。
+
+macOS の LaunchAgent は `stdout_path` / `stderr_path` の**ディレクトリが存在しないとログを書けない**
+（launchd は program 実行前にログファイルを開き、親ディレクトリは作らない）。ログ出力先を使う場合は
+先に作成しておく:
+
+```sh
+mkdir -p ~/.local/state/agentsview
+```
 
 ```sh
 # 差分だけ確認（何も触らない）

--- a/docs/mise.md
+++ b/docs/mise.md
@@ -103,3 +103,100 @@ mise brew も real brew も同じ `/opt/homebrew` prefix を使うため、Phase
 その後 real brew 側で `brew upgrade` / `brew doctor` / `brew cleanup` を走らせると、mise が張った
 リンクを「見知らぬリンク」とみなして触ってしまう可能性がある。real brew は cask（GUI アプリ）用途
 に限定して使い、`brew cleanup` は慎重に実行すること。
+
+# mise bootstrap で user service（定期 push 等）を設定する
+
+`mise bootstrap` は package 導入だけでなく、OS 標準の常駐/定期実行の仕組み（macOS: LaunchAgent、
+Linux: systemd user unit）も宣言的に管理できる。`mise.toml` に書いた定義から plist / unit ファイルを
+生成し、`launchctl` / `systemctl --user` へ load まで行う。cron を書かずに「N 分ごとに task を叩く」
+といった定期ジョブを dotfiles 管理下に置ける。
+
+このリポジトリでは AgentsView のセッションを 15 分ごとに PostgreSQL へ push する定期ジョブに使っている
+（[docs/agentsview.md](./agentsview.md) の「定期 push」参照）。以下はその設定を例にした一般的な使い方。
+
+## 定義（mise.toml）
+
+OS 別 config に書く。`[bootstrap.packages]` と同じく、`MISE_ENV` で読み込む config を切り替える。
+
+### macOS（LaunchAgent）
+
+`dot_config/mise/config.mac.toml`:
+
+```toml
+[bootstrap.macos.launchd.agents.agentsview-push]
+program        = "~/.local/bin/mise"          # launchd の最小 PATH でも辿れるよう絶対パス
+args           = ["run", "agentsview:pg:push:daemon"]
+run_at_load    = true                          # load 時にも 1 回走らせる
+start_interval = 900                           # 秒。15 分ごとに起動
+keep_alive     = false                         # 常駐ではなく都度起動なので false
+stdout_path    = "~/.local/state/agentsview/push.log"
+stderr_path    = "~/.local/state/agentsview/push.log"
+```
+
+主なキー: `program` / `args`（実行コマンド）、`run_at_load`（load 時実行）、`start_interval`（秒間隔）、
+`start_calendar_interval`（時刻指定）、`keep_alive`（落ちたら再起動する常駐）、`environment`（env 追加）、
+`working_directory`、`stdout_path` / `stderr_path`。
+
+### Linux（systemd user timer）
+
+`dot_config/mise/config.linux.toml`:
+
+```toml
+[bootstrap.linux.systemd.units.agentsview-push]
+description        = "Push AgentsView sessions to PostgreSQL every 15 minutes"
+exec_start         = "%h/.local/bin/mise run agentsview:pg:push:daemon"  # %h は systemd が $HOME に展開
+type               = "oneshot"
+on_boot_sec        = "5min"     # 起動 5 分後に初回
+on_unit_active_sec = "15min"    # 以後 15 分ごと
+persistent         = true       # 停止中に逃した分を次回起動時に補填
+```
+
+timer 系フィールド（`on_unit_active_sec` / `on_boot_sec` / `on_calendar` / `persistent` など）を書くと、
+mise が `.service` と `.timer` の両方を生成して timer を有効化する。timer 系を書かなければ常駐 service に
+なる（その場合は `restart = "on-failure"` 等を使う）。service 側の主なキー: `description` / `exec_start` /
+`type` / `restart` / `restart_sec` / `environment` / `working_directory` / `wanted_by`。
+
+## 適用
+
+`chezmoi apply` で config を反映してから、OS 別に bootstrap を適用する。まず `--dry-run` で差分を確認する。
+
+```sh
+# 差分だけ確認（何も触らない）
+MISE_ENV=mac   mise bootstrap macos launchd-agents apply --dry-run
+MISE_ENV=linux mise bootstrap linux systemd-units apply --dry-run
+
+# 適用（plist/unit を書き出して load / enable）
+MISE_ENV=mac   mise bootstrap macos launchd-agents apply
+MISE_ENV=linux mise bootstrap linux systemd-units apply
+```
+
+Linux の headless / WSL では、ログインしていない間も timer を動かすため lingering を有効化する:
+
+```sh
+loginctl enable-linger "$USER"
+```
+
+## 状態確認・ログ
+
+```sh
+# mise から見た状態（Loaded/Missing/Differs 等）
+mise bootstrap macos launchd-agents status      # macOS
+mise bootstrap linux systemd-units status        # Linux
+
+# OS 側から
+launchctl list | grep agentsview                 # macOS
+systemctl --user list-timers 'agentsview-push*'  # Linux（次回発火時刻）
+journalctl --user -u agentsview-push -f          # Linux（ログ）
+```
+
+## 注意点
+
+- **PATH が最小**: LaunchAgent / systemd user unit は login shell を経ないため PATH が最小
+  （`/usr/bin:/bin` 等）。実行コマンドは絶対パス（macOS: `~/.local/bin/mise`、Linux: `%h/.local/bin/mise`）
+  で指定する。`mise run <task>` 経由にすれば、その task が使う mise 管理ツール（fnox / flyctl 等）は
+  mise が PATH に載せてくれる。
+- **secret は env に置かない**: 定期ジョブ用の secret も dotfiles や plist に直書きせず、task 側で
+  fnox（bws/age）から解決する。bws の `BWS_ACCESS_TOKEN` は age で解けるため、`~/.config/fnox/age.txt`
+  があれば非対話で解決できる（[docs/fnox.md](./fnox.md) 参照）。
+- **多重起動対策**: 前回実行が長引いて次の interval と重なりうる場合は、task 側でロック（例: proxy port の
+  使用チェック）を入れてスキップさせる。

--- a/dot_config/mise/config.linux.toml
+++ b/dot_config/mise/config.linux.toml
@@ -10,3 +10,17 @@
 "apt:tig"       = "latest"
 "apt:tree"      = "latest"
 "apt:ugrep"     = "latest"
+
+# AgentsView のセッションを 15 分ごとに PostgreSQL へ push する systemd user timer（詳細は docs/mise.md）。
+# timer 系フィールド（on_unit_active_sec 等）があると mise が .service と .timer を生成する。
+# 適用: MISE_ENV=linux mise bootstrap linux systemd-units apply
+# secret（AGENTSVIEW_PROXY_PG_URL）は task 側が fnox（bws/age）から解決する。
+# 事前に flyctl auth login 済みで、mise が %h/.local/bin/mise にあること。
+# headless / WSL では起動永続化に loginctl enable-linger "$USER" が必要。
+[bootstrap.linux.systemd.units.agentsview-push]
+description        = "Push AgentsView sessions to PostgreSQL every 15 minutes"
+exec_start         = "%h/.local/bin/mise run agentsview:pg:push:daemon"
+on_boot_sec        = "5min"
+on_unit_active_sec = "15min"
+persistent         = true
+type               = "oneshot"

--- a/dot_config/mise/config.linux.toml
+++ b/dot_config/mise/config.linux.toml
@@ -13,6 +13,8 @@
 
 # AgentsView のセッションを 15 分ごとに PostgreSQL へ push する systemd user timer（詳細は docs/mise.md）。
 # timer 系フィールド（on_unit_active_sec 等）があると mise が .service と .timer を生成する。
+# on_boot_sec / on_unit_active_sec は monotonic timer のため Persistent=（停止中の取りこぼし補填）
+# は効かない。15 分間隔では次回発火で追いつくため補填は不要とし persistent は付けない。
 # 適用: MISE_ENV=linux mise bootstrap linux systemd-units apply
 # secret（AGENTSVIEW_PROXY_PG_URL）は task 側が fnox（bws/age）から解決する。
 # 事前に flyctl auth login 済みで、mise が %h/.local/bin/mise にあること。
@@ -22,5 +24,4 @@ description        = "Push AgentsView sessions to PostgreSQL every 15 minutes"
 exec_start         = "%h/.local/bin/mise run agentsview:pg:push:daemon"
 on_boot_sec        = "5min"
 on_unit_active_sec = "15min"
-persistent         = true
 type               = "oneshot"

--- a/dot_config/mise/config.mac.toml
+++ b/dot_config/mise/config.mac.toml
@@ -20,3 +20,16 @@
 "brew:tig"          = "latest"
 "brew:tree"         = "latest"
 "brew:ugrep"        = "latest"
+
+# AgentsView のセッションを 15 分ごとに PostgreSQL へ push する LaunchAgent（詳細は docs/mise.md）。
+# 適用: MISE_ENV=mac mise bootstrap macos launchd-agents apply
+# secret（AGENTSVIEW_PROXY_PG_URL）は task 側が fnox（bws/age）から解決する。
+# 事前に flyctl auth login 済みで、mise が ~/.local/bin/mise にあること。
+[bootstrap.macos.launchd.agents.agentsview-push]
+args           = ["run", "agentsview:pg:push:daemon"]
+keep_alive     = false
+program        = "~/.local/bin/mise"
+run_at_load    = true
+start_interval = 900                                  # 15 min
+stderr_path    = "~/.local/state/agentsview/push.log"
+stdout_path    = "~/.local/state/agentsview/push.log"

--- a/dot_config/mise/tasks/agentsview.toml
+++ b/dot_config/mise/tasks/agentsview.toml
@@ -351,6 +351,10 @@ log() { printf '%s agentsview-push: %s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)" "$*"; }
 # （nc が無い環境で readiness 待ちが timeout するのを避ける）。subshell で FD を閉じる。
 port_open() { (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null; }
 
+# PID $1 の起動時刻トークン（PID 再利用の識別用）。同一 PID でも再利用後は別値になる。
+# macOS/Linux とも ps -o lstart で取得でき、死んだ PID では空になる。
+proc_token() { ps -o lstart= -p "$1" 2>/dev/null | tr -s ' ' | sed 's/^ *//;s/ *$//'; }
+
 # AGENTSVIEW_PROXY_PG_URL 未解決なら fnox 経由で解決して自身を再実行する（他 task と同じ流儀）。
 # launchd/systemd の最小 PATH でも確実に mise を辿れるよう、mise は絶対パスで指定する。
 if [ -z "${AGENTSVIEW_PROXY_PG_URL:-}" ] && [ -z "${_FNOX_REEXEC:-}" ]; then
@@ -395,32 +399,32 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 # 多重起動防止（macOS/Linux 共通。macOS に無い flock は使わず mkdir で atomic に取る）。
-# 判定は 2 段構え:
-#   1) lock の mtime が TTL 超過 → 無条件で stale とみなし奪う。異常終了で残った lock や、
-#      記録 PID が無関係プロセスに再利用されて kill -0 が誤って「生存」を返すケースでも、
-#      「同期が永久に止まる」ことを防ぐ backstop。TTL は通常 push（数分）や初回全件
-#      （~数時間）より十分大きく取る。
-#   2) TTL 内なら PID で判定。生存 or PID 未記録（取得直後で pid 書き込み前）は「実行中」
-#      とみなして skip（二重起動・取得直後の奪取レースを防ぐ）。記録 PID が既に死んでいる
-#      ときだけ「最近クラッシュ」として奪う。
+# ロックの正当性は PID + 起動時刻トークンで判定する:
+#   - token 未記録（mkdir 直後で書き込み前）→ 取得中とみなし skip（取得レース回避）。
+#   - PID 生存かつ token 一致 → 実行中の push。何時間かかっても skip（＝生きたロックを
+#     経過時間で奪わない。初回全件 push が数時間かかっても誤って奪取しない）。
+#   - PID 死亡、または token 不一致（PID が別プロセスに再利用された）→ stale として奪う。
+#     これで「異常終了後に PID が再利用されて永久に skip」も回避できる。
+# token を先、PID を後に書き、PID の有無を「取得完了」マーカーにする。
 # なお最終的な二重 push は port(15432) を同時 bind できない flyctl 側でも弾かれる。
-lock_stale_min=360
 mkdir -p "$(dirname "$lock_dir")"
 if ! mkdir "$lock_dir" 2>/dev/null; then
-  if [ -n "$(find "$lock_dir" -maxdepth 0 -mmin "+${lock_stale_min}" 2>/dev/null)" ]; then
-    log "reclaiming stale lock (older than ${lock_stale_min}min)"
-  else
-    old_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
-    if [ -z "$old_pid" ] || kill -0 "$old_pid" 2>/dev/null; then
-      log "another push (pid ${old_pid:-acquiring}) appears active. Skipping."
-      exit 0
-    fi
-    log "reclaiming stale lock (pid $old_pid not running)"
+  old_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+  old_tok="$(cat "$lock_dir/token" 2>/dev/null || true)"
+  if [ -z "$old_pid" ]; then
+    log "another push is acquiring the lock. Skipping."
+    exit 0
   fi
+  if kill -0 "$old_pid" 2>/dev/null && [ "$(proc_token "$old_pid")" = "$old_tok" ]; then
+    log "another push (pid $old_pid) is still running. Skipping."
+    exit 0
+  fi
+  log "reclaiming stale lock (pid $old_pid no longer the owner)"
   rm -rf "$lock_dir"
   mkdir "$lock_dir" 2>/dev/null || { log "could not acquire lock. Skipping."; exit 0; }
 fi
 lock_owned=1
+proc_token "$$" >"$lock_dir/token"
 printf '%s\n' "$$" >"$lock_dir/pid"
 
 proxy_log="$(mktemp)"

--- a/dot_config/mise/tasks/agentsview.toml
+++ b/dot_config/mise/tasks/agentsview.toml
@@ -395,17 +395,28 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 # 多重起動防止（macOS/Linux 共通。macOS に無い flock は使わず mkdir で atomic に取る）。
-# 前回 push がまだ生きていれば skip（初回全件 push は数時間かかり interval と重なりうる）。
-# 異常終了で残ったロックは、記録した PID の生死で stale と判定して奪い直す。これにより
-# port 占有チェックだけの実装のように「同期が永久に止まる」ことを避ける。
+# 判定は 2 段構え:
+#   1) lock の mtime が TTL 超過 → 無条件で stale とみなし奪う。異常終了で残った lock や、
+#      記録 PID が無関係プロセスに再利用されて kill -0 が誤って「生存」を返すケースでも、
+#      「同期が永久に止まる」ことを防ぐ backstop。TTL は通常 push（数分）や初回全件
+#      （~数時間）より十分大きく取る。
+#   2) TTL 内なら PID で判定。生存 or PID 未記録（取得直後で pid 書き込み前）は「実行中」
+#      とみなして skip（二重起動・取得直後の奪取レースを防ぐ）。記録 PID が既に死んでいる
+#      ときだけ「最近クラッシュ」として奪う。
+# なお最終的な二重 push は port(15432) を同時 bind できない flyctl 側でも弾かれる。
+lock_stale_min=360
 mkdir -p "$(dirname "$lock_dir")"
 if ! mkdir "$lock_dir" 2>/dev/null; then
-  old_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
-  if [ -n "$old_pid" ] && kill -0 "$old_pid" 2>/dev/null; then
-    log "another push (pid $old_pid) is still running. Skipping."
-    exit 0
+  if [ -n "$(find "$lock_dir" -maxdepth 0 -mmin "+${lock_stale_min}" 2>/dev/null)" ]; then
+    log "reclaiming stale lock (older than ${lock_stale_min}min)"
+  else
+    old_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+    if [ -z "$old_pid" ] || kill -0 "$old_pid" 2>/dev/null; then
+      log "another push (pid ${old_pid:-acquiring}) appears active. Skipping."
+      exit 0
+    fi
+    log "reclaiming stale lock (pid $old_pid not running)"
   fi
-  log "reclaiming stale lock (pid ${old_pid:-unknown})"
   rm -rf "$lock_dir"
   mkdir "$lock_dir" 2>/dev/null || { log "could not acquire lock. Skipping."; exit 0; }
 fi

--- a/dot_config/mise/tasks/agentsview.toml
+++ b/dot_config/mise/tasks/agentsview.toml
@@ -399,33 +399,42 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 # 多重起動防止（macOS/Linux 共通。macOS に無い flock は使わず mkdir で atomic に取る）。
-# ロックの正当性は PID + 起動時刻トークンで判定する:
-#   - token 未記録（mkdir 直後で書き込み前）→ 取得中とみなし skip（取得レース回避）。
-#   - PID 生存かつ token 一致 → 実行中の push。何時間かかっても skip（＝生きたロックを
-#     経過時間で奪わない。初回全件 push が数時間かかっても誤って奪取しない）。
-#   - PID 死亡、または token 不一致（PID が別プロセスに再利用された）→ stale として奪う。
-#     これで「異常終了後に PID が再利用されて永久に skip」も回避できる。
-# token を先、PID を後に書き、PID の有無を「取得完了」マーカーにする。
-# なお最終的な二重 push は port(15432) を同時 bind できない flyctl 側でも弾かれる。
+# owner 情報は "<pid> <lstart>" を 1 ファイル(info)に temp+rename で atomic に書く
+# （half-written を作らない）。既存ロックは以下で判定する:
+#   - info 無し → 取得直後(ms)の他プロセス、または info 書き込み前のクラッシュ跡。恒久
+#     orphan を避けるため奪う。まれな取得レースは flyctl の port 単一 bind で直列化される。
+#   - PID 生存かつ lstart 一致 → 実行中の push。経過時間では奪わない（初回全件 push が
+#     数時間かかっても誤奪取しない）。
+#   - PID 死亡 or lstart 不一致（PID 再利用）→ stale として奪う。
+#   - 上記で「生存」でも mtime が TTL 超過なら奪う。lstart は秒解像度のため、同一 PID が
+#     同秒に再起動する病的ケースの最後の backstop。TTL は実 push 最長（~数時間）を大きく
+#     上回る 24h とし、生きた push を経過時間で奪わない。
+# 最終的な二重 push は port(15432) を同時 bind できない flyctl 側でも弾かれる。
+lock_stale_min=1440
 mkdir -p "$(dirname "$lock_dir")"
 if ! mkdir "$lock_dir" 2>/dev/null; then
-  old_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
-  old_tok="$(cat "$lock_dir/token" 2>/dev/null || true)"
-  if [ -z "$old_pid" ]; then
-    log "another push is acquiring the lock. Skipping."
-    exit 0
+  info="$(cat "$lock_dir/info" 2>/dev/null || true)"
+  old_pid="${info%% *}"
+  old_tok="${info#* }"
+  stale=""
+  if [ -z "$info" ]; then
+    stale="no owner recorded"
+  elif ! kill -0 "$old_pid" 2>/dev/null || [ "$(proc_token "$old_pid")" != "$old_tok" ]; then
+    stale="pid $old_pid no longer the owner"
+  elif [ -n "$(find "$lock_dir" -maxdepth 0 -mmin "+${lock_stale_min}" 2>/dev/null)" ]; then
+    stale="older than ${lock_stale_min}min"
   fi
-  if kill -0 "$old_pid" 2>/dev/null && [ "$(proc_token "$old_pid")" = "$old_tok" ]; then
+  if [ -z "$stale" ]; then
     log "another push (pid $old_pid) is still running. Skipping."
     exit 0
   fi
-  log "reclaiming stale lock (pid $old_pid no longer the owner)"
+  log "reclaiming stale lock ($stale)"
   rm -rf "$lock_dir"
   mkdir "$lock_dir" 2>/dev/null || { log "could not acquire lock. Skipping."; exit 0; }
 fi
 lock_owned=1
-proc_token "$$" >"$lock_dir/token"
-printf '%s\n' "$$" >"$lock_dir/pid"
+printf '%s %s\n' "$$" "$(proc_token "$$")" >"$lock_dir/.info.$$"
+mv -f "$lock_dir/.info.$$" "$lock_dir/info"
 
 proxy_log="$(mktemp)"
 

--- a/dot_config/mise/tasks/agentsview.toml
+++ b/dot_config/mise/tasks/agentsview.toml
@@ -347,6 +347,10 @@ set -eu
 
 log() { printf '%s agentsview-push: %s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)" "$*"; }
 
+# 127.0.0.1:<port> が接続可能か。bash 組み込みの /dev/tcp を使い nc 非依存にする
+# （nc が無い環境で readiness 待ちが timeout するのを避ける）。subshell で FD を閉じる。
+port_open() { (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null; }
+
 # AGENTSVIEW_PROXY_PG_URL 未解決なら fnox 経由で解決して自身を再実行する（他 task と同じ流儀）。
 # launchd/systemd の最小 PATH でも確実に mise を辿れるよう、mise は絶対パスで指定する。
 if [ -z "${AGENTSVIEW_PROXY_PG_URL:-}" ] && [ -z "${_FNOX_REEXEC:-}" ]; then
@@ -369,32 +373,61 @@ fi
 
 proxy_port="${AGENTSVIEW_PG_PROXY_PORT:-15432}"
 proxy_app="${AGENTSVIEW_PG_APP:-psgl}"
-proxy_log="$(mktemp)"
+proxy_log=""
+proxy_pid=""
+lock_dir="${XDG_STATE_HOME:-$HOME/.local/state}/agentsview/push.lock"
+lock_owned=""
 
 cleanup() {
-  if [ -n "${proxy_pid:-}" ]; then
+  if [ -n "$proxy_pid" ]; then
     kill "$proxy_pid" 2>/dev/null || true
     wait "$proxy_pid" 2>/dev/null || true
   fi
-  rm -f "$proxy_log"
+  [ -n "$proxy_log" ] && rm -f "$proxy_log"
+  [ -n "$lock_owned" ] && rm -rf "$lock_dir"
+  # EXIT trap の最後の評価が終了コードになるため、必ず 0 で返す（skip 経路が失敗扱いに
+  # ならないように）。
+  return 0
 }
-
-# 前回 push が長引いて proxy が生きている場合は多重起動せず今回はスキップする
-# （初回全件 push は数時間かかるため、次の interval と重なりうる）。
-if nc -z 127.0.0.1 "$proxy_port" >/dev/null 2>&1; then
-  log "127.0.0.1:${proxy_port} is already in use (previous push still running?). Skipping."
-  exit 0
-fi
-
-flyctl proxy "${proxy_port}:5432" -a "$proxy_app" >"$proxy_log" 2>&1 &
-proxy_pid=$!
 
 trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
+# 多重起動防止（macOS/Linux 共通。macOS に無い flock は使わず mkdir で atomic に取る）。
+# 前回 push がまだ生きていれば skip（初回全件 push は数時間かかり interval と重なりうる）。
+# 異常終了で残ったロックは、記録した PID の生死で stale と判定して奪い直す。これにより
+# port 占有チェックだけの実装のように「同期が永久に止まる」ことを避ける。
+mkdir -p "$(dirname "$lock_dir")"
+if ! mkdir "$lock_dir" 2>/dev/null; then
+  old_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+  if [ -n "$old_pid" ] && kill -0 "$old_pid" 2>/dev/null; then
+    log "another push (pid $old_pid) is still running. Skipping."
+    exit 0
+  fi
+  log "reclaiming stale lock (pid ${old_pid:-unknown})"
+  rm -rf "$lock_dir"
+  mkdir "$lock_dir" 2>/dev/null || { log "could not acquire lock. Skipping."; exit 0; }
+fi
+lock_owned=1
+printf '%s\n' "$$" >"$lock_dir/pid"
+
+proxy_log="$(mktemp)"
+
+# ロックで自分自身の多重起動は防いだうえで port がまだ埋まっている場合は、無関係な
+# サービスや異常終了で残った proxy が握っている状況。skip で握り潰さず失敗させて可視化する。
+if port_open "$proxy_port"; then
+  log "127.0.0.1:${proxy_port} is already in use by another process. Aborting."
+  exit 1
+fi
+
+flyctl proxy "${proxy_port}:5432" -a "$proxy_app" >"$proxy_log" 2>&1 &
+proxy_pid=$!
+
+# 自分が起動した flyctl proxy が listen し始めるまで待つ。proxy が bind に失敗すれば
+# （＝別プロセスが port を奪った等）flyctl は即終了するため、その死活で検出できる。
 i=0
-while ! nc -z 127.0.0.1 "$proxy_port" >/dev/null 2>&1; do
+while ! port_open "$proxy_port"; do
   if ! kill -0 "$proxy_pid" 2>/dev/null; then
     cat "$proxy_log" >&2
     log "flyctl proxy exited before it was ready"
@@ -408,6 +441,15 @@ while ! nc -z 127.0.0.1 "$proxy_port" >/dev/null 2>&1; do
   fi
   sleep 0.25
 done
+
+# push 直前に自分の proxy が生きていることを最終確認する。pre-check 後〜bind 前の僅かな
+# 隙に別プロセスが port を握ると flyctl は bind 失敗で終了しているはずで、ここで捕まえる。
+# （credential を含む接続先を誤って別 listener に向けて push しないための保険。）
+if ! kill -0 "$proxy_pid" 2>/dev/null; then
+  cat "$proxy_log" >&2
+  log "flyctl proxy is no longer running just before push. Aborting."
+  exit 1
+fi
 
 export AGENTSVIEW_PG_URL="$AGENTSVIEW_PROXY_PG_URL"
 export AGENTSVIEW_PG_MACHINE="${AGENTSVIEW_PG_MACHINE:-$(hostname)}"

--- a/dot_config/mise/tasks/agentsview.toml
+++ b/dot_config/mise/tasks/agentsview.toml
@@ -337,6 +337,87 @@ agentsview pg push "$@"
 '''
 shell = "bash -c"
 
+["agentsview:pg:push:daemon"]
+description = "Non-interactive AgentsView push for launchd/systemd timers (resolve secret via fnox, start flyctl proxy, push, stop proxy)"
+# launchd / systemd timer から定期起動される想定の非対話 push。
+# secret（AGENTSVIEW_PROXY_PG_URL）は他 task と同じく fnox（bws/age）から解決する。
+# launchd/systemd は zsh 起動を経ないため、AGENTSVIEW_PG_MACHINE も dot_zshenv と同じ導出で補う。
+run = '''
+set -eu
+
+log() { printf '%s agentsview-push: %s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)" "$*"; }
+
+# AGENTSVIEW_PROXY_PG_URL 未解決なら fnox 経由で解決して自身を再実行する（他 task と同じ流儀）。
+# launchd/systemd の最小 PATH でも確実に mise を辿れるよう、mise は絶対パスで指定する。
+if [ -z "${AGENTSVIEW_PROXY_PG_URL:-}" ] && [ -z "${_FNOX_REEXEC:-}" ]; then
+  export _FNOX_REEXEC=1
+  mise_bin="$(command -v mise 2>/dev/null || printf '%s' "$HOME/.local/bin/mise")"
+  exec fnox exec -- "$mise_bin" run agentsview:pg:push:daemon "$@"
+fi
+
+: "${AGENTSVIEW_PROXY_PG_URL:?fnox が未解決です。dot_config/fnox/config.toml を確認してください}"
+
+# machine 名は dot_zshenv.tmpl と同じく host-env.map から導出し、対話 push と同じ名前に揃える。
+# zsh を経ない起動でも DB 上の machine 名が分裂しないようにする（未解決なら hostname にフォールバック）。
+if [ -z "${AGENTSVIEW_PG_MACHINE:-}" ]; then
+  _host_id="${MISE_HOST_ID:-$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null)}"
+  _host_env="$(awk -F'[[:space:]]*=[[:space:]]*' -v h="$_host_id" \
+      '!/^[[:space:]]*(#|$)/ && $1 == h {print $2; exit}' \
+      "${XDG_CONFIG_HOME:-$HOME/.config}/zsh/host-env.map" 2>/dev/null || true)"
+  [ -n "$_host_env" ] && AGENTSVIEW_PG_MACHINE="$(printf '%s' "$_host_env" | tr ',' '-')"
+fi
+
+proxy_port="${AGENTSVIEW_PG_PROXY_PORT:-15432}"
+proxy_app="${AGENTSVIEW_PG_APP:-psgl}"
+proxy_log="$(mktemp)"
+
+cleanup() {
+  if [ -n "${proxy_pid:-}" ]; then
+    kill "$proxy_pid" 2>/dev/null || true
+    wait "$proxy_pid" 2>/dev/null || true
+  fi
+  rm -f "$proxy_log"
+}
+
+# 前回 push が長引いて proxy が生きている場合は多重起動せず今回はスキップする
+# （初回全件 push は数時間かかるため、次の interval と重なりうる）。
+if nc -z 127.0.0.1 "$proxy_port" >/dev/null 2>&1; then
+  log "127.0.0.1:${proxy_port} is already in use (previous push still running?). Skipping."
+  exit 0
+fi
+
+flyctl proxy "${proxy_port}:5432" -a "$proxy_app" >"$proxy_log" 2>&1 &
+proxy_pid=$!
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+i=0
+while ! nc -z 127.0.0.1 "$proxy_port" >/dev/null 2>&1; do
+  if ! kill -0 "$proxy_pid" 2>/dev/null; then
+    cat "$proxy_log" >&2
+    log "flyctl proxy exited before it was ready"
+    exit 1
+  fi
+  i=$((i + 1))
+  if [ "$i" -ge 40 ]; then
+    cat "$proxy_log" >&2
+    log "Timed out waiting for flyctl proxy on 127.0.0.1:${proxy_port}"
+    exit 1
+  fi
+  sleep 0.25
+done
+
+export AGENTSVIEW_PG_URL="$AGENTSVIEW_PROXY_PG_URL"
+export AGENTSVIEW_PG_MACHINE="${AGENTSVIEW_PG_MACHINE:-$(hostname)}"
+
+log "pushing (machine=${AGENTSVIEW_PG_MACHINE})"
+agentsview pg push "$@"
+log "done"
+'''
+shell = "bash -c"
+
 ["agentsview:serve"]
 description = "Start local AgentsView server"
 run         = "agentsview serve"


### PR DESCRIPTION
## Summary

This PR adds support for automated periodic pushing of AgentsView sessions to PostgreSQL every 15 minutes using OS-level user services (macOS LaunchAgent and Linux systemd timer), managed declaratively through mise bootstrap.

## Key Changes

- **New daemon task** (`agentsview:pg:push:daemon`): Non-interactive push task designed for periodic execution via launchd/systemd timers. Handles:
  - Secret resolution via fnox (bws/age) with automatic re-execution if needed
  - Machine name derivation from `host-env.map` to match interactive push behavior
  - Temporary flyctl proxy lifecycle management (start, push, stop)
  - Multi-run protection by checking if proxy port is already in use

- **macOS LaunchAgent configuration** (`dot_config/mise/config.mac.toml`):
  - Runs `mise run agentsview:pg:push:daemon` every 900 seconds (15 minutes)
  - Logs to `~/.local/state/agentsview/push.log`
  - Executes on load and keeps_alive disabled for one-shot execution

- **Linux systemd timer configuration** (`dot_config/mise/config.linux.toml`):
  - Systemd oneshot service with timer triggering every 15 minutes
  - 5-minute delay on boot before first execution
  - Persistent timer to catch missed runs during system downtime

- **Documentation**:
  - Comprehensive guide in `docs/mise.md` explaining mise bootstrap user service management with general examples
  - AgentsView-specific documentation in `docs/agentsview.md` detailing the periodic push feature, prerequisites, and troubleshooting

## Implementation Details

- Secrets remain managed through fnox (bws/age) rather than stored in config files or environment
- Task handles missing environment variables (e.g., `AGENTSVIEW_PG_MACHINE`) that aren't available in non-login shells by deriving them from configuration files
- Multi-run safety: skips execution if previous push is still running (initial full sync can take hours)
- Uses absolute paths for mise binary since launchd/systemd have minimal PATH
- Includes proper signal handling (INT/TERM) and cleanup of temporary proxy processes

https://claude.ai/code/session_01CPbMxyoM5HXocNWwF5GGcJ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 15-minute, non-interactive AgentsView push to PostgreSQL using `mise` user services on macOS (LaunchAgent) and Linux (systemd timer). Improves reliability with a self-healing PID+start-time lock, `/dev/tcp` readiness, and strict proxy ownership checks.

- New Features
  - New `agentsview:pg:push:daemon`: resolves `AGENTSVIEW_PROXY_PG_URL` via `fnox` (re-exec), derives `AGENTSVIEW_PG_MACHINE` from `host-env.map` (hostname fallback), starts/stops `flyctl` proxy per run, waits via `/dev/tcp`, rechecks proxy liveness before push, traps signals, and cleans up.
  - Locking: portable `mkdir` lock with owner recorded atomically as "<pid> <start-time>"; self-heals empty/incomplete locks; reclaims dead/reused PIDs; 24h backstop for pathological PID+lstart collisions; foreign listener aborts; legitimate skips exit 0.
  - macOS: LaunchAgent every 900s; logs to `~/.local/state/agentsview/push.log` (create dir first). `~` in `program` is expanded by `mise` when writing the plist.
  - Linux: systemd oneshot + timer every 15m with 5m boot delay; monotonic timers (no Persistent backfill). Docs note using `OnCalendar` if backfill is required.

- Migration
  - Apply: `MISE_ENV=mac mise bootstrap macos launchd-agents apply` or `MISE_ENV=linux mise bootstrap linux systemd-units apply`.
  - Prereqs: `flyctl auth login`; `fnox` configured; `mise` at `~/.local/bin/mise` (Linux uses `%h/.local/bin/mise`); on macOS run `mkdir -p ~/.local/state/agentsview`; on headless/WSL Linux run `loginctl enable-linger $USER`.
  - Verify: `mise run agentsview:pg:push:daemon`, check logs/status.

<sup>Written for commit 60f20cf04aca9b0c9551151cbb9a473f83c9080f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
- AgentsView のセッションを PostgreSQL へ15分ごとに自動 push する仕組みを追加。
- mise タスクで proxy 起動・停止、秘密情報解決、マシン名導出、重複実行防止、後処理を実装。
- macOS LaunchAgent と Linux systemd user timer による定期実行を設定。
- セットアップ方法、前提条件、確認・トラブルシューティング手順をドキュメント化。

## 変更理由
AgentsView のセッション情報を継続的に PostgreSQL へ同期するため。常駐プロセスではなく、必要なときだけ proxy を起動して差分 push することで、運用負荷と不要な常駐を抑える。

## 確認した項目
- macOS は900秒間隔、Linux は起動5分後から15分間隔で実行される設定。
- fnox による認証情報解決、proxy の確実な停止、シグナル時のクリーンアップを確認。
- proxy 稼働中の重複実行をスキップする制御を確認。
- mise bootstrap、Linux の lingering、ログ確認などの運用手順を確認。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an OS-scheduled AgentsView PostgreSQL synchronization flow.
- Adds a non-interactive mise task that resolves secrets, derives the machine identity, manages a temporary Fly proxy, and serializes scheduled runs.
- Adds macOS LaunchAgent and Linux systemd timer definitions for 15-minute execution.
- Documents setup, prerequisites, service management, and troubleshooting.

<h3>Confidence Score: 3/5</h3>

The PR should not be merged until the previously reported listener-ownership boundary is shown to be enforced or otherwise fixed.

The daemon now checks that the launched Fly process is alive, but readiness still accepts any process listening on the configured port and the available evidence does not establish that the accepting socket belongs to Fly.

**Files Needing Attention:** dot_config/mise/tasks/agentsview.toml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| dot_config/mise/tasks/agentsview.toml | Adds the scheduled push workflow with secret resolution, host mapping, process-aware locking, Fly proxy lifecycle management, and readiness checks. |
| dot_config/mise/config.mac.toml | Adds a 15-minute macOS LaunchAgent for the daemon task. |
| dot_config/mise/config.linux.toml | Adds a Linux systemd user oneshot service and monotonic timer. |
| docs/agentsview.md | Documents the periodic synchronization architecture, prerequisites, application, and troubleshooting. |
| docs/mise.md | Documents declarative mise bootstrap management for LaunchAgents and systemd user units. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Timer as launchd/systemd timer
    participant Mise as mise daemon task
    participant Fnox as fnox
    participant Fly as flyctl proxy
    participant AV as AgentsView
    participant PG as PostgreSQL
    Timer->>Mise: Run every 15 minutes
    Mise->>Fnox: Resolve PostgreSQL URL
    Fnox-->>Mise: Re-execute with secret
    Mise->>Mise: Acquire single-run lock
    Mise->>Fly: Start local proxy
    Mise->>Fly: Wait for local port
    Mise->>AV: pg push
    AV->>PG: Synchronize through proxy
    AV-->>Mise: Push result
    Mise->>Fly: Stop proxy
    Mise->>Mise: Release lock
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(agentsview): self-heal incomplete pu..."](https://github.com/ryo246912/dotfiles/commit/60f20cf04aca9b0c9551151cbb9a473f83c9080f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47430936)</sub>

<!-- /greptile_comment -->