### PR TITLE
Move omnidisksweeper to real-brew exception task

### DIFF
--- a/docs/mise.md
+++ b/docs/mise.md
@@ -317,6 +317,12 @@ brew list --cask --versions
   対話実行するタスクなので sudo プロンプトが出ても想定内になる。本リポジトリでは
   google-drive / tailscale-app がこれに該当する。いずれも private ホスト限定のため
   `HOST_ENV` で判定して work ホストではスキップする）。
+- EULA 同意プロンプトで**止まって見える**（エラーは出ない） →
+  cask のインストーラが利用許諾（EULA）への同意を求めるページャー表示を挟む場合、
+  上記のパスワードプロンプトと同様に非対話実行の post-apply hook で気づかれにくく止まる。
+  該当パッケージは `[bootstrap.packages]` から外し `mise run bootstrap:mac-packages`
+  側の例外パッケージとして扱う（本リポジトリでは omnidisksweeper がこれに該当する。
+  private ホスト限定のため `HOST_ENV` で判定して work ホストではスキップする）。
 - `ERROR brew-cask: app artifact '<Name>.app' was not found` →
   ダウンロード/展開した中に期待する `.app` が見つからない場合の**エラー**（根本原因未確認）。
   これも `mise bootstrap packages apply` 全体を中断させる。他の unsupported artifact type

--- a/dot_config/mise/config.private.toml
+++ b/dot_config/mise/config.private.toml
@@ -7,8 +7,9 @@
 
 [bootstrap.packages]
 # 実際に WSL を使い始めたら bootstrap-mac.toml 側への切り出しを検討する
-"brew-cask:android-studio"  = "latest"
-"brew-cask:insomnia"        = "latest"
-"brew-cask:linear"          = "latest"
-"brew-cask:omnidisksweeper" = "latest"
-"brew:ffmpeg"               = "latest"
+# omnidisksweeper: インストール時に EULA 同意プロンプトが出て `mise bootstrap packages apply`
+# が止まるため、対話実行の bootstrap-mac.toml 側に移している
+"brew-cask:android-studio" = "latest"
+"brew-cask:insomnia"       = "latest"
+"brew-cask:linear"         = "latest"
+"brew:ffmpeg"              = "latest"

--- a/dot_config/mise/config.private.toml
+++ b/dot_config/mise/config.private.toml
@@ -7,8 +7,6 @@
 
 [bootstrap.packages]
 # 実際に WSL を使い始めたら bootstrap-mac.toml 側への切り出しを検討する
-# omnidisksweeper: インストール時に EULA 同意プロンプトが出て `mise bootstrap packages apply`
-# が止まるため、対話実行の bootstrap-mac.toml 側に移している
 "brew-cask:android-studio" = "latest"
 "brew-cask:insomnia"       = "latest"
 "brew-cask:linear"         = "latest"

--- a/dot_config/mise/tasks/bootstrap-mac.toml
+++ b/dot_config/mise/tasks/bootstrap-mac.toml
@@ -76,10 +76,12 @@ fi
 # private ホスト限定パッケージ。google-drive/tailscale-app は pkg インストーラが sudo を
 # 要求するため post-apply hook（非対話実行）に含めるとパスワード入力を待って止まってしまう。
 # keycastr/termius/thunderbird は auto_updates を使っており mise の brew-cask シムが未対応。
-# zoom はユーザーの用途が private ホストのみのため、こちらに寄せている
+# zoom はユーザーの用途が private ホストのみのため、こちらに寄せている。
+# omnidisksweeper はインストール時に EULA 同意プロンプトが出て
+# `mise bootstrap packages apply` が止まるため、対話実行のこちらに寄せている
 case "${HOST_ENV:-}" in
 *private*)
-  for cask in google-drive tailscale-app keycastr termius thunderbird zoom; do
+  for cask in google-drive tailscale-app keycastr termius thunderbird zoom omnidisksweeper; do
     if ! brew list --cask "$cask" &>/dev/null; then
       brew install --cask "$cask"
     else
@@ -88,7 +90,7 @@ case "${HOST_ENV:-}" in
   done
   ;;
 *)
-  echo "google-drive/tailscale-app/keycastr/termius/thunderbird/zoom are private-only; skipping (HOST_ENV=${HOST_ENV:-unset})"
+  echo "google-drive/tailscale-app/keycastr/termius/thunderbird/zoom/omnidisksweeper are private-only; skipping (HOST_ENV=${HOST_ENV:-unset})"
   ;;
 esac
 


### PR DESCRIPTION
## Summary
- `omnidisksweeper`'s cask installer shows an EULA acceptance pager, which blocks `mise bootstrap packages apply` (confirmed hanging even during an interactive run).
- Moved it out of `config.private.toml`'s declarative `[bootstrap.packages]` into the private-gated real-brew exception task in `dot_config/mise/tasks/bootstrap-mac.toml`, same pattern as the sudo-prompting `google-drive`/`tailscale-app`.
- Documented the new "EULA prompt looks like a hang" message class in `docs/mise.md`, alongside the existing sudo-password one.

## Test plan
- [ ] `mise run bootstrap:mac-packages` installs omnidisksweeper via real brew and correctly prompts for/accepts the EULA
- [ ] `mise bootstrap packages apply` no longer attempts omnidisksweeper and completes without hanging


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qh3RmFDEtiPDDigCrGhoKt)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved `omnidisksweeper` to the private, interactive real-brew task to avoid the EULA pager hang. `mise bootstrap packages apply` now skips it and completes reliably; docs add a note about EULA prompts.

- **Bug Fixes**
  - Removed `omnidisksweeper` from `[bootstrap.packages]` in `dot_config/mise/config.private.toml`.
  - Added `omnidisksweeper` to the private-gated loop in `dot_config/mise/tasks/bootstrap-mac.toml` and updated the skip message.

- **Migration**
  - Install `omnidisksweeper` via `mise run bootstrap:mac-packages` on private hosts; `mise bootstrap packages apply` will skip it.

<sup>Written for commit f07661fa5d485ad2a46ecb488ebdf75a4a56a8b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

