### PR TITLE
fix: group tool and skill Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -215,9 +215,9 @@
       "customType": "regex",
       "managerFilePatterns": ["dot_apm/apm.yml"],
       "matchStrings": [
-        "git:\\sctxrs/ctx\\s+path:\\s+skills/ctx-agent-history-search\\s+ref:\\s+v?(?<currentValue>[^\\s]+)"
+        "-\\s(?<depName>[^/\\s]+/[^/\\s]+)/\\S*?#v?(?<currentValue>[^\\s]+)",
+        "git:\\s(?<depName>[^/\\s]+/[^/\\s]+)(?:\\s+(?:path|alias):[^\\n]*)*\\s+ref:\\s+v?(?<currentValue>[^\\s]+)"
       ],
-      "depNameTemplate": "ctxrs/ctx",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
     }

--- a/dot_apm/apm.lock.yaml
+++ b/dot_apm/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-08-06T13:52:58.521552+00:00'
+generated_at: '2026-08-06T14:08:17.412221+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: classmethod/tsumiki
@@ -584,8 +584,8 @@ dependencies:
 - repo_url: tomasz-tomczyk/crit
   name: crit
   host: github.com
-  resolved_commit: 2c180fee6cb030fe0a2a2dc402053fbe7152512b
-  resolved_ref: 2c180fee6cb030fe0a2a2dc402053fbe7152512b
+  resolved_commit: bb6a8bcd9020c2de7a522c264bd859155915139f
+  resolved_ref: v0.18.2
   version: unknown
   virtual_path: integrations/claude-code/skills/crit
   is_virtual: true
@@ -598,12 +598,12 @@ dependencies:
   deployed_file_hashes:
     .agents/skills/crit/SKILL.md: sha256:8edde24a92b58bc8dba5d5c002f7a846264a7c95ead69ad62fe5fc09ef0f6b0b
     .claude/skills/crit/SKILL.md: sha256:8edde24a92b58bc8dba5d5c002f7a846264a7c95ead69ad62fe5fc09ef0f6b0b
-  content_hash: sha256:3da57731dbdf2846ad3b3d214b6a6ecd69d4bfaa08eb74cdaad1af8f1359b2b8
+  content_hash: sha256:fe83a4e68c02e2c77eed71ced3e519acf7a5d41ea404cbb1ba1776d45113357f
 - repo_url: tomasz-tomczyk/crit
   name: crit-cli
   host: github.com
-  resolved_commit: 2c180fee6cb030fe0a2a2dc402053fbe7152512b
-  resolved_ref: 2c180fee6cb030fe0a2a2dc402053fbe7152512b
+  resolved_commit: bb6a8bcd9020c2de7a522c264bd859155915139f
+  resolved_ref: v0.18.2
   version: unknown
   virtual_path: integrations/claude-code/skills/crit-cli
   is_virtual: true
@@ -616,12 +616,12 @@ dependencies:
   deployed_file_hashes:
     .agents/skills/crit-cli/SKILL.md: sha256:0e4dfa41c0fbf1a540bc97d78876da8bf59ebf6de753c0ae3763f847052851e8
     .claude/skills/crit-cli/SKILL.md: sha256:0e4dfa41c0fbf1a540bc97d78876da8bf59ebf6de753c0ae3763f847052851e8
-  content_hash: sha256:420cf38f07094fa638f3225acd392e7b47f839202e99b572a0a59924ce775bde
+  content_hash: sha256:c62c3b4d93667eb2f8046f5ee7f8a51a3a2c5ac574faad108501e05747bf0f7a
 - repo_url: zenbu-labs/terminal-browser
   name: terminal-browser
   host: github.com
-  resolved_commit: 5e4f4745cc2214f646eed37666567317561efef0
-  resolved_ref: 5e4f4745cc2214f646eed37666567317561efef0
+  resolved_commit: 1b21e3a76453a53eda7f5bdc93c4aaabf70052f2
+  resolved_ref: v0.3.2
   version: unknown
   virtual_path: skill
   is_virtual: true

--- a/dot_apm/apm.yml
+++ b/dot_apm/apm.yml
@@ -11,16 +11,16 @@ targets:
   - cursor
 dependencies:
   # 外部スキルはすべて upstream リポジトリから依存として取得する（vendor しない）。
-  # 再現性のため各依存は immutable なコミット SHA に pin する（`#<sha>`）。
-  # SHA 更新は `git ls-remote <repo> HEAD` 等で取得して差し替える。
+  # 再現性のため各依存をコミット SHA または release tag に pin する。
+  # CLI も配布するリポジトリは release tag を使い、Renovate で同一PRにまとめる。
   apm:
     # crit（tomasz-tomczyk/crit プラグイン）。devcontainer 固有のグルーは crit ラッパーに分離済み。
-    - tomasz-tomczyk/crit/integrations/claude-code/skills/crit#2c180fee6cb030fe0a2a2dc402053fbe7152512b
-    - tomasz-tomczyk/crit/integrations/claude-code/skills/crit-cli#2c180fee6cb030fe0a2a2dc402053fbe7152512b
+    - tomasz-tomczyk/crit/integrations/claude-code/skills/crit#v0.18.2
+    - tomasz-tomczyk/crit/integrations/claude-code/skills/crit-cli#v0.18.2
     # virtual package の既定名 terminal-browser-skill ではなく、skill 名と同じ配置名にする。
     - git: zenbu-labs/terminal-browser
       path: skill
-      ref: 5e4f4745cc2214f646eed37666567317561efef0
+      ref: v0.3.2
       alias: terminal-browser
     # tsumiki はリポジトリ全体を plugin package として取り込み、skills 14種と commands を配布する。
     - git: classmethod/tsumiki


### PR DESCRIPTION
## Summary
- detect release-tag-pinned APM dependencies generically instead of only ctx
- pin terminal-browser and crit skills to the same release versions as their tools
- regenerate the APM lockfile for the release-tag refs

## Testing
- `python3 -m json.tool .github/renovate.json`
- `npx --yes renovate@44.0.1 renovate-config-validator .github/renovate.json`
- `git diff --check`
- `apm lock --no-policy`
- `apm audit --ci` (deployment presence check is unavailable in this clean environment)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach Renovate to group APM tool and skill updates by detecting release-tag pins, and pin skills to the same released versions as their tools. Also update `tomasz-tomczyk/crit` and `zenbu-labs/terminal-browser` to release tags and regenerate the APM lockfile.

- **Refactors**
  - Replace ctx-specific regex with generic patterns in `.github/renovate.json` to extract `depName` and release-tag versions from `dot_apm/apm.yml`.

- **Dependencies**
  - Pin `tomasz-tomczyk/crit` skills `crit` and `crit-cli` to `v0.18.2`.
  - Pin `zenbu-labs/terminal-browser` skill to `v0.3.2`.
  - Regenerate `dot_apm/apm.lock.yaml` for the new refs.

<sup>Written for commit 08bb8bb727334ae5699c52f671446b1a50041931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

