### PR TITLE
Refactor lefthook installation hooks to use postinstall

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -137,7 +137,8 @@ bun = true
 uvx = true
 
 [hooks]
-enter = """
+postinstall = """
 [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] || exit 0
+[ -f lefthook.yml ] || exit 0
 lefthook install
 """

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -138,7 +138,9 @@ uvx = true
 
 [hooks]
 postinstall = """
-[ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] || exit 0
-[ -f lefthook.yml ] || exit 0
+command -v lefthook >/dev/null 2>&1 || exit 0
+root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+[ -f "$root/lefthook.yml" ] || exit 0
+cd "$root"
 lefthook install
 """

--- a/mise.toml
+++ b/mise.toml
@@ -20,8 +20,12 @@ includes = ["tasks/*.toml"]
 "npm:oxlint"                     = "1.76.0"
 
 [hooks]
-postinstall = "lefthook install"
+postinstall = """
+command -v lefthook >/dev/null 2>&1 || exit 0
+[ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] || exit 0
+lefthook install
+"""
 
 [[watch_files]]
 patterns = ["lefthook.yml"]
-run = "lefthook install"
+run      = "lefthook install"

--- a/mise.toml
+++ b/mise.toml
@@ -20,7 +20,8 @@ includes = ["tasks/*.toml"]
 "npm:oxlint"                     = "1.76.0"
 
 [hooks]
-enter = """
-[ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] || exit 0
-lefthook install
-"""
+postinstall = "lefthook install"
+
+[[watch_files]]
+patterns = ["lefthook.yml"]
+run = "lefthook install"


### PR DESCRIPTION
## Summary
Refactored the lefthook installation configuration from using `enter` hooks to `postinstall` hooks, and added file watching for automatic re-installation when the lefthook configuration changes.

## Key Changes
- **mise.toml**: Converted `enter` hook to `postinstall` hook and added a `watch_files` section to monitor `lefthook.yml` for changes
- **dot_config/mise/config.toml**: Changed `enter` hook to `postinstall` hook and added a check to verify `lefthook.yml` exists before attempting installation

## Implementation Details
- The `postinstall` hook is more appropriate than `enter` for one-time setup tasks like installing lefthook
- Added file watching pattern for `lefthook.yml` to automatically trigger `lefthook install` when the configuration file changes
- Added defensive check (`[ -f lefthook.yml ] || exit 0`) in the global config to gracefully handle cases where lefthook configuration doesn't exist
- Maintained the existing git repository check to skip installation outside of git repositories

https://claude.ai/code/session_01DwpfF9LAh7KnDM2cqDUpVU

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch lefthook installation to run on `postinstall` instead of on every directory `enter`, add a watcher for `lefthook.yml`, and harden guards to avoid running outside Git repos or when `lefthook` isn’t installed.

- **Refactors**
  - `mise.toml`: replace `enter` with `postinstall`; add `watch_files` for `lefthook.yml`; add Git work-tree check and skip if `lefthook` is missing.
  - `dot_config/mise/config.toml`: replace `enter` with `postinstall`; anchor to the repo top-level and only run if `lefthook.yml` exists; skip if `lefthook` is missing.

<sup>Written for commit 41e732da73928411d1e0cde2a0282174a6a98ff6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

