### PR TITLE
Obsidian CLIをmiseで管理する手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@
 # Setup
 
 - [setup](docs/setup.md)
+- [Obsidian CLI](docs/obsidian.md)

--- a/docs/obsidian.md
+++ b/docs/obsidian.md
@@ -1,0 +1,48 @@
+# Obsidian CLI
+
+Obsidian CLI は独立した CLI パッケージではなく、Obsidian 1.12.7 以降のデスクトップアプリに
+同梱されている。このリポジトリでは macOS 版 Obsidian を mise の
+`brew-cask:obsidian` bootstrap package として宣言し、アプリと CLI のバージョンをまとめて管理する。
+
+## インストール
+
+chezmoi の設定を反映すると、post-apply hook が不足している bootstrap package を導入する。
+Obsidian だけを明示的に同期したい場合も、通常の packages apply を実行する。
+
+```sh
+chezmoi apply
+# または
+mise bootstrap packages apply
+```
+
+インストール後、Obsidian で CLI を一度だけ登録する。
+
+1. Obsidian を起動する。
+2. **Settings** → **General** を開く。
+3. **Command line interface** を有効にし、画面の案内に従う。
+4. ターミナルを開き直して動作を確認する。
+
+```sh
+obsidian version
+obsidian help
+```
+
+CLI はデスクトップアプリを操作するため、コマンド実行時に Obsidian が起動していなければ
+アプリも起動する。
+
+## バージョン更新
+
+現在の upstream バージョンは `dot_config/mise/config.mac.toml` の Obsidian 行末コメントで追跡する。
+Renovate がコメントのバージョンを更新する PR を作成し、マージ後の `chezmoi apply` または次の
+コマンドで `latest` の cask に収束させる。
+
+```sh
+mise bootstrap packages status
+mise bootstrap packages upgrade
+```
+
+Obsidian CLI の必要条件は Obsidian installer 1.12.7 以降。アプリ内更新だけでは installer が
+古いままになる場合があるため、CLI が登録できないときは bootstrap package を再適用してから
+もう一度登録する。
+
+参考: [Obsidian CLI 公式ドキュメント](https://obsidian.md/help/cli)

--- a/dot_config/mise/config.mac.toml
+++ b/dot_config/mise/config.mac.toml
@@ -54,6 +54,8 @@
 "brew-cask:karabiner-elements"    = "latest" # 13.7.0
 "brew-cask:keyboardcleantool"     = "latest" # 7
 "brew-cask:memory-cleaner"        = "latest" # 5.5.3,271
+# Obsidian CLI は 1.12.7+ のデスクトップアプリに同梱。導入後にアプリの
+# Settings > General > Command line interface から一度だけ登録する（docs/obsidian.md）。
 "brew-cask:obsidian"              = "latest" # 1.13.4
 "brew-cask:overview"              = "latest" # 1.2.3-beta
 "brew-cask:slack"                 = "latest" # 4.51.180


### PR DESCRIPTION
## Summary
- Obsidian desktop app/CLI を mise の `brew-cask:obsidian` で導入・更新する意図を設定に明記
- Obsidian CLI の初回登録、動作確認、mise による更新手順をドキュメント化
- README から Obsidian CLI ガイドへリンク

## Testing
- `python` の `tomllib` で mise TOML 設定をパース
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Obsidian Desktop/CLI を mise でまとめて管理する手順を追加。`brew-cask:obsidian` 経由でインストール・登録・更新する流れをドキュメント化し、README にガイドへのリンクを追加しました。

- **Migration**
  - `chezmoi apply` または `mise bootstrap packages apply` を実行。
  - Obsidian の Settings → General → Command line interface で一度だけ登録。
  - 端末を再起動して確認: `obsidian version` / `obsidian help`。
  - 登録できない場合はブートストラップを再適用して再登録。

<sup>Written for commit 36469cf4cab04e37e4ae2bfbc6ee55454ef49e31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

