### PR TITLE
chore: add .agent mount

### DIFF
--- a/dot_config/devcontainer/devcontainer.json
+++ b/dot_config/devcontainer/devcontainer.json
@@ -59,6 +59,7 @@
     "type=bind,source=${localEnv:HOME}/.claude-account2,target=/home/vscode/.claude-account2",
     // .claude.jsonは一時的に読み取り専用でマウント(コピー用)
     "type=bind,source=${localEnv:HOME}/.claude.json,target=/tmp/claude-config-host.json,readonly",
+    "type=bind,source=${localEnv:HOME}/.agents,target=/home/vscode/.agents",
     "type=bind,source=${localEnv:HOME}/.codex,target=/home/vscode/.codex",
     "type=bind,source=${localEnv:HOME}/.copilot,target=/home/vscode/.copilot",
     "type=bind,source=${localEnv:HOME}/.coderabbit,target=/home/vscode/.coderabbit",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts host `~/.agents` into the devcontainer at `/home/vscode/.agents` so agent-based tools can use the host config inside the container.

<sup>Written for commit c09be46f4a86d9241599c3a033f593616689d8d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

`.agent` をコンテナ内の `/home/vscode/.agent` にバインドマウントする設定を追加しました。

## 変更理由

コンテナからホスト側の `.agent` 設定を利用できるようにします。

## 確認した項目

- マウント元とマウント先のパスを確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->