### PR TITLE
Add "open with" picker to neo-tree file explorer

### DIFF
--- a/dot_config/nvim/lua/plugins/filer.lua
+++ b/dot_config/nvim/lua/plugins/filer.lua
@@ -9,7 +9,6 @@ return {
     },
     lazy = false,
     config = function()
-      -- yazi の "open with" のように、開き方を選択して開く
       local function open_with_picker(state)
         local ok, node = pcall(function()
           return state.tree:get_node()

--- a/dot_config/nvim/lua/plugins/filer.lua
+++ b/dot_config/nvim/lua/plugins/filer.lua
@@ -46,12 +46,8 @@ return {
                 if not cmd or cmd:match("^%s*$") then
                   return
                 end
-                local argv = {}
-                for token in cmd:gmatch("%S+") do
-                  table.insert(argv, token)
-                end
-                table.insert(argv, path)
-                local job_id = vim.fn.jobstart(argv, { detach = true })
+                -- シェル経由で実行することで、cmd 内の引用符付き引数を維持しつつ path を安全にエスケープする
+                local job_id = vim.fn.jobstart(cmd .. " " .. vim.fn.shellescape(path), { detach = true })
                 if job_id <= 0 then
                   vim.notify("コマンドの起動に失敗しました: " .. cmd, vim.log.levels.ERROR)
                 end

--- a/dot_config/nvim/lua/plugins/filer.lua
+++ b/dot_config/nvim/lua/plugins/filer.lua
@@ -11,12 +11,19 @@ return {
     config = function()
       -- yazi の "open with" のように、開き方を選択して開く
       local function open_with_picker(state)
-        local node = state.tree:get_node()
+        local ok, node = pcall(function()
+          return state.tree:get_node()
+        end)
+        if not ok or not node then
+          return
+        end
+
         if node.type == "directory" then
           require("neo-tree.sources.filesystem.commands").open(state)
           return
         end
 
+        local path = node:get_id()
         local commands = require("neo-tree.sources.common.commands")
         local options = {
           { label = "現在のウィンドウで開く", fn = commands.open },
@@ -25,17 +32,28 @@ return {
           { label = "新規タブで開く", fn = commands.open_tabnew },
           {
             label = "システムのデフォルトアプリで開く",
-            fn = function(s)
-              vim.ui.open(s.tree:get_node():get_id())
+            fn = function()
+              local obj, err = vim.ui.open(path)
+              if not obj then
+                vim.notify("開けませんでした: " .. (err or "不明なエラー"), vim.log.levels.ERROR)
+              end
             end,
           },
           {
             label = "コマンドを指定して開く...",
-            fn = function(s)
-              local path = s.tree:get_node():get_id()
+            fn = function()
               vim.ui.input({ prompt = "Open with command: " }, function(cmd)
-                if cmd and cmd ~= "" then
-                  vim.fn.jobstart({ cmd, path }, { detach = true })
+                if not cmd or cmd:match("^%s*$") then
+                  return
+                end
+                local argv = {}
+                for token in cmd:gmatch("%S+") do
+                  table.insert(argv, token)
+                end
+                table.insert(argv, path)
+                local job_id = vim.fn.jobstart(argv, { detach = true })
+                if job_id <= 0 then
+                  vim.notify("コマンドの起動に失敗しました: " .. cmd, vim.log.levels.ERROR)
                 end
               end)
             end,

--- a/dot_config/nvim/lua/plugins/filer.lua
+++ b/dot_config/nvim/lua/plugins/filer.lua
@@ -9,6 +9,51 @@ return {
     },
     lazy = false,
     config = function()
+      -- yazi の "open with" のように、開き方を選択して開く
+      local function open_with_picker(state)
+        local node = state.tree:get_node()
+        if node.type == "directory" then
+          require("neo-tree.sources.filesystem.commands").open(state)
+          return
+        end
+
+        local commands = require("neo-tree.sources.common.commands")
+        local options = {
+          { label = "現在のウィンドウで開く", fn = commands.open },
+          { label = "水平分割で開く", fn = commands.open_split },
+          { label = "垂直分割で開く", fn = commands.open_vsplit },
+          { label = "新規タブで開く", fn = commands.open_tabnew },
+          {
+            label = "システムのデフォルトアプリで開く",
+            fn = function(s)
+              vim.ui.open(s.tree:get_node():get_id())
+            end,
+          },
+          {
+            label = "コマンドを指定して開く...",
+            fn = function(s)
+              local path = s.tree:get_node():get_id()
+              vim.ui.input({ prompt = "Open with command: " }, function(cmd)
+                if cmd and cmd ~= "" then
+                  vim.fn.jobstart({ cmd, path }, { detach = true })
+                end
+              end)
+            end,
+          },
+        }
+
+        vim.ui.select(options, {
+          prompt = "Open with...",
+          format_item = function(item)
+            return item.label
+          end,
+        }, function(choice)
+          if choice then
+            choice.fn(state)
+          end
+        end)
+      end
+
       require("neo-tree").setup({
         close_if_last_window = false,
         popup_border_style = "rounded",
@@ -76,6 +121,7 @@ return {
             ["t"] = "open_tabnew",
             ["P"] = { "toggle_preview", config = { use_float = true } },
             ["l"] = "open",
+            ["O"] = open_with_picker,
             ["h"] = "close_node",
             ["z"] = "close_all_nodes",
             ["a"] = "add",


### PR DESCRIPTION
## Summary
Added an "open with" picker feature to neo-tree that allows users to choose how to open files, similar to yazi's "open with" functionality.

## Key Changes
- Implemented `open_with_picker()` function that displays a selection menu with multiple file opening options:
  - Open in current window
  - Open in horizontal split
  - Open in vertical split
  - Open in new tab
  - Open with system default application
  - Open with custom command
- Bound the new picker to the `O` key in neo-tree's filesystem view
- Directories are opened normally without showing the picker menu

## Implementation Details
- Uses `vim.ui.select()` to display the picker menu with formatted labels in Japanese
- For custom command option, prompts user for input via `vim.ui.input()` and executes the command with `vim.fn.jobstart()` in detached mode
- Integrates with neo-tree's existing command infrastructure for standard open operations
- Gracefully handles directory navigation by delegating to neo-tree's default open behavior

https://claude.ai/code/session_013zEtufXovjvgrV5Zdv1eE7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an “open with” picker to `neo-tree` so you can choose how to open files. Press O in the filesystem view; directories open normally.

- **New Features**
  - Picker options: current window, split, vsplit, new tab, system default app, custom command.
  - Uses `vim.ui.select` and `vim.ui.input`; runs custom commands via `vim.fn.jobstart` as a shell string (preserves quoted args), appends the path with `vim.fn.shellescape`, runs detached, and shows errors for `vim.ui.open` and `jobstart` failures. Includes a nil-node guard.

<sup>Written for commit 45f573d1751f77fdf3613b630f81840a1db24618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更内容概要

- neo-tree に `open_with_picker` を追加しました。
- `O` キーで `vim.ui.select()` の選択メニューを開きます。
- ファイルを現在のウィンドウ、水平分割、垂直分割、新規タブ、システム既定アプリ、カスタムコマンドで開けます。
- ディレクトリは従来どおり開きます。

## 変更理由

- yazi のように、ファイルの開き方を選択できるようにするためです。
- カスタムコマンドを指定できるようにするためです。

## 確認した項目

- ファイル選択時の各オープン方法を追加しました。
- カスタムコマンドの入力に `vim.ui.input()` を使用します。
- システム既定アプリとカスタムコマンドを、切り離した `vim.fn.jobstart()` で実行します。
- `O` キーにピッカーを割り当てました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->