### PR TITLE
Change lazygit keybinding from <leader>lg to <leader>gg

### DIFF
--- a/dot_config/nvim/lua/plugins/git.lua
+++ b/dot_config/nvim/lua/plugins/git.lua
@@ -685,7 +685,7 @@ return {
         end
       end
 
-      keymap("n", "<leader>lg", open_lazygit_with_selection, { noremap = true, silent = true, desc = "lazygit を開く（ディレクトリ選択）" })
+      keymap("n", "<leader>gg", open_lazygit_with_selection, { noremap = true, silent = true, desc = "lazygit を開く（ディレクトリ選択）" })
     end,
   },
 }


### PR DESCRIPTION
## Summary
Updated the keybinding for opening lazygit with directory selection from `<leader>lg` to `<leader>gg` in the Neovim git plugins configuration.

## Changes
- Changed the lazygit keybinding from `<leader>lg` to `<leader>gg` to provide a more intuitive mnemonic (gg for "git gui")
- The functionality and description remain unchanged

## Details
This change improves the keybinding consistency by using `<leader>gg` which better represents "git gui" (lazygit), making it more memorable and aligned with common git command conventions.

https://claude.ai/code/session_011K8v3YALisKH5St8CBK2Tq

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changed the lazygit keybinding from <leader>lg to <leader>gg. This fixes the <leader>l prefix conflict that caused input delay and groups lazygit under the git prefix for an easier mnemonic.

<sup>Written for commit f827364d0f1c056a3d1ef063435bc2e4925d7bad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
lazygit のキーバインドを `<leader>lg` から `<leader>gg` に変更しました。

## 変更理由
`<leader>g` 系の Git マッピングに統一しました。`<leader>l` とのプレフィックス競合による入力遅延も解消します。

## 確認した項目
lazygit の起動処理、リポジトリ選択機能、説明は変更していません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->