### PR TITLE
Enable inline Renovate branch directive parsing and annotate tmux http entries

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -134,19 +134,8 @@
       "customType": "regex",
       "managerFilePatterns": ["dot_config/mise/**/*.toml"],
       "matchStrings": [
-        "\"http:[^\"]+\"\\s*=\\s*\\{[^}]*?version = \"(?<currentDigest>[0-9a-f]{40})\"[^}]*?url = \"https://github\\.com/(?<depName>[^/]+/[^/]+)/archive/"
+        "\"http:[^\"]+\"\\s*=\\s*\\{[^}]*?version = \"(?<currentDigest>[0-9a-f]{40})\"[^}]*?url = \"https://github\\.com/(?<depName>[^/]+/[^/]+)/archive/[^\n#]+[ \t]*#[ \t]*renovate: branch=(?<currentValue>main|master)"
       ],
-      "currentValueTemplate": "master",
-      "datasourceTemplate": "git-refs",
-      "packageNameTemplate": "https://github.com/{{{depName}}}"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["dot_config/mise/**/*.toml"],
-      "matchStrings": [
-        "\"http:[^\"]+\"\\s*=\\s*\\{[^}]*?version = \"(?<currentDigest>[0-9a-f]{40})\"[^}]*?url = \"https://github\\.com/(?<depName>[^/]+/[^/]+)/archive/"
-      ],
-      "currentValueTemplate": "main",
       "datasourceTemplate": "git-refs",
       "packageNameTemplate": "https://github.com/{{{depName}}}"
     },

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -102,10 +102,10 @@ ASDF_FFMPEG_ENABLE = "gpl libx264"
 "go:github.com/go-delve/delve/cmd/dlv"                      = "1.27.0"
 "go:github.com/x-motemen/gore/cmd/gore"                     = "0.7.0"
 "http:tmux-continuum"                                       = { version = "3.1.0", url = "https://github.com/tmux-plugins/tmux-continuum/archive/refs/tags/v{{version}}.tar.gz", strip_components = 1 }
-"http:tmux-cpu"                                             = { version = "bcb110d754ab2417de824c464730c412a3eb2769", url = "https://github.com/tmux-plugins/tmux-cpu/archive/{{version}}.tar.gz", strip_components = 1 }
+"http:tmux-cpu"                                             = { version = "bcb110d754ab2417de824c464730c412a3eb2769", url = "https://github.com/tmux-plugins/tmux-cpu/archive/{{version}}.tar.gz", strip_components = 1 } # renovate: branch=master
 "http:tmux-fingers"                                         = { version = "2.7.1", url = "https://github.com/Morantron/tmux-fingers/archive/refs/tags/{{version}}.tar.gz", strip_components = 1 }
-"http:tmux-fzf"                                             = { version = "4cbbbbde54e1b63712d77483b83075fd712d3bb5", url = "https://github.com/sainnhe/tmux-fzf/archive/{{version}}.tar.gz", strip_components = 1 }
-"http:tmux-resurrect"                                       = { version = "d05fd6696716bd2434c25155374dc36d21347db4", url = "https://github.com/ryo246912/tmux-resurrect/archive/{{version}}.tar.gz", strip_components = 1 }
+"http:tmux-fzf"                                             = { version = "4cbbbbde54e1b63712d77483b83075fd712d3bb5", url = "https://github.com/sainnhe/tmux-fzf/archive/{{version}}.tar.gz", strip_components = 1 } # renovate: branch=master
+"http:tmux-resurrect"                                       = { version = "d05fd6696716bd2434c25155374dc36d21347db4", url = "https://github.com/ryo246912/tmux-resurrect/archive/{{version}}.tar.gz", strip_components = 1 } # renovate: branch=master
 "http:tmux-yank"                                            = { version = "2.3.0", url = "https://github.com/tmux-plugins/tmux-yank/archive/refs/tags/v{{version}}.tar.gz", strip_components = 1 }
 "npm:@devcontainers/cli"                                    = "0.88.0"
 "npm:@kitlangton/ghui"                                      = "0.9.0"

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -102,9 +102,9 @@ ASDF_FFMPEG_ENABLE = "gpl libx264"
 "go:github.com/go-delve/delve/cmd/dlv"                      = "1.27.0"
 "go:github.com/x-motemen/gore/cmd/gore"                     = "0.7.0"
 "http:tmux-continuum"                                       = { version = "3.1.0", url = "https://github.com/tmux-plugins/tmux-continuum/archive/refs/tags/v{{version}}.tar.gz", strip_components = 1 }
-"http:tmux-cpu"                                             = { version = "bcb110d754ab2417de824c464730c412a3eb2769", url = "https://github.com/tmux-plugins/tmux-cpu/archive/{{version}}.tar.gz", strip_components = 1 } # renovate: branch=master
+"http:tmux-cpu"                                             = { version = "bcb110d754ab2417de824c464730c412a3eb2769", url = "https://github.com/tmux-plugins/tmux-cpu/archive/{{version}}.tar.gz", strip_components = 1 }    # renovate: branch=master
 "http:tmux-fingers"                                         = { version = "2.7.1", url = "https://github.com/Morantron/tmux-fingers/archive/refs/tags/{{version}}.tar.gz", strip_components = 1 }
-"http:tmux-fzf"                                             = { version = "4cbbbbde54e1b63712d77483b83075fd712d3bb5", url = "https://github.com/sainnhe/tmux-fzf/archive/{{version}}.tar.gz", strip_components = 1 } # renovate: branch=master
+"http:tmux-fzf"                                             = { version = "4cbbbbde54e1b63712d77483b83075fd712d3bb5", url = "https://github.com/sainnhe/tmux-fzf/archive/{{version}}.tar.gz", strip_components = 1 }         # renovate: branch=master
 "http:tmux-resurrect"                                       = { version = "d05fd6696716bd2434c25155374dc36d21347db4", url = "https://github.com/ryo246912/tmux-resurrect/archive/{{version}}.tar.gz", strip_components = 1 } # renovate: branch=master
 "http:tmux-yank"                                            = { version = "2.3.0", url = "https://github.com/tmux-plugins/tmux-yank/archive/refs/tags/v{{version}}.tar.gz", strip_components = 1 }
 "npm:@devcontainers/cli"                                    = "0.88.0"


### PR DESCRIPTION
### Motivation
- Allow Renovate to detect the target branch for git-based `http:` dependencies from inline comments in TOML files so branch selection is explicit per-dependency.
- Annotate existing `http:` tmux dependencies with the chosen branch to make updates deterministic for Renovate.

### Description
- Update `.github/renovate.json` regex to capture an inline `# renovate: branch=(main|master)` comment and extract the branch into `currentValue` for `dot_config/mise/**/*.toml` `http:` entries.
- Remove the fixed `currentValueTemplate` approach and rely on the new capture group for branch selection while keeping `datasourceTemplate` as `git-refs` and `packageNameTemplate` as `https://github.com/{{{depName}}}`.
- Add `# renovate: branch=master` inline comments to `dot_config/mise/config.toml` on the `http:tmux-cpu`, `http:tmux-fzf`, and `http:tmux-resurrect` lines so Renovate picks up the intended branch.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7260df759883329a5359cb19bac65f)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach Renovate to parse inline `# renovate: branch=...` comments for git-based `http:` dependencies in mise TOML. Annotate tmux plugins with `branch=master` so digest lookups use the right branch and updates are deterministic.

- **New Features**
  - Extend `.github/renovate.json` regex to capture `branch=(main|master)` from `dot_config/mise/**/*.toml` `http:` entries and set it as `currentValue`.
  - Remove the fixed `currentValueTemplate` and rely on the captured branch while keeping `datasourceTemplate` as `git-refs` and `packageNameTemplate` as `https://github.com/{{{depName}}}`.

- **Bug Fixes**
  - Drop the duplicate manager that assumed `main`, which broke SHA digest resolution for GitHub archives on `master`.
  - Add `# renovate: branch=master` to `tmux-cpu`, `tmux-fzf`, and `tmux-resurrect` entries in `dot_config/mise/config.toml`.

<sup>Written for commit 8cf8aa21805ab242579921812927dce071def74c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更内容概要
Renovate が `http:` 依存関係のコメントから対象ブランチを取得するように更新しました。対象の tmux 依存関係に `master` 指定を追加しました。

## 変更理由
`main` と `master` の重複設定を統合し、Renovate が実際のブランチを追跡できるようにしました。

## 確認した項目
対象ファイルの差分概要を確認しました。自動テストは実行していません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->