### PR TITLE
Add two mattpocock skills to apm manifest

### DIFF
--- a/dot_apm/apm.yml
+++ b/dot_apm/apm.yml
@@ -26,6 +26,14 @@ dependencies:
     - git: classmethod/tsumiki
       ref: 9a0a2348ebf1cb83b7cf91adfe2ffff28be02525
       alias: tsumiki
+    - git: mattpocock/skills
+      path: skills/engineering/resolving-merge-conflicts
+      ref: 2ab958093e83e0ec752e6c1c5932da465bf23e0c
+      alias: resolving-merge-conflicts
+    - git: mattpocock/skills
+      path: skills/productivity/grill-me
+      ref: 2ab958093e83e0ec752e6c1c5932da465bf23e0c
+      alias: grill-me
   mcp: []
 includes: auto
 scripts: {}


### PR DESCRIPTION
### Motivation
- Add two external skills from `mattpocock/skills` to the user-scope APM manifest so they can be deployed via `apm`.

### Description
- Add two `apm` dependency entries pointing to `mattpocock/skills` with `path: skills/engineering/resolving-merge-conflicts` aliased as `resolving-merge-conflicts` and `path: skills/productivity/grill-me` aliased as `grill-me`, both pinned to `ref: 2ab958093e83e0ec752e6c1c5932da465bf23e0c`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71f317351c8332b5f5beea5740d392)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two external skills to `dot_apm/apm.yml` so they can be installed via `apm`. Adds `resolving-merge-conflicts` and `grill-me` from `mattpocock/skills`, pinned to ref `2ab958093e83e0ec752e6c1c5932da465bf23e0c`.

<sup>Written for commit 9bf825749b5e1078fffdec89c4ec3f8e6c35b5ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

