### PR TITLE
Pass chezmoi sourceDir to rulesync and make rulesync:generate robust

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -75,7 +75,7 @@ fi
 # 3) rulesync generate:
 #    rulesync のソース（プロジェクト直下の .rulesync/ + rulesync.jsonc、および
 #    グローバルの ~/.config/rulesync/）に差分があるときだけハッシュマーカーで判定して走らせる。
-source_dir=$(chezmoi source-path 2>/dev/null || echo "${CHEZMOI_SOURCE_DIR:-$HOME/.local/share/chezmoi}")
+source_dir={{ .chezmoi.sourceDir | quote }}
 hash_cmd() { if command -v sha1sum >/dev/null; then sha1sum; else shasum -a 1; fi; }
 rulesync_hash=$(
   {
@@ -91,7 +91,7 @@ rulesync_hash=$(
 )
 if [ "$(cat "$state_dir/rulesync-hash" 2>/dev/null)" != "$rulesync_hash" ]; then
   echo "Running mise run rulesync:generate..."
-  if mise run rulesync:generate; then
+  if CHEZMOI_SOURCE_DIR=$source_dir mise run rulesync:generate; then
     # マーカー書き込み失敗（state_dir が書込み不可/容量不足）も検知して警告する。
     # 未検知だと毎回の apply で無駄に再生成され続けるため。
     if ! printf '%s' "$rulesync_hash" > "$state_dir/rulesync-hash" 2>/dev/null; then

--- a/docs/rulesync.md
+++ b/docs/rulesync.md
@@ -41,6 +41,48 @@ Agent Skillへ変換するため、`$tsumiki-<name>`として利用できます�
 module path・namespace・APMが生成したnamespaceなしcommandの削除先を追加して配布できます。sourceの同期と生成は
 `mise run apm:install` がまとめて実行します。
 
+## `rulesync init` で生成されるファイルの扱い
+
+このリポジトリでは **rulesync のソースは git 管理し、rulesync の出力先は原則 git 管理しません**。
+ただし、プロジェクト単位スコープの出力である `CLAUDE.md` は「このリポジトリ自体で参照したい生成物」なので、
+例外的にリポジトリ直下へ生成しますが、`.gitignore` で git 管理から外しています。
+
+| 種類                               | 例                                                                                | git 管理 | 理由                                                                |
+| ---------------------------------- | --------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------- |
+| プロジェクト単位の rulesync 設定   | `rulesync.jsonc`                                                                  | する     | generate の入力であり、リポジトリ固有の target / output 設定だから  |
+| プロジェクト単位の rulesync source | `.rulesync/rules/CLAUDE.md`                                                       | する     | `CLAUDE.md` を生成するための正本だから                              |
+| プロジェクト単位の生成物           | `CLAUDE.md`                                                                       | しない   | `rulesync generate` で再生成される出力だから                        |
+| グローバル配布用の rulesync 設定   | `dot_config/rulesync/rulesync.jsonc`                                              | する     | chezmoi で `~/.config/rulesync/rulesync.jsonc` へ配布する入力だから |
+| グローバル配布用の rulesync source | `dot_config/rulesync/exact_dot_rulesync/rules/COMMON.md`, `.../skills/*/SKILL.md` | する     | chezmoi で `~/.config/rulesync/.rulesync/` へ配布する正本だから     |
+| グローバル生成物                   | `~/.claude/`, `~/.codex/`, `~/.copilot/` 配下へ生成されるファイル                 | しない   | `rulesync generate` で実ホームへ再生成される出力だから              |
+
+### 初回 clone と `rulesync init` の関係
+
+Rulesync では、`rulesync init` が作る `rulesync.jsonc` と `.rulesync/` が **初期化済みかどうかの実体**です。
+追加のローカル DB や hidden state を作って「初期化済み」と記録する仕組みではありません。そのため、初回
+`git clone` 直後でも、git 管理された `rulesync.jsonc` と `.rulesync/rules/CLAUDE.md` が存在していれば、
+その clone は rulesync 的にはすでに初期化済みです。
+
+この状態で `mise run rulesync:generate` を実行しても、`.rulesync/rules/CLAUDE.md` は **入力 source**、
+リポジトリ直下の `CLAUDE.md` は **生成 output** なので、パスが異なりバッティングしません。output の
+`CLAUDE.md` は `.gitignore` で git 管理から外しているため、初回生成で作られるローカル生成物として扱います。
+
+### 既存ファイルと `rulesync init` のバッティングについて
+
+`rulesync init` は、新規プロジェクトに `rulesync.jsonc` と `.rulesync/` の雛形を作るためのコマンドです。
+このリポジトリにはすでに `rulesync.jsonc` と `.rulesync/rules/CLAUDE.md` があるため、
+**リポジトリ直下で `rulesync init` を再実行する必要はありません**。既存の `.rulesync/rules/CLAUDE.md` と
+init が作ろうとする雛形がぶつかる場合は、init ではなく既存の source を編集してください。
+
+もし別リポジトリで、すでに手書きの `CLAUDE.md` や他ツール用 rule ファイルがある状態から rulesync へ移行するなら、
+`rulesync init` で上書き方向に進めるのではなく、既存 output を `.rulesync/` 側へ取り込む `rulesync import` 系の
+ワークフローを使うか、手で `.rulesync/rules/` に移してから生成 output を `.gitignore` に入れてください。
+
+グローバル側も同様に、source の正本は `dot_config/rulesync/exact_dot_rulesync/` 配下で git 管理し、
+chezmoi が `~/.config/rulesync/.rulesync/` へ展開します。実ホーム側の `~/.config/rulesync/.rulesync/` で
+直接 `rulesync init` して作ったファイルは、正本ではないため git 管理しません。必要な内容だけ
+`dot_config/rulesync/exact_dot_rulesync/` へ移してください。
+
 ## 生成コマンド
 
 ```bash
@@ -49,23 +91,16 @@ mise run rulesync:generate
 
 `dot_config/mise/tasks/dev.toml` で以下の2ステップを実行します。
 
-```toml
-run = [
-    "cd \"$(chezmoi source-path)\" && rulesync generate",
-    "cd ~/.config/rulesync && rulesync generate",
-]
-```
+1. **プロジェクト単位**: `chezmoi apply` の post hook からは、テンプレート変数 `.chezmoi.sourceDir` で
+   解決した実行中の chezmoi source directory を `CHEZMOI_SOURCE_DIR` として `mise run rulesync:generate` へ渡す。
+   そのため、`sourceDir = ...` や `chezmoi apply --source ...` で非既定の source directory を使う場合も同じ
+   source directory を参照できる。task 側は `CHEZMOI_SOURCE_DIR` 配下に `rulesync.jsonc` と `.rulesync/` が
+   両方ある場合だけ `cd` して実行する。
+   `chezmoi apply` の post hook 中は chezmoi が persistent state lock を保持しうるため、ここでは
+   `chezmoi source-path` を呼ばない。
+2. **グローバル**: `~/.config/rulesync` に `rulesync.jsonc` と `.rulesync/` が両方ある場合だけ `cd` して実行する。
 
-1. **プロジェクト単位**: `chezmoi source-path`（= このリポジトリのソースディレクトリ）へ `cd` してから実行。
-   `mise run` をどのディレクトリから叩いても解決できるよう明示的に `cd` している。
-2. **グローバル**: `~/.config/rulesync` へ `cd` してから実行。
-
-> [!IMPORTANT]
-> グローバル側は **`chezmoi apply` 済みであること**が前提です。`~/.config/rulesync/.rulesync/`
-> は chezmoi が生成するディレクトリなので、`chezmoi apply` 前は存在せず
-> `.rulesync directory not found. Run 'rulesync init' first.` で失敗します。
-> 新しいマシンや `dot_config/rulesync/` を編集した直後は、先に `chezmoi apply` してから
-> `mise run rulesync:generate` を実行してください。
+どちらかのスコープが未初期化でも、もう片方の生成を止めないように warning を出して skip します。
 
 ## トラブルシューティング
 

--- a/dot_config/mise/tasks/dev.toml
+++ b/dot_config/mise/tasks/dev.toml
@@ -4,10 +4,25 @@ description = "Generate all rulesync outputs after chezmoi apply"
 # どこから `mise run` しても解決できるよう明示的に cd する。
 # - 1つ目: このリポジトリ自身の CLAUDE.md を再生成（chezmoi source-path で解決）
 # - 2つ目: グローバル配布用（~/.claude, ~/.codex, ~/.copilot 等）を再生成
-run = [
-    "cd \"$(chezmoi source-path)\" && rulesync generate",
-    "cd ~/.config/rulesync && rulesync generate",
-]
+run = '''
+set -eu
+
+source_dir="${CHEZMOI_SOURCE_DIR:-$HOME/.local/share/chezmoi}"
+global_dir="$HOME/.config/rulesync"
+
+if [ -f "$source_dir/rulesync.jsonc" ] && [ -d "$source_dir/.rulesync" ]; then
+  (cd "$source_dir" && rulesync generate)
+else
+  echo "warning: project rulesync source not found under $source_dir; skipping project generation" >&2
+fi
+
+if [ -f "$global_dir/rulesync.jsonc" ] && [ -d "$global_dir/.rulesync" ]; then
+  (cd "$global_dir" && rulesync generate)
+else
+  echo "warning: global rulesync source not found under $global_dir; skipping global generation" >&2
+fi
+'''
+shell = "bash -c"
 
 ["apm:install"]
 description = "Deploy user-scope external skills and commands to agent dirs"


### PR DESCRIPTION
### Motivation

- Avoid calling `chezmoi source-path` from inside `chezmoi apply` hooks and support non-default source directories by using the resolved `chezmoi` template variable instead. 
- Prevent unnecessary or failing `rulesync generate` runs by only invoking generation when the expected `rulesync.jsonc` and `.rulesync/` sources exist for project or global scopes. 

### Description

- Replace runtime `chezmoi source-path` lookup with the template variable `{{ .chezmoi.sourceDir }}` in `.chezmoi.toml.tmpl` and set `CHEZMOI_SOURCE_DIR` for `mise run rulesync:generate`. 
- Change the `rulesync:generate` task in `dot_config/mise/tasks/dev.toml` to a resilient shell script that honors `CHEZMOI_SOURCE_DIR` (falling back to `~/.local/share/chezmoi`) and conditionally runs `rulesync generate` only when `rulesync.jsonc` and `.rulesync/` exist, emitting warnings otherwise. 
- Update `docs/rulesync.md` with a new section explaining how rulesync-generated files are treated in git, and document the use of `CHEZMOI_SOURCE_DIR` in post-hook generation and the rationale for not calling `chezmoi source-path` inside hooks. 

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a734b2b00d08332870e01fe97caa8bc)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `rulesync` with the resolved `chezmoi` source directory and make `rulesync:generate` skip gracefully when sources are missing. This removes fragile `chezmoi source-path` calls in hooks and supports non-default source dirs.

- **Refactors**
  - `.chezmoi.toml.tmpl`: use `{{ .chezmoi.sourceDir }}` and export `CHEZMOI_SOURCE_DIR` to `mise run rulesync:generate`.
  - `dot_config/mise/tasks/dev.toml`: replace task with a bash script; honor `CHEZMOI_SOURCE_DIR` (fallback `~/.local/share/chezmoi`); run only if both `rulesync.jsonc` and `.rulesync/` exist; warn and skip otherwise.
  - `docs/rulesync.md`: document git tracking policy for rulesync inputs/outputs, clone/init expectations, and the rationale for avoiding `chezmoi source-path` in post hooks.

<sup>Written for commit 6a72f68b9437e681994d4f05f2d74cf6b31396ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

