### PR TITLE
Add gh skill docs, shell snippets, and `gh:skill-install-all` task for pinned user-scope installs

### DIFF
--- a/docs/gh.md
+++ b/docs/gh.md
@@ -1,0 +1,44 @@
+# GitHub CLI / gh skill メモ
+
+## 方針
+
+`gh skill` は GitHub CLI 組み込みの agent skill 管理コマンドです。この dotfiles では、短期の試用は
+`gh skill`、常時使う外部 skill は APM で管理する方針にします。
+
+`gh:skill-install-all` は GitHub Copilot / Cursor / Codex / Claude Code に user scope でまとめて install する
+mise task です。
+
+```bash
+mise run gh:skill-install-all github/awesome-copilot git-commit
+mise run gh:skill-install-all github/awesome-copilot git-commit --pin v2.0.0
+```
+
+`--pin` 未指定時は、latest を浮かせたままにしないため、最新 release tag を解決して `gh skill install --pin <tag>`
+に渡します。release が無い repository は default branch HEAD SHA に pin します。
+
+## gh skill と APM の使い分け
+
+基本方針は **試し使いは gh skill、常時使用したいものは APM 管理へ昇格**です。
+
+| 観点 | gh skill | APM |
+| ---- | -------- | --- |
+| 主目的 | skill 単体の検索・preview・install | 標準セットを manifest で再現可能にする |
+| この repo での位置付け | 個人の試用導線 | 常時使用する外部 skill の正式管理 |
+| 管理単位 | `gh skill install` で agent ごとに配置 | `dot_apm/apm.yml` の `dependencies.apm` に宣言 |
+| 再現性 | `--pin <tag-or-sha>` で個別に固定 | commit SHA と lock file で管理しやすい |
+| 運用 | `gh skill preview` / `gh skill search` / `mise run gh:skill-install-all` で軽く試す | `dot_apm/apm.yml` に SHA pin 付きで追加し、`mise run apm:install` |
+
+### 昇格フロー
+
+1. `gh skill search <keyword>` で候補を探す。
+2. `gh skill preview <owner>/<repo> [skill]` で内容を読む。
+3. `mise run gh:skill-install-all <owner>/<repo> [skill]` で user scope に pin install して試す。
+4. 常時使いたいと判断したら、`dot_apm/apm.yml` の `dependencies.apm` に upstream 依存として追加する。
+5. `git ls-remote https://github.com/<owner>/<repo> HEAD` などで immutable な commit SHA に pin する。
+6. `mise run apm:install` で APM 管理の標準セットとして再配布する。
+
+## 注意
+
+- `gh skill preview` は人間が読むための確認であり、不可視 Unicode などの自動検査までは代替しません。
+- `mise run gh:skill-install-all` は user scope の試用導線なので、repo に長期保持したい skill は APM へ移してください。
+- APM 側の詳しい manifest / pin / lock 方針は [`docs/apm.md`](./apm.md) を参照してください。

--- a/docs/gh.md
+++ b/docs/gh.md
@@ -20,13 +20,13 @@ mise run gh:skill-install-all github/awesome-copilot git-commit --pin v2.0.0
 
 基本方針は **試し使いは gh skill、常時使用したいものは APM 管理へ昇格**です。
 
-| 観点 | gh skill | APM |
-| ---- | -------- | --- |
-| 主目的 | skill 単体の検索・preview・install | 標準セットを manifest で再現可能にする |
-| この repo での位置付け | 個人の試用導線 | 常時使用する外部 skill の正式管理 |
-| 管理単位 | `gh skill install` で agent ごとに配置 | `dot_apm/apm.yml` の `dependencies.apm` に宣言 |
-| 再現性 | `--pin <tag-or-sha>` で個別に固定 | commit SHA と lock file で管理しやすい |
-| 運用 | `gh skill preview` / `gh skill search` / `mise run gh:skill-install-all` で軽く試す | `dot_apm/apm.yml` に SHA pin 付きで追加し、`mise run apm:install` |
+| 観点                   | gh skill                                                                            | APM                                                               |
+| ---------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| 主目的                 | skill 単体の検索・preview・install                                                  | 標準セットを manifest で再現可能にする                            |
+| この repo での位置付け | 個人の試用導線                                                                      | 常時使用する外部 skill の正式管理                                 |
+| 管理単位               | `gh skill install` で agent ごとに配置                                              | `dot_apm/apm.yml` の `dependencies.apm` に宣言                    |
+| 再現性                 | `--pin <tag-or-sha>` で個別に固定                                                   | commit SHA と lock file で管理しやすい                            |
+| 運用                   | `gh skill preview` / `gh skill search` / `mise run gh:skill-install-all` で軽く試す | `dot_apm/apm.yml` に SHA pin 付きで追加し、`mise run apm:install` |
 
 ### 昇格フロー
 

--- a/dot_config/zabrze/gh.toml
+++ b/dot_config/zabrze/gh.toml
@@ -353,6 +353,6 @@ snippet = "gh skill search"
 trigger = "ghss"
 
 [[snippets]]
-name = "gh skill install user scope for Copilot/Cursor/Codex/Claude Code with pin"
+name    = "gh skill install user scope for Copilot/Cursor/Codex/Claude Code with pin"
 snippet = "mise run gh:skill-install-all"
 trigger = "ghsi"

--- a/dot_config/zabrze/gh.toml
+++ b/dot_config/zabrze/gh.toml
@@ -341,3 +341,18 @@ global          = true
 name            = "(gh pr ready) --undo"
 snippet         = "--undo"
 trigger-pattern = "(d|u)"
+
+[[snippets]]
+name    = "gh skill preview"
+snippet = "gh skill preview"
+trigger = "ghsp"
+
+[[snippets]]
+name    = "gh skill search"
+snippet = "gh skill search"
+trigger = "ghss"
+
+[[snippets]]
+name = "gh skill install user scope for Copilot/Cursor/Codex/Claude Code with pin"
+snippet = "mise run gh:skill-install-all"
+trigger = "ghsi"

--- a/dot_config/zsh/lazy/alias.zsh
+++ b/dot_config/zsh/lazy/alias.zsh
@@ -31,4 +31,3 @@ if [ "$(uname)" = "Linux" ]; then
   alias pwsh="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
   alias powershell="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
 fi
-

--- a/dot_config/zsh/lazy/alias.zsh
+++ b/dot_config/zsh/lazy/alias.zsh
@@ -31,3 +31,4 @@ if [ "$(uname)" = "Linux" ]; then
   alias pwsh="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
   alias powershell="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
 fi
+

--- a/tasks/gh.toml
+++ b/tasks/gh.toml
@@ -1,0 +1,58 @@
+["gh:skill-install-all"]
+description = "Install a GitHub Skill for Copilot/Cursor/Codex/Claude Code at user scope with pinning"
+run = '''
+python3 -c '
+import shutil
+import subprocess
+import sys
+
+AGENTS = ["github-copilot", "cursor", "codex", "claude-code"]
+
+if shutil.which("gh") is None:
+    print("Error: gh command is required.", file=sys.stderr)
+    sys.exit(127)
+
+if len(sys.argv) < 2:
+    print("Usage: mise run gh:skill-install-all OWNER/REPO [SKILL_OR_PATH[@VERSION]] [extra gh skill install flags...]", file=sys.stderr)
+    sys.exit(2)
+
+repo = sys.argv[1]
+install_args = sys.argv[2:]
+has_pin = any(arg == "--pin" or arg.startswith("--pin=") for arg in install_args)
+pin_args = []
+
+if not has_pin:
+    resolved_ref = ""
+    release = subprocess.run(
+        ["gh", "release", "view", repo, "--json", "tagName", "--jq", ".tagName"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    resolved_ref = release.stdout.strip()
+
+    if not resolved_ref:
+        default_branch = subprocess.run(
+            ["gh", "repo", "view", repo, "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.target.oid"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        resolved_ref = default_branch.stdout.strip()
+
+    if not resolved_ref:
+        print(f"Error: could not resolve latest release tag or default branch SHA for {repo}.", file=sys.stderr)
+        print("Pass an explicit --pin <tag-or-sha> if this is a private or unusual repository.", file=sys.stderr)
+        sys.exit(1)
+
+    pin_args = ["--pin", resolved_ref]
+
+for agent in AGENTS:
+    subprocess.run(
+        ["gh", "skill", "install", repo, *install_args, "--agent", agent, "--scope", "user", *pin_args],
+        check=True,
+    )
+' "$@"
+'''

--- a/tasks/gh.toml
+++ b/tasks/gh.toml
@@ -5,6 +5,7 @@ python3 -c '
 import shutil
 import subprocess
 import sys
+import urllib.parse
 
 AGENTS = ["github-copilot", "cursor", "codex", "claude-code"]
 
@@ -14,7 +15,7 @@ if shutil.which("gh") is None:
 
 if len(sys.argv) < 2:
     print("Usage: mise run gh:skill-install-all OWNER/REPO [SKILL_OR_PATH[@VERSION]] [extra gh skill install flags...]", file=sys.stderr)
-    sys.exit(2)
+    sys.exit(0)
 
 repo = sys.argv[1]
 install_args = sys.argv[2:]
@@ -33,14 +34,27 @@ if not has_pin:
     resolved_ref = release.stdout.strip()
 
     if not resolved_ref:
-        default_branch = subprocess.run(
-            ["gh", "repo", "view", repo, "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.target.oid"],
+        default_branch_ref = subprocess.run(
+            ["gh", "repo", "view", repo, "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.target.oid // .defaultBranchRef.name // empty"],
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,
         )
-        resolved_ref = default_branch.stdout.strip()
+        default_branch_ref = default_branch_ref.stdout.strip()
+
+        if default_branch_ref and len(default_branch_ref) == 40 and all(c in "0123456789abcdefABCDEF" for c in default_branch_ref):
+            resolved_ref = default_branch_ref
+        elif default_branch_ref:
+            branch = urllib.parse.quote(default_branch_ref, safe="")
+            commit = subprocess.run(
+                ["gh", "api", f"repos/{repo}/commits/{branch}", "--jq", ".sha"],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+            resolved_ref = commit.stdout.strip()
 
     if not resolved_ref:
         print(f"Error: could not resolve latest release tag or default branch SHA for {repo}.", file=sys.stderr)


### PR DESCRIPTION
### Motivation

- Provide a lightweight workflow for trying GitHub CLI agent skills via `gh skill` while keeping long-term managed skills in APM.  
- Automate user-scope installation of common agent skills (Copilot/Cursor/Codex/Claude Code) with deterministic pinning to releases or default-branch SHAs.  
- Expose convenient editor/snippet shortcuts for `gh skill` operations to speed discovery and trial.

### Description

- Adds a new task `gh:skill-install-all` in `tasks/gh.toml` which runs a small Python helper to install `github-copilot`, `cursor`, `codex`, and `claude-code` via `gh skill install --agent <agent> --scope user`, and automatically resolves a `--pin` value from the latest release tag or the default branch commit SHA when `--pin` is not supplied.  
- Adds `docs/gh.md` documenting the policy, usage examples, pinning behavior, and an escalation flow from trial (`gh skill`) to permanent management (APM).  
- Adds snippets to `dot_config/zabrze/gh.toml` for `gh skill preview`, `gh skill search`, and the `mise run gh:skill-install-all` invocation to make discovery and install trials quicker.  
- Small whitespace/cleanup in `dot_config/zsh/lazy/alias.zsh` (trailing newline/formatting tidy).

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72c3b0d28c8332b7290b6622103d43)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `gh:skill-install-all` task, `gh` snippets, and docs to streamline trying agent skills with pinned user-scope installs and a simple path to APM.

- **New Features**
  - `gh:skill-install-all`: installs a repo as a skill for `github-copilot`, `cursor`, `codex`, and `claude-code` via `gh skill install --scope user --agent <agent>`, auto-resolves `--pin` to the latest release tag or default-branch HEAD SHA, and includes clear usage/errors with fail-fast installs.
  - Docs (`docs/gh.md`): policy, usage examples, pin logic, and the trial-to-APM flow.
  - Snippets (`dot_config/zabrze/gh.toml`): `ghsp` → `gh skill preview`, `ghss` → `gh skill search`, `ghsi` → `mise run gh:skill-install-all`.

<sup>Written for commit 812240b53fe459be1ae7e1383d0790906e90fae5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

