### PR TITLE
feat(tmux): manage tmux plugins via mise instead of tpm

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -151,6 +151,16 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["dot_config/mise/**/*.toml"],
+      "matchStrings": [
+        "\"http:tmux-[a-z]+\"\\s*=\\s*\\{ version = \"(?<currentDigest>[0-9a-f]{40})\", url = \"https://github\\.com/(?<depName>[^/]+/[^/]+)/archive/"
+      ],
+      "currentValueTemplate": "master",
+      "datasourceTemplate": "git-refs",
+      "packageNameTemplate": "https://github.com/{{{depName}}}"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["dot_config/sheldon/**/*.toml"],
       "matchStrings": [
         "\\[plugins\\.(?<depName>[^\\]]+)\\]\\s+github\\s*=\\s*\"(?<packageName>[^\"]+)\"\\s+tag\\s*=\\s*\"(?<currentValue>[^\"]+)\""

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -161,6 +161,16 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["dot_config/mise/**/*.toml"],
+      "matchStrings": [
+        "\"http:[^\"]+\"\\s*=\\s*\\{[^}]*?version = \"(?<currentDigest>[0-9a-f]{40})\"[^}]*?url = \"https://github\\.com/(?<depName>[^/]+/[^/]+)/archive/"
+      ],
+      "currentValueTemplate": "main",
+      "datasourceTemplate": "git-refs",
+      "packageNameTemplate": "https://github.com/{{{depName}}}"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["dot_config/sheldon/**/*.toml"],
       "matchStrings": [
         "\\[plugins\\.(?<depName>[^\\]]+)\\]\\s+github\\s*=\\s*\"(?<packageName>[^\"]+)\"\\s+tag\\s*=\\s*\"(?<currentValue>[^\"]+)\""

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -144,7 +144,7 @@
       "customType": "regex",
       "managerFilePatterns": ["dot_config/mise/**/*.toml"],
       "matchStrings": [
-        "\"http:tmux-[a-z]+\"\\s*=\\s*\\{ version = \"(?<currentValue>[^\"]+)\", url = \"https://github\\.com/(?<depName>[^/]+/[^/]+)/archive/refs/tags/"
+        "\"http:[^\"]+\"\\s*=\\s*\\{[^}]*?version = \"(?<currentValue>[^\"]+)\"[^}]*?url = \"https://github\\.com/(?<depName>[^/]+/[^/]+)/archive/refs/tags/"
       ],
       "datasourceTemplate": "github-tags",
       "extractVersionTemplate": "^v?(?<version>.*)$"
@@ -153,7 +153,7 @@
       "customType": "regex",
       "managerFilePatterns": ["dot_config/mise/**/*.toml"],
       "matchStrings": [
-        "\"http:tmux-[a-z]+\"\\s*=\\s*\\{ version = \"(?<currentDigest>[0-9a-f]{40})\", url = \"https://github\\.com/(?<depName>[^/]+/[^/]+)/archive/"
+        "\"http:[^\"]+\"\\s*=\\s*\\{[^}]*?version = \"(?<currentDigest>[0-9a-f]{40})\"[^}]*?url = \"https://github\\.com/(?<depName>[^/]+/[^/]+)/archive/"
       ],
       "currentValueTemplate": "master",
       "datasourceTemplate": "git-refs",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -142,6 +142,15 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["dot_config/mise/**/*.toml"],
+      "matchStrings": [
+        "\"http:tmux-[a-z]+\"\\s*=\\s*\\{ version = \"(?<currentValue>[^\"]+)\", url = \"https://github\\.com/(?<depName>[^/]+/[^/]+)/archive/refs/tags/"
+      ],
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["dot_config/sheldon/**/*.toml"],
       "matchStrings": [
         "\\[plugins\\.(?<depName>[^\\]]+)\\]\\s+github\\s*=\\s*\"(?<packageName>[^\"]+)\"\\s+tag\\s*=\\s*\"(?<currentValue>[^\"]+)\""

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -99,6 +99,15 @@ ASDF_FFMPEG_ENABLE = "gpl libx264"
 "go:github.com/atotto/clipboard/cmd/gopaste"                = "0.1.4"
 "go:github.com/go-delve/delve/cmd/dlv"                      = "1.27.0"
 "go:github.com/x-motemen/gore/cmd/gore"                     = "0.6.2"
+# tmuxプラグイン: tpmの代わりにmiseでソースをpin取得し、tmux.confから直接ロードする
+# tag無しリポジトリ（cpu/fzf/resurrect）はcommit SHAでpinする
+"http:tmux-continuum"                                       = { version = "3.1.0", url = "https://github.com/tmux-plugins/tmux-continuum/archive/refs/tags/v{{version}}.tar.gz", strip_components = 1 }
+"http:tmux-cpu"                                             = { version = "bcb110d754ab2417de824c464730c412a3eb2769", url = "https://github.com/tmux-plugins/tmux-cpu/archive/{{version}}.tar.gz", strip_components = 1 }
+# バイナリはgithub backend（上記）でPATHに入れ、.tmuxスクリプト一式はここで取得する
+"http:tmux-fingers"                                         = { version = "2.7.1", url = "https://github.com/Morantron/tmux-fingers/archive/refs/tags/{{version}}.tar.gz", strip_components = 1 }
+"http:tmux-fzf"                                             = { version = "4cbbbbde54e1b63712d77483b83075fd712d3bb5", url = "https://github.com/sainnhe/tmux-fzf/archive/{{version}}.tar.gz", strip_components = 1 }
+"http:tmux-resurrect"                                       = { version = "d05fd6696716bd2434c25155374dc36d21347db4", url = "https://github.com/ryo246912/tmux-resurrect/archive/{{version}}.tar.gz", strip_components = 1 }
+"http:tmux-yank"                                            = { version = "2.3.0", url = "https://github.com/tmux-plugins/tmux-yank/archive/refs/tags/v{{version}}.tar.gz", strip_components = 1 }
 "npm:@devcontainers/cli"                                    = "0.88.0"
 "npm:@kitlangton/ghui"                                      = "0.9.0"
 "npm:agentlytics"                                           = "0.2.13"

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -99,11 +99,8 @@ ASDF_FFMPEG_ENABLE = "gpl libx264"
 "go:github.com/atotto/clipboard/cmd/gopaste"                = "0.1.4"
 "go:github.com/go-delve/delve/cmd/dlv"                      = "1.27.0"
 "go:github.com/x-motemen/gore/cmd/gore"                     = "0.6.2"
-# tmuxプラグイン: tpmの代わりにmiseでソースをpin取得し、tmux.confから直接ロードする
-# tag無しリポジトリ（cpu/fzf/resurrect）はcommit SHAでpinする
 "http:tmux-continuum"                                       = { version = "3.1.0", url = "https://github.com/tmux-plugins/tmux-continuum/archive/refs/tags/v{{version}}.tar.gz", strip_components = 1 }
 "http:tmux-cpu"                                             = { version = "bcb110d754ab2417de824c464730c412a3eb2769", url = "https://github.com/tmux-plugins/tmux-cpu/archive/{{version}}.tar.gz", strip_components = 1 }
-# バイナリはgithub backend（上記）でPATHに入れ、.tmuxスクリプト一式はここで取得する
 "http:tmux-fingers"                                         = { version = "2.7.1", url = "https://github.com/Morantron/tmux-fingers/archive/refs/tags/{{version}}.tar.gz", strip_components = 1 }
 "http:tmux-fzf"                                             = { version = "4cbbbbde54e1b63712d77483b83075fd712d3bb5", url = "https://github.com/sainnhe/tmux-fzf/archive/{{version}}.tar.gz", strip_components = 1 }
 "http:tmux-resurrect"                                       = { version = "d05fd6696716bd2434c25155374dc36d21347db4", url = "https://github.com/ryo246912/tmux-resurrect/archive/{{version}}.tar.gz", strip_components = 1 }

--- a/dot_config/navi/cheats/tmux.cheat.md
+++ b/dot_config/navi/cheats/tmux.cheat.md
@@ -37,7 +37,7 @@ tmux capture-pane -p -S -100 -t <pane_from>
 tmux select-layout tiled
 
 # restore resurrect file
-ln -sf <resurrect_file> ~/.local/share/tmux/resurrect/last && tmux run-shell ~/.config/tmux/plugins/tmux-resurrect/scripts/restore.sh
+ln -sf <resurrect_file> ~/.local/share/tmux/resurrect/last && tmux run-shell "$(mise where http:tmux-resurrect)/scripts/restore.sh"
 
 # relink resurrect file
 ln -fs <resurrect_file> ~/.local/share/tmux/resurrect/last

--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -246,12 +246,13 @@ bind C-v run-shell ' \
 # plugin
 #--------------------------------------------------------------
 
-# plugin追加したら、prefix + Iでロードする
-set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'tmux-plugins/tmux-yank'
+# プラグインはtpmではなくmise（http backend）で取得・version管理し、mise where で解決したパスから直接ロードする
+# mise install 済みが前提（auto_install=false）。miseが解決できない場合は該当プラグインを黙ってスキップする
+
+# tmux-yank
+run 'if p="$(mise where http:tmux-yank 2>/dev/null)"; then "$p/yank.tmux"; fi'
 
 # tmux-resurrect/tmux-continuum
-set -g @plugin 'ryo246912/tmux-resurrect'
 ## pane-contentをrestore
 set -g @resurrect-capture-pane-contents 'on'
 ## restore process [~:プロセス名が部分一致していたら、そのプロセスを復元する][->:復元の際に、指定したコマンド名で復元する][*:復元の際に、引数は保持した状態でコマンド名で復元する]
@@ -263,10 +264,12 @@ set -g @resurrect-strategy-nvim 'session'
 ## keybindをprefix→S・Rに設定
 set -g @resurrect-save 'S'
 set -g @resurrect-restore 'R'
+run 'if p="$(mise where http:tmux-resurrect 2>/dev/null)"; then "$p/resurrect.tmux"; fi'
 
-set -g @plugin 'tmux-plugins/tmux-continuum'
 ## tmux起動時にtmux-continuumで最後に保存された環境で復元する（デフォルトでは15分毎に自動保存）
+## continuumはresurrectの後にロードする必要がある
 set -g @continuum-restore 'on'
+run 'if p="$(mise where http:tmux-continuum 2>/dev/null)"; then "$p/continuum.tmux"; fi'
 
 # tmux-easy-motion
 # set -g @plugin 'IngoMeyer441/tmux-easy-motion'
@@ -285,8 +288,7 @@ set -g @continuum-restore 'on'
 #   }
 
 # tmux-fingers
-# バイナリはmise経由でダウンロードし、PATH上のtmux-fingersを使用する（crystalビルド不要）
-set -g @plugin 'Morantron/tmux-fingers'
+# バイナリはmise（github backend）でPATHに入れ、.tmuxスクリプト一式はmise（http backend）で取得する（crystalビルド不要）
 # mise管理のバイナリを使うため、インストールウィザード（ビルド）をスキップする
 set -g @fingers-skip-wizard '1'
 # 起動キー（旧tmux-thumbsのデフォルトと同じ prefix + space に合わせる）
@@ -299,18 +301,16 @@ set -g @fingers-main-action 'gocopy'
 set -g @fingers-shift-action 'xargs open'
 # ctrl+hintを選んだ時のコマンド（選択したURLをterminal-browserで右分割ペインに開く。）
 set -g @fingers-ctrl-action 'xargs -I{} terminal-browser open {} --split right'
+run 'if p="$(mise where http:tmux-fingers 2>/dev/null)"; then "$p/tmux-fingers.tmux"; fi'
 
 # tmux-cpu
-set -g @plugin 'tmux-plugins/tmux-cpu'
 set -g status-right '#{cpu_fg_color} CPU: #{cpu_icon} #{cpu_percentage} #{ram_fg_color} MEM: #{ram_icon} #{ram_percentage}'
 set -g status-left '#[fg=#FFFF00]#S                               '
 set -g status-left-length 35
+run 'if p="$(mise where http:tmux-cpu 2>/dev/null)"; then "$p/cpu.tmux"; fi'
 
 # tmux-fzf
-set -g @plugin 'sainnhe/tmux-fzf'
-bind C-b run-shell -b "${HOME}/.config/tmux/plugins/tmux-fzf/scripts/pane.sh switch"
+bind C-b run-shell -b 'p="$(mise where http:tmux-fzf 2>/dev/null)" && "$p/scripts/pane.sh" switch'
 TMUX_FZF_OPTIONS="-p -w 90% -h 90% -m --layout=reverse --border"
 TMUX_FZF_PANE_FORMAT="[#I#P] #{pane_current_command} #{pane_current_path}"
-
-# Tmux plugin managerを初期化する
-run '~/.config/tmux/plugins/tpm/tpm'
+run 'if p="$(mise where http:tmux-fzf 2>/dev/null)"; then "$p/main.tmux"; fi'

--- a/dot_config/zsh/lazy/alias.zsh
+++ b/dot_config/zsh/lazy/alias.zsh
@@ -1,6 +1,6 @@
 alias vim="nvim"
 alias fly="flyctl"
-alias restore_tmux="~/.config/tmux/plugins/tmux-resurrect/scripts/restore.sh"
+alias restore_tmux='"$(mise where http:tmux-resurrect)/scripts/restore.sh"'
 
 claude_check_version() {
   local desired_version="1.0.48"

--- a/dot_config/zsh/lazy/main.zsh
+++ b/dot_config/zsh/lazy/main.zsh
@@ -1,8 +1,3 @@
-# tpmのインストール
-if ! [ -e "$HOME/.config/tmux/plugins/tpm" ]; then
-  git clone https://github.com/tmux-plugins/tpm "$HOME/.config/tmux/plugins/tpm"
-fi
-
 # historyの保存先
 mkdir -p "$XDG_STATE_HOME/node" 2>/dev/null
 export NODE_REPL_HISTORY="$XDG_STATE_HOME/node/.node_repl_history"


### PR DESCRIPTION
Install and version-manage all tmux plugins through mise (http backend)
and load them directly from tmux.conf, replacing tpm entirely.

Each plugin's source archive is pinned in mise/config.toml and resolved
at load time via `mise where`, so versions are tracked the same way as
every other tool in this repo.

- mise/config.toml: add http:tmux-{yank,resurrect,continuum,cpu,fzf}
  and http:tmux-fingers (the .tmux script; the binary stays on the
  existing github backend). Tagged repos are pinned to their latest tag;
  tag-less repos (cpu / fzf / resurrect fork) are pinned by commit SHA.
- tmux.conf: drop all `@plugin` declarations and the `run tpm` line.
  Load each plugin's entrypoint from `$(mise where http:<plugin>)`,
  guarded so a plugin is silently skipped if mise can't resolve it.
  Keep the original load order (resurrect before continuum). Repoint the
  tmux-fzf pane.sh keybinding to the mise install path.
- zsh/lazy/main.zsh: remove the tpm git-clone bootstrap (no longer used).
- zsh/lazy/alias.zsh, navi tmux cheat: repoint tmux-resurrect restore.sh
  to the mise install path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qm5pF9krLnYB8tz8t8xbYF

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch tmux plugins from `tpm` to `mise`, load them directly from `tmux.conf`, and update Renovate to track versions for `mise` `http:*` tools (tmux plugins now, others later), including SHA-pinned tools on both `master` and `main`.

- **Refactors**
  - Pin `http:tmux-{yank,resurrect,continuum,cpu,fzf}` and `http:tmux-fingers` in `mise/config.toml` (tags or SHAs). `tmux-fingers` binary stays on the GitHub backend; its `.tmux` script is fetched via HTTP.
  - Replace `@plugin`/`run tpm` with guarded `run` calls to `$(mise where http:<plugin>)` in `tmux.conf`, keeping load order (`resurrect` before `continuum`). Use `mise` paths for `tmux-fzf` (`pane.sh` and `main.tmux`) and other plugins.
  - Remove the `tpm` git-clone bootstrap from `zsh/lazy/main.zsh`. Repoint `restore_tmux` alias and the navi cheat to the `mise` `resurrect` path.
  - Generalize Renovate `customManager`s in `.github/renovate.json` to any `http:*` GitHub source in `mise`: `github-tags` for tag-pinned tools and `git-refs` for SHA-pinned tools, following `master` and `main`.

- **Migration**
  - Run `mise install` to fetch plugin sources. No `prefix + I` needed.
  - Optional: remove `~/.config/tmux/plugins` if you previously used `tpm`. Plugins are skipped if `mise` can’t resolve them.

<sup>Written for commit 2a65d4ea041c83ef37e97a3afbfd7b76bc1b5480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

- tmuxプラグインの管理方式をTPMからmiseへ変更しました。
- `mise/config.toml` に6つのtmuxプラグインをHTTPソースとして登録しました。
- `tmux.conf`、navi、zshからプラグインのパスを `mise where` で解決するように変更しました。
- TPMの宣言、初期化処理、インストール処理を削除しました。
- miseがプラグインを解決できない場合は、該当プラグインの読み込みをスキップします。

## 変更理由

- tmuxプラグインのバージョンと取得元をmiseで一元管理するためです。
- 固定パスへの依存を削減するためです。
- 既存のプラグイン読み込み順序を維持しながら、管理方式を統一するためです。

## 確認した項目

- 6つのtmuxプラグインにバージョン、取得URL、展開設定を追加しました。
- `tmux.conf` のプラグイン読み込みとtmux-fzfのキーバインドをmise管理のパスへ変更しました。
- tmux-resurrectの復元処理をmise管理のパスへ変更しました。
- TPMのクローンおよび初期化処理を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->