### PR TITLE
mise の brew backend ツールに renovate 検知用の version コメントを追加

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -183,7 +183,8 @@
       "matchStrings": [
         "\"brew-cask:(?<depName>[^\"]+)\"[ \\t]*=[ \\t]*\"latest\"[ \\t]*#[ \\t]*(?<currentValue>\\S+)"
       ],
-      "datasourceTemplate": "custom.brew-cask"
+      "datasourceTemplate": "custom.brew-cask",
+      "versioningTemplate": "loose"
     },
     {
       "customType": "regex",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,13 +43,6 @@
       "enabled": false
     },
     {
-      "matchDepNames": ["cosign"],
-      "matchManagers": ["custom.regex"],
-      "matchFileNames": ["dot_config/brew/brew.json"],
-      "matchUpdateTypes": ["patch"],
-      "enabled": false
-    },
-    {
       "matchManagers": ["gomod"],
       "groupName": "Go modules"
     },
@@ -95,18 +88,6 @@
         "image\\s*=\\s*\"(?<depName>ghcr\\.io/kenn-io/agentsview):(?<currentValue>v?[^\"]+)\""
       ],
       "datasourceTemplate": "docker"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["dot_config/brew/brew.json"],
-      "matchStrings": ["\"(?<depName>[^\"]+)\": \"(?<currentValue>[^\"]+)\""],
-      "datasourceTemplate": "custom.brew-formula"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["dot_config/brew/brew_cask.json"],
-      "matchStrings": ["\"(?<depName>[^\"]+)\": \"(?<currentValue>[^\"]+)\""],
-      "datasourceTemplate": "custom.brew-cask"
     },
     {
       "customType": "regex",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -171,6 +171,22 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["dot_config/mise/**/*.toml"],
+      "matchStrings": [
+        "\"brew:(?<depName>[^\"]+)\"[ \\t]*=[ \\t]*\"latest\"[ \\t]*#[ \\t]*(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "custom.brew-formula"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["dot_config/mise/**/*.toml"],
+      "matchStrings": [
+        "\"brew-cask:(?<depName>[^\"]+)\"[ \\t]*=[ \\t]*\"latest\"[ \\t]*#[ \\t]*(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "custom.brew-cask"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["dot_config/sheldon/**/*.toml"],
       "matchStrings": [
         "\\[plugins\\.(?<depName>[^\\]]+)\\]\\s+github\\s*=\\s*\"(?<packageName>[^\"]+)\"\\s+tag\\s*=\\s*\"(?<currentValue>[^\"]+)\""

--- a/dot_config/brew/brew.json
+++ b/dot_config/brew/brew.json
@@ -1,3 +1,0 @@
-{
-  "kamillobinski/thock/thock": "1.17.4"
-}

--- a/dot_config/brew/brew_cask.json
+++ b/dot_config/brew/brew_cask.json
@@ -1,3 +1,0 @@
-{
-  "google-japanese-ime": "3.33.6088"
-}

--- a/dot_config/mise/config.mac.toml
+++ b/dot_config/mise/config.mac.toml
@@ -6,22 +6,24 @@
 # silicon は mac 専用（config.mac.toml の brew:silicon, native arm64。harfbuzz 等の依存も
 # brew が解決）。aqua の darwin prebuilt は x86_64 で /usr/local(Intel brew) の libharfbuzz に
 # 動的リンクしており arm64 mac では dyld で読めず起動不可のため使わない。
-"brew:blueutil"     = "latest"
-"brew:colordiff"    = "latest"
-"brew:coreutils"    = "latest"
-"brew:findutils"    = "latest"
-"brew:git"          = "latest"
-"brew:gnu-sed"      = "latest"
-"brew:gnupg"        = "latest"
-"brew:goaccess"     = "latest"
-"brew:grep"         = "latest"
-"brew:imagemagick"  = "latest"
-"brew:pinentry-mac" = "latest"
-"brew:poppler"      = "latest"
-"brew:silicon"      = "latest"
-"brew:tig"          = "latest"
-"brew:tree"         = "latest"
-"brew:ugrep"        = "latest"
+# バージョン部分のコメントは実インストールには使われず、renovate が新バージョンを検知して
+# PR を作成するためのマーカー。実際のアップグレードは "latest" 指定によりツール自身に任せる。
+"brew:blueutil"     = "latest" # 2.13.0
+"brew:colordiff"    = "latest" # 1.0.22
+"brew:coreutils"    = "latest" # 9.11
+"brew:findutils"    = "latest" # 4.11.0
+"brew:git"          = "latest" # 2.55.0
+"brew:gnu-sed"      = "latest" # 4.10
+"brew:gnupg"        = "latest" # 2.5.21
+"brew:goaccess"     = "latest" # 1.11
+"brew:grep"         = "latest" # 3.12
+"brew:imagemagick"  = "latest" # 7.1.2-29
+"brew:pinentry-mac" = "latest" # 1.3.1.1
+"brew:poppler"      = "latest" # 26.08.0
+"brew:silicon"      = "latest" # 0.5.3
+"brew:tig"          = "latest" # 2.6.1
+"brew:tree"         = "latest" # 2.3.2
+"brew:ugrep"        = "latest" # 7.8.3
 
 # casks（下記一覧には含まれない例外あり: brew-cask 経由だと `mise bootstrap packages apply`
 # が中断/ハングするため `mise run bootstrap:mac-packages`
@@ -37,27 +39,28 @@
 #   止めてしまう。keycastr/termius/thunderbird は auto_updates を使っており mise の
 #   brew-cask シムが未対応。zoom は private ホストでしか使わない。
 #   いずれも private ホスト限定で bootstrap-mac.toml 側から導入する）
-"brew-cask:arc"                   = "latest"
-"brew-cask:battery"               = "latest"
-"brew-cask:bitwarden"             = "latest"
-"brew-cask:chatgpt"               = "latest"
-"brew-cask:claude"                = "latest"
-"brew-cask:codexbar"              = "latest"
-"brew-cask:cursor"                = "latest"
-"brew-cask:dbeaver-community"     = "latest"
-"brew-cask:font-hackgen"          = "latest"
-"brew-cask:font-hackgen-nerd"     = "latest"
-"brew-cask:ghostty"               = "latest"
-"brew-cask:google-chrome"         = "latest"
-"brew-cask:karabiner-elements"    = "latest"
-"brew-cask:keyboardcleantool"     = "latest"
-"brew-cask:memory-cleaner"        = "latest"
-"brew-cask:obsidian"              = "latest"
-"brew-cask:overview"              = "latest"
-"brew-cask:slack"                 = "latest"
-"brew-cask:syncthing-app"         = "latest"
-"brew-cask:thebrowsercompany-dia" = "latest"
-"brew-cask:visual-studio-code"    = "latest"
+"brew-cask:arc"                   = "latest" # 1.158.1,84367
+"brew-cask:battery"               = "latest" # 1.4.0
+"brew-cask:bitwarden"             = "latest" # 2026.7.0
+"brew-cask:chatgpt"               = "latest" # 26.727.51351
+"brew-cask:claude"                = "latest" # 1.24012.11,09114b681f6f333d10cf1a08df130fe7080ddc9b
+"brew-cask:codexbar"              = "latest" # 0.47.0
+"brew-cask:cursor"                = "latest" # 3.14.7,a758f2241ca99fecf380180b6cbdbbce0f1f42cf
+"brew-cask:dbeaver-community"     = "latest" # 26.1.4
+"brew-cask:font-hackgen"          = "latest" # 2.10.0
+"brew-cask:font-hackgen-nerd"     = "latest" # 2.10.0
+"brew-cask:ghostty"               = "latest" # 1.3.1
+"brew-cask:google-chrome"         = "latest" # 151.0.7922.72
+"brew-cask:karabiner-elements"    = "latest" # 13.7.0
+"brew-cask:keyboardcleantool"     = "latest" # 7
+"brew-cask:memory-cleaner"        = "latest" # 5.5.3,271
+"brew-cask:obsidian"              = "latest" # 1.13.4
+"brew-cask:overview"              = "latest" # 1.2.3-beta
+"brew-cask:slack"                 = "latest" # 4.45.69
+"brew-cask:syncthing-app"         = "latest" # 2.1.2-1
+"brew-cask:thebrowsercompany-dia" = "latest" # 1.42.1,84365
+"brew-cask:visual-studio-code"    = "latest" # 1.106.3
+# wezterm@nightly は discrete version を持たないため version コメントによる追跡対象外
 "brew-cask:wezterm@nightly"       = "latest"
 
 # macOS defaults（`mise bootstrap macos defaults apply` で適用。）

--- a/dot_config/mise/config.mac.toml
+++ b/dot_config/mise/config.mac.toml
@@ -60,7 +60,6 @@
 "brew-cask:syncthing-app"         = "latest" # 2.1.2-1
 "brew-cask:thebrowsercompany-dia" = "latest" # 1.42.1,84365
 "brew-cask:visual-studio-code"    = "latest" # 1.106.3
-# wezterm@nightly は discrete version を持たないため version コメントによる追跡対象外
 "brew-cask:wezterm@nightly"       = "latest"
 
 # macOS defaults（`mise bootstrap macos defaults apply` で適用。）

--- a/dot_config/mise/config.private.toml
+++ b/dot_config/mise/config.private.toml
@@ -7,7 +7,7 @@
 
 [bootstrap.packages]
 # 実際に WSL を使い始めたら bootstrap-mac.toml 側への切り出しを検討する
-"brew-cask:android-studio" = "latest"
-"brew-cask:insomnia"       = "latest"
-"brew-cask:linear"         = "latest"
-"brew:ffmpeg"              = "latest"
+"brew-cask:android-studio" = "latest" # 2026.1.3.7,quail3,AI-261.26222.65.2613.15948027
+"brew-cask:insomnia"       = "latest" # 13.1.0
+"brew-cask:linear"         = "latest" # 1.32.1
+"brew:ffmpeg"              = "latest" # 8.1.2

--- a/dot_config/navi/cheats/mac.cheat.md
+++ b/dot_config/navi/cheats/mac.cheat.md
@@ -22,12 +22,6 @@ bat -l rb $(brew edit --print-path <app_name>)
 # open app homegage [ex:brew home colordiff]
 brew home <app_name>
 
-# tool
-brew info --installed --json | jq 'map(select(.installed[].installed_on_request == true)) | map({key: .full_name, value: .installed[0].version}) | from_entries' > ~/.local/share/chezmoi/dot_config/brew/brew.json
-
-# cask
-brew info --cask --installed --json=v2 | jq '.casks | map({key: .full_token, value: .version}) | from_entries' > ~/.local/share/chezmoi/dot_config/brew/brew_cask.json
-
 % other
 # chrome : list user profile
 cat ~/Library/Application\ Support/Google/Chrome/Local\ State | jq -r '.profile.info_cache | to_entries[] | "\(.key): \(.value.name)"'


### PR DESCRIPTION
## Summary

- mise の `[bootstrap.packages]` にある `brew:xxx` / `brew-cask:xxx` = `"latest"` の各行に、現在の最新バージョンを示す `# <version>` コメントを追加
- `.github/renovate.json` に、その version コメントを対象とする custom regex manager（`custom.brew-formula` / `custom.brew-cask` datasource を使用）を2つ追加し、renovate が新バージョンを検知して PR を作成できるようにした
- 値自体は引き続き `"latest"` のままで、実際のツールアップグレードは brew backend（ツール自身）に任せる方針は変更していない
- `wezterm@nightly` は discrete version を持たないため、今回のコメント付与対象からは除外した

## Test plan

- [x] `python3 -c "import json; json.load(open('.github/renovate.json'))"` で JSON として妥当なことを確認
- [x] `npx renovate-config-validator` で renovate 設定として妥当なことを確認
- [x] 追加した正規表現が対象の `brew:` / `brew-cask:` 行のみにマッチし、`wezterm@nightly`（コメントなし）などの後続行に誤って波及しないことを Python でのマッチングテストで確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01AmdZPQeRYHN88dECmTHpz9)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `# <version>` markers to `brew:`/`brew-cask:` entries in `mise` and add Renovate regex managers so updates are detected while installs stay on `latest` managed by `brew`. Also removed legacy JSON tracking and references, handled non‑semver casks, and fixed a Taplo formatting issue.

- **New Features**
  - Added version comments to each `brew:`/`brew-cask:` line in `dot_config/mise/*.toml` (excluding `wezterm@nightly`); installs remain `"latest"`.
  - Added two `regex` managers in `.github/renovate.json` using `custom.brew-formula` and `custom.brew-cask` with `versioningTemplate: "loose"` for casks.

- **Bug Fixes**
  - Removed a standalone comment near `brew-cask:wezterm@nightly` that broke Taplo `align_entries` and `lint:toml` checks.

<sup>Written for commit 014fd581c1ccf09df4dfec0f910ea671ee1cf566. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

