### PR TITLE
Use explicit chezmoi sourceDir for rulesync generation, add guards and docs

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -75,7 +75,7 @@ fi
 # 3) rulesync generate:
 #    rulesync のソース（プロジェクト直下の .rulesync/ + rulesync.jsonc、および
 #    グローバルの ~/.config/rulesync/）に差分があるときだけハッシュマーカーで判定して走らせる。
-source_dir="${CHEZMOI_SOURCE_DIR:-$HOME/.local/share/chezmoi}"
+source_dir={{ .chezmoi.sourceDir | quote }}
 hash_cmd() { if command -v sha1sum >/dev/null; then sha1sum; else shasum -a 1; fi; }
 rulesync_hash=$(
   {

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -75,7 +75,7 @@ fi
 # 3) rulesync generate:
 #    rulesync のソース（プロジェクト直下の .rulesync/ + rulesync.jsonc、および
 #    グローバルの ~/.config/rulesync/）に差分があるときだけハッシュマーカーで判定して走らせる。
-source_dir=$(chezmoi source-path 2>/dev/null || echo "${CHEZMOI_SOURCE_DIR:-$HOME/.local/share/chezmoi}")
+source_dir="${CHEZMOI_SOURCE_DIR:-$HOME/.local/share/chezmoi}"
 hash_cmd() { if command -v sha1sum >/dev/null; then sha1sum; else shasum -a 1; fi; }
 rulesync_hash=$(
   {
@@ -91,7 +91,7 @@ rulesync_hash=$(
 )
 if [ "$(cat "$state_dir/rulesync-hash" 2>/dev/null)" != "$rulesync_hash" ]; then
   echo "Running mise run rulesync:generate..."
-  if mise run rulesync:generate; then
+  if CHEZMOI_SOURCE_DIR=$source_dir mise run rulesync:generate; then
     # マーカー書き込み失敗（state_dir が書込み不可/容量不足）も検知して警告する。
     # 未検知だと毎回の apply で無駄に再生成され続けるため。
     if ! printf '%s' "$rulesync_hash" > "$state_dir/rulesync-hash" 2>/dev/null; then

--- a/docs/rulesync.md
+++ b/docs/rulesync.md
@@ -56,12 +56,27 @@ module path・namespace・APMが生成したnamespaceなしcommandの削除先�
 | グローバル配布用の rulesync source | `dot_config/rulesync/exact_dot_rulesync/rules/COMMON.md`, `.../skills/*/SKILL.md` | する     | chezmoi で `~/.config/rulesync/.rulesync/` へ配布する正本だから     |
 | グローバル生成物                   | `~/.claude/`, `~/.codex/`, `~/.copilot/` 配下へ生成されるファイル                 | しない   | `rulesync generate` で実ホームへ再生成される出力だから              |
 
+### 初回 clone と `rulesync init` の関係
+
+Rulesync では、`rulesync init` が作る `rulesync.jsonc` と `.rulesync/` が **初期化済みかどうかの実体**です。
+追加のローカル DB や hidden state を作って「初期化済み」と記録する仕組みではありません。そのため、初回
+`git clone` 直後でも、git 管理された `rulesync.jsonc` と `.rulesync/rules/CLAUDE.md` が存在していれば、
+その clone は rulesync 的にはすでに初期化済みです。
+
+この状態で `mise run rulesync:generate` を実行しても、`.rulesync/rules/CLAUDE.md` は **入力 source**、
+リポジトリ直下の `CLAUDE.md` は **生成 output** なので、パスが異なりバッティングしません。output の
+`CLAUDE.md` は `.gitignore` で git 管理から外しているため、初回生成で作られるローカル生成物として扱います。
+
 ### 既存ファイルと `rulesync init` のバッティングについて
 
 `rulesync init` は、新規プロジェクトに `rulesync.jsonc` と `.rulesync/` の雛形を作るためのコマンドです。
 このリポジトリにはすでに `rulesync.jsonc` と `.rulesync/rules/CLAUDE.md` があるため、
 **リポジトリ直下で `rulesync init` を再実行する必要はありません**。既存の `.rulesync/rules/CLAUDE.md` と
 init が作ろうとする雛形がぶつかる場合は、init ではなく既存の source を編集してください。
+
+もし別リポジトリで、すでに手書きの `CLAUDE.md` や他ツール用 rule ファイルがある状態から rulesync へ移行するなら、
+`rulesync init` で上書き方向に進めるのではなく、既存 output を `.rulesync/` 側へ取り込む `rulesync import` 系の
+ワークフローを使うか、手で `.rulesync/rules/` に移してから生成 output を `.gitignore` に入れてください。
 
 グローバル側も同様に、source の正本は `dot_config/rulesync/exact_dot_rulesync/` 配下で git 管理し、
 chezmoi が `~/.config/rulesync/.rulesync/` へ展開します。実ホーム側の `~/.config/rulesync/.rulesync/` で

--- a/docs/rulesync.md
+++ b/docs/rulesync.md
@@ -41,6 +41,34 @@ Agent Skillへ変換するため、`$tsumiki-<name>`として利用できます�
 module path・namespace・APMが生成したnamespaceなしcommandの削除先を追加して配布できます。sourceの同期と生成は
 `mise run apm:install` がまとめて実行します。
 
+
+## `rulesync init` で生成されるファイルの扱い
+
+このリポジトリでは **rulesync のソースは git 管理し、rulesync の出力先は原則 git 管理しません**。
+ただし、プロジェクト単位スコープの出力である `CLAUDE.md` は「このリポジトリ自体で参照したい生成物」なので、
+例外的にリポジトリ直下へ生成しますが、`.gitignore` で git 管理から外しています。
+
+| 種類                            | 例                                                                                  | git 管理 | 理由                                                                                      |
+| ------------------------------- | ----------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------- |
+| プロジェクト単位の rulesync 設定 | `rulesync.jsonc`                                                                     | する     | generate の入力であり、リポジトリ固有の target / output 設定だから                       |
+| プロジェクト単位の rulesync source | `.rulesync/rules/CLAUDE.md`                                                        | する     | `CLAUDE.md` を生成するための正本だから                                                     |
+| プロジェクト単位の生成物        | `CLAUDE.md`                                                                         | しない   | `rulesync generate` で再生成される出力だから                                               |
+| グローバル配布用の rulesync 設定 | `dot_config/rulesync/rulesync.jsonc`                                                | する     | chezmoi で `~/.config/rulesync/rulesync.jsonc` へ配布する入力だから                       |
+| グローバル配布用の rulesync source | `dot_config/rulesync/exact_dot_rulesync/rules/COMMON.md`, `.../skills/*/SKILL.md` | する     | chezmoi で `~/.config/rulesync/.rulesync/` へ配布する正本だから                           |
+| グローバル生成物                | `~/.claude/`, `~/.codex/`, `~/.copilot/` 配下へ生成されるファイル                   | しない   | `rulesync generate` で実ホームへ再生成される出力だから                                   |
+
+### 既存ファイルと `rulesync init` のバッティングについて
+
+`rulesync init` は、新規プロジェクトに `rulesync.jsonc` と `.rulesync/` の雛形を作るためのコマンドです。
+このリポジトリにはすでに `rulesync.jsonc` と `.rulesync/rules/CLAUDE.md` があるため、
+**リポジトリ直下で `rulesync init` を再実行する必要はありません**。既存の `.rulesync/rules/CLAUDE.md` と
+init が作ろうとする雛形がぶつかる場合は、init ではなく既存の source を編集してください。
+
+グローバル側も同様に、source の正本は `dot_config/rulesync/exact_dot_rulesync/` 配下で git 管理し、
+chezmoi が `~/.config/rulesync/.rulesync/` へ展開します。実ホーム側の `~/.config/rulesync/.rulesync/` で
+直接 `rulesync init` して作ったファイルは、正本ではないため git 管理しません。必要な内容だけ
+`dot_config/rulesync/exact_dot_rulesync/` へ移してください。
+
 ## 生成コマンド
 
 ```bash
@@ -49,23 +77,13 @@ mise run rulesync:generate
 
 `dot_config/mise/tasks/dev.toml` で以下の2ステップを実行します。
 
-```toml
-run = [
-    "cd \"$(chezmoi source-path)\" && rulesync generate",
-    "cd ~/.config/rulesync && rulesync generate",
-]
-```
+1. **プロジェクト単位**: `CHEZMOI_SOURCE_DIR`（未設定なら `~/.local/share/chezmoi`）をこのリポジトリの
+   source directory とみなし、`rulesync.jsonc` と `.rulesync/` が両方ある場合だけ `cd` して実行する。
+   `chezmoi apply` の post hook 中は chezmoi が persistent state lock を保持しうるため、ここでは
+   `chezmoi source-path` を呼ばない。
+2. **グローバル**: `~/.config/rulesync` に `rulesync.jsonc` と `.rulesync/` が両方ある場合だけ `cd` して実行する。
 
-1. **プロジェクト単位**: `chezmoi source-path`（= このリポジトリのソースディレクトリ）へ `cd` してから実行。
-   `mise run` をどのディレクトリから叩いても解決できるよう明示的に `cd` している。
-2. **グローバル**: `~/.config/rulesync` へ `cd` してから実行。
-
-> [!IMPORTANT]
-> グローバル側は **`chezmoi apply` 済みであること**が前提です。`~/.config/rulesync/.rulesync/`
-> は chezmoi が生成するディレクトリなので、`chezmoi apply` 前は存在せず
-> `.rulesync directory not found. Run 'rulesync init' first.` で失敗します。
-> 新しいマシンや `dot_config/rulesync/` を編集した直後は、先に `chezmoi apply` してから
-> `mise run rulesync:generate` を実行してください。
+どちらかのスコープが未初期化でも、もう片方の生成を止めないように warning を出して skip します。
 
 ## トラブルシューティング
 

--- a/docs/rulesync.md
+++ b/docs/rulesync.md
@@ -76,8 +76,11 @@ mise run rulesync:generate
 
 `dot_config/mise/tasks/dev.toml` で以下の2ステップを実行します。
 
-1. **プロジェクト単位**: `CHEZMOI_SOURCE_DIR`（未設定なら `~/.local/share/chezmoi`）をこのリポジトリの
-   source directory とみなし、`rulesync.jsonc` と `.rulesync/` が両方ある場合だけ `cd` して実行する。
+1. **プロジェクト単位**: `chezmoi apply` の post hook からは、テンプレート変数 `.chezmoi.sourceDir` で
+   解決した実行中の chezmoi source directory を `CHEZMOI_SOURCE_DIR` として `mise run rulesync:generate` へ渡す。
+   そのため、`sourceDir = ...` や `chezmoi apply --source ...` で非既定の source directory を使う場合も同じ
+   source directory を参照できる。task 側は `CHEZMOI_SOURCE_DIR` 配下に `rulesync.jsonc` と `.rulesync/` が
+   両方ある場合だけ `cd` して実行する。
    `chezmoi apply` の post hook 中は chezmoi が persistent state lock を保持しうるため、ここでは
    `chezmoi source-path` を呼ばない。
 2. **グローバル**: `~/.config/rulesync` に `rulesync.jsonc` と `.rulesync/` が両方ある場合だけ `cd` して実行する。

--- a/docs/rulesync.md
+++ b/docs/rulesync.md
@@ -41,21 +41,20 @@ Agent Skillへ変換するため、`$tsumiki-<name>`として利用できます�
 module path・namespace・APMが生成したnamespaceなしcommandの削除先を追加して配布できます。sourceの同期と生成は
 `mise run apm:install` がまとめて実行します。
 
-
 ## `rulesync init` で生成されるファイルの扱い
 
 このリポジトリでは **rulesync のソースは git 管理し、rulesync の出力先は原則 git 管理しません**。
 ただし、プロジェクト単位スコープの出力である `CLAUDE.md` は「このリポジトリ自体で参照したい生成物」なので、
 例外的にリポジトリ直下へ生成しますが、`.gitignore` で git 管理から外しています。
 
-| 種類                            | 例                                                                                  | git 管理 | 理由                                                                                      |
-| ------------------------------- | ----------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------- |
-| プロジェクト単位の rulesync 設定 | `rulesync.jsonc`                                                                     | する     | generate の入力であり、リポジトリ固有の target / output 設定だから                       |
-| プロジェクト単位の rulesync source | `.rulesync/rules/CLAUDE.md`                                                        | する     | `CLAUDE.md` を生成するための正本だから                                                     |
-| プロジェクト単位の生成物        | `CLAUDE.md`                                                                         | しない   | `rulesync generate` で再生成される出力だから                                               |
-| グローバル配布用の rulesync 設定 | `dot_config/rulesync/rulesync.jsonc`                                                | する     | chezmoi で `~/.config/rulesync/rulesync.jsonc` へ配布する入力だから                       |
-| グローバル配布用の rulesync source | `dot_config/rulesync/exact_dot_rulesync/rules/COMMON.md`, `.../skills/*/SKILL.md` | する     | chezmoi で `~/.config/rulesync/.rulesync/` へ配布する正本だから                           |
-| グローバル生成物                | `~/.claude/`, `~/.codex/`, `~/.copilot/` 配下へ生成されるファイル                   | しない   | `rulesync generate` で実ホームへ再生成される出力だから                                   |
+| 種類                               | 例                                                                                | git 管理 | 理由                                                                |
+| ---------------------------------- | --------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------- |
+| プロジェクト単位の rulesync 設定   | `rulesync.jsonc`                                                                  | する     | generate の入力であり、リポジトリ固有の target / output 設定だから  |
+| プロジェクト単位の rulesync source | `.rulesync/rules/CLAUDE.md`                                                       | する     | `CLAUDE.md` を生成するための正本だから                              |
+| プロジェクト単位の生成物           | `CLAUDE.md`                                                                       | しない   | `rulesync generate` で再生成される出力だから                        |
+| グローバル配布用の rulesync 設定   | `dot_config/rulesync/rulesync.jsonc`                                              | する     | chezmoi で `~/.config/rulesync/rulesync.jsonc` へ配布する入力だから |
+| グローバル配布用の rulesync source | `dot_config/rulesync/exact_dot_rulesync/rules/COMMON.md`, `.../skills/*/SKILL.md` | する     | chezmoi で `~/.config/rulesync/.rulesync/` へ配布する正本だから     |
+| グローバル生成物                   | `~/.claude/`, `~/.codex/`, `~/.copilot/` 配下へ生成されるファイル                 | しない   | `rulesync generate` で実ホームへ再生成される出力だから              |
 
 ### 既存ファイルと `rulesync init` のバッティングについて
 

--- a/dot_config/mise/tasks/dev.toml
+++ b/dot_config/mise/tasks/dev.toml
@@ -4,10 +4,25 @@ description = "Generate all rulesync outputs after chezmoi apply"
 # どこから `mise run` しても解決できるよう明示的に cd する。
 # - 1つ目: このリポジトリ自身の CLAUDE.md を再生成（chezmoi source-path で解決）
 # - 2つ目: グローバル配布用（~/.claude, ~/.codex, ~/.copilot 等）を再生成
-run = [
-    "cd \"$(chezmoi source-path)\" && rulesync generate",
-    "cd ~/.config/rulesync && rulesync generate",
-]
+run = '''
+set -eu
+
+source_dir="${CHEZMOI_SOURCE_DIR:-$HOME/.local/share/chezmoi}"
+global_dir="$HOME/.config/rulesync"
+
+if [ -f "$source_dir/rulesync.jsonc" ] && [ -d "$source_dir/.rulesync" ]; then
+  (cd "$source_dir" && rulesync generate)
+else
+  echo "warning: project rulesync source not found under $source_dir; skipping project generation" >&2
+fi
+
+if [ -f "$global_dir/rulesync.jsonc" ] && [ -d "$global_dir/.rulesync" ]; then
+  (cd "$global_dir" && rulesync generate)
+else
+  echo "warning: global rulesync source not found under $global_dir; skipping global generation" >&2
+fi
+'''
+shell = "bash -c"
 
 ["apm:install"]
 description = "Deploy user-scope external skills and commands to agent dirs"


### PR DESCRIPTION
### Motivation

- Ensure `rulesync generate` uses the same chezmoi source directory that `chezmoi apply` is using and avoid calling `chezmoi source-path` from inside post-hooks where chezmoi may hold a persistent lock.
- Make rulesync generation robust by skipping missing project/global sources with diagnostics instead of failing noisily.
- Clarify the rulesync source/output model so first clone, `rulesync init`, and generated files do not feel ambiguous.

### Description

- Replace dynamic `chezmoi source-path` resolution in the chezmoi template with the template variable `{{ .chezmoi.sourceDir }}` and export it as `CHEZMOI_SOURCE_DIR` when invoking `mise run rulesync:generate` in `.chezmoi.toml.tmpl`.
- Replace the simple `cd` commands in `dot_config/mise/tasks/dev.toml` with a `bash -c` wrapper that reads `CHEZMOI_SOURCE_DIR` (with a direct-task fallback), verifies presence of `rulesync.jsonc` and `.rulesync`, runs `rulesync generate` only when appropriate, and prints warnings when skipping.
- Update `docs/rulesync.md` to document which rulesync sources/outputs are git-managed, explain that tracked `rulesync.jsonc` + `.rulesync/` means a fresh clone is already initialized, distinguish `.rulesync/rules/CLAUDE.md` input from generated root `CLAUDE.md`, and recommend import/source migration for pre-existing hand-written output files.

### Testing

- `npx --yes oxfmt@0.59.0 --check **/*.md`
- `git diff --check`
- Python assertion that docs include clone/init/source/output/import guidance.