### PR TITLE
Add OneCLI integration: docs, mise config, and devcontainer env passthrough

### DIFF
--- a/docs/onecli.md
+++ b/docs/onecli.md
@@ -1,0 +1,127 @@
+# OneCLI
+
+[OneCLI](https://github.com/onecli/onecli) は、AI エージェントの HTTP(S) 通信を gateway に通し、
+接続先に応じた credential を注入する secret gateway です。この設定では AI エージェントと
+OneCLI CLI を devcontainer 内で実行します。実際の API key は OneCLI に保存し、エージェントには
+渡しません。
+
+## 導入されるもの
+
+`dot_config/devcontainer/mise.toml` で
+[OneCLI CLI](https://github.com/onecli/onecli-cli) を導入します。devcontainer image の build 時に
+mise がインストールするため、専用の install task や setup script はありません。
+
+OneCLI CLI は `onecli run -- <agent>` の実行時に、次の処理を行います。
+
+1. OneCLI から agent 用 proxy URL、dummy credential、gateway CA を取得する。
+2. CA と agent integration を準備する。
+3. proxy と dummy credential を子プロセスだけに設定して AI エージェントを起動する。
+
+このため devcontainer 全体へ `HTTP_PROXY` などを設定する必要はありません。
+
+## OneCLI の接続先
+
+### OneCLI Cloud を使う場合
+
+Dashboard で API key（`oc_...`）を発行し、ホストの `~/.zshrc.secret` に設定します。
+
+```bash
+export ONECLI_API_HOST="https://api.onecli.sh"
+export ONECLI_API_KEY="oc_..."
+```
+
+### self-hosted 版を使う場合
+
+OneCLI 本体は公式手順に従ってホストの Docker で起動します。
+
+```bash
+curl -fsSL https://onecli.sh/install | sh
+```
+
+ローカルモードでは API key は不要です。ホストの `~/.zshrc.secret` には、devcontainer から
+ホストへ到達できる URL を設定します。
+
+```bash
+export ONECLI_API_HOST="http://host.docker.internal:10254"
+unset ONECLI_API_KEY
+```
+
+`devcontainer.json` はこの2変数だけをホスト環境から引き継ぎます。設定後に新しい shell から
+devcontainer を recreate してください。
+
+## real API key と dummy の対応
+
+### Anthropic / OpenAI
+
+LLM 用 credential の dummy 値は手作業で対応表を作る必要がありません。OneCLI が agent に許可された
+secret を見て、`onecli run` の子プロセスへ自動的に次の値を設定します。
+
+| Connection        | エージェント側の設定                | gateway が注入する値                                 |
+| ----------------- | ----------------------------------- | ---------------------------------------------------- |
+| Anthropic API key | 手動設定不要                        | OneCLI に保存した real API key を `x-api-key` に注入 |
+| OpenAI API key    | OneCLI CLI が dummy/stub を自動設定 | OneCLI に保存した real API key                       |
+
+設定手順は次のとおりです。
+
+1. OneCLI Dashboard の **Connections** を開く。
+2. **LLM keys** から Anthropic または OpenAI を選び、real API key を保存する。
+3. **Agents** で devcontainer 用 agent を作成する。
+4. agent の **Credential access** で、その connection の利用を許可する。
+5. policy に未反映の変更がある場合は publish する。
+
+real API key や dummy を `.env`、`devcontainer.json`、`~/.zshrc.secret` に書かないでください。
+必要な dummy credential や認証 stub は `onecli run` が起動するプロセスにだけ設定します。
+
+### custom API
+
+任意の API は **Connections > Custom secrets** で次を設定します。
+
+- **Value**: real API key
+- **Host pattern**: 例 `api.example.com`
+- **Path pattern**: 必要な場合のみ、例 `/v1/*`
+- **Inject as**: `Header`、`URL Parameter`、または `URL Path`
+- **Header name / Parameter name**: 例 `Authorization` または `api_key`
+- **Header value / Parameter value**: 例 `Bearer {value}`。`{value}` が real API key に置換される
+
+たとえば `Authorization: Bearer {value}` を設定した場合、エージェントは dummy を使って通常どおり
+リクエストできます。
+
+```bash
+curl -H 'Authorization: Bearer dummy' https://api.example.com/v1/resources
+```
+
+gateway は host/path が一致した通信だけを `Authorization: Bearer <real API key>` に差し替えます。
+custom secret も agent の **Credential access** で明示的に許可してください。
+
+## devcontainer での使い方
+
+接続確認を行います。
+
+```bash
+onecli auth status
+onecli agents list
+onecli agents get-default
+```
+
+使用する agent を OneCLI 経由で起動します。
+
+```bash
+onecli run -- claude
+onecli run -- codex
+onecli run -- copilot
+```
+
+default 以外の agent を使う場合は OneCLI CLI の `run --help` で agent 指定オプションを確認します。
+OneCLI を経由させずに `claude` や `codex` を直接起動した場合、proxy、CA、dummy credential は
+設定されないため、OneCLI の credential injection は動作しません。
+
+## 確認とトラブルシューティング
+
+- `onecli auth status` が失敗する: `ONECLI_API_HOST` と、Cloud の場合は `ONECLI_API_KEY` を確認する。
+- self-hosted へ接続できない: ホストで `docker compose -p onecli -f ~/.onecli/docker-compose.yml ps` を確認する。
+- credential が注入されない: agent の Credential access、published policy、secret の host/path を確認する。
+- API が `401` を返す: AI エージェントを直接ではなく `onecli run -- ...` で起動したか確認する。
+- 詳細は Dashboard の **Activity** で、対象リクエストが gateway を通過したか確認する。
+
+> OneCLI の API key は OneCLI 自体を操作するための credential です。`~/.zshrc.secret` を commit せず、
+> agent には必要最小限の connection だけを許可してください。

--- a/dot_config/devcontainer/devcontainer.json
+++ b/dot_config/devcontainer/devcontainer.json
@@ -18,7 +18,10 @@
     "CRIT_HOST": "0.0.0.0",
     "CRIT_PORT": "7842",
     // crit: コンテナ内では更新チェック不要のため無効化
-    "CRIT_NO_UPDATE_CHECK": "1"
+    "CRIT_NO_UPDATE_CHECK": "1",
+    // OneCLI CLI の接続先と API key。proxy/CA は `onecli run` が子プロセスに設定する。
+    "ONECLI_API_HOST": "${localEnv:ONECLI_API_HOST}",
+    "ONECLI_API_KEY": "${localEnv:ONECLI_API_KEY}"
   },
   // crit のレビューUIをホストのブラウザから開けるようにポートを公開する。
   // multi-worktree は devcontainer CLI (`devcontainer up`) で起動するが、CLI は forwardPorts を

--- a/dot_config/devcontainer/mise.toml
+++ b/dot_config/devcontainer/mise.toml
@@ -17,6 +17,7 @@ experimental = true
 "core:node"                      = "22.19.0"
 "core:python"                    = "3.14.6"
 "github:github/copilot-cli"      = "1.0.63"
+"github:onecli/onecli-cli"       = "2.7.0"
 "github:philschmid/mcp-cli"      = { version = "0.3.0", asset_pattern = "mcp-cli-linux-x64" }
 "github:tomasz-tomczyk/crit"     = "0.18.1"
 "npm:@typescript/native-preview" = "7.0.0-dev.20260519.1"


### PR DESCRIPTION
### Motivation

- Add support for running AI agents through OneCLI as a secret gateway in the devcontainer environment. 
- Ensure the OneCLI CLI is installed in the devcontainer image via `mise` so `onecli run` can prepare proxy/CA and inject credentials into child processes. 
- Provide user-facing documentation explaining setup, credential injection rules, and troubleshooting for OneCLI usage.

### Description

- Add `docs/onecli.md` with comprehensive Japanese documentation covering OneCLI concepts, onboarding (cloud and self-hosted), credential injection behavior, usage in the devcontainer, and troubleshooting. 
- Add `github:onecli/onecli-cli = "2.7.0"` to `dot_config/devcontainer/mise.toml` so the OneCLI CLI is installed during image build. 
- Expose `ONECLI_API_HOST` and `ONECLI_API_KEY` in `dot_config/devcontainer/devcontainer.json` `remoteEnv` so the container can reach OneCLI, with comments clarifying that proxy/CA and dummy credentials are set only for processes started via `onecli run`.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64cc3c34e08332871736eea9f1af3c)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates OneCLI into the devcontainer so agents run via `onecli run` with proxy/CA and credential injection. Installs the CLI via `mise`, passes through API host/key, and adds setup docs.

- **New Features**
  - Added `docs/onecli.md` (Japanese) covering setup (Cloud/self-hosted), credential injection, devcontainer usage, and troubleshooting.
  - Installed `github:onecli/onecli-cli` at `2.7.0` via `dot_config/devcontainer/mise.toml`.
  - Exposed `ONECLI_API_HOST` and `ONECLI_API_KEY` in `dot_config/devcontainer/devcontainer.json` `remoteEnv`. Proxy/CA and dummy creds are applied only to processes started with `onecli run`.

- **Migration**
  - Set `ONECLI_API_HOST` (and `ONECLI_API_KEY` for Cloud) in the host shell, then recreate the devcontainer.
  - Launch agents with `onecli run -- <agent>` to enable credential injection.

<sup>Written for commit 0f20ffa3089f0412009c237e183dbec35a9469c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

