### PR TITLE
devcontainerにObsidian Headless CLIを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@
 # Setup
 
 - [setup](docs/setup.md)
+- [Obsidian CLI in devcontainer](docs/obsidian.md)

--- a/docs/obsidian.md
+++ b/docs/obsidian.md
@@ -1,0 +1,42 @@
+# Obsidian CLI in devcontainer
+
+devcontainer では、デスクトップアプリを含まない公式 CLI の
+[Obsidian Headless](https://github.com/obsidianmd/obsidian-headless) を使用する。
+`dot_config/devcontainer/mise.toml` の `npm:obsidian-headless` でバージョンを固定しているため、
+devcontainer のリビルド時に mise が Node.js と CLI をインストールする。
+
+```sh
+ob --version
+ob --help
+```
+
+## 初期設定
+
+Obsidian Headless は Obsidian Sync / Publish 用の CLI であり、デスクトップアプリを必要としない。
+Obsidian Sync を使用する場合は、コンテナ内でログインして vault を設定する。
+
+```sh
+ob login
+mkdir -p ~/vaults/my-vault
+cd ~/vaults/my-vault
+ob sync-setup --vault "My Vault"
+ob sync
+```
+
+継続的に同期する場合は `ob sync --continuous` を実行する。認証情報と vault をコンテナの
+リビルド後にも残す場合は、それらの保存先を devcontainer の volume または bind mount に置く。
+
+## `obsidian` コマンドとの違い
+
+[Obsidian CLI](https://obsidian.md/help/cli) の `obsidian` コマンドはデスクトップアプリに
+同梱され、起動中のアプリを操作する。独立した CLI パッケージではないため、CLI だけを mise で
+devcontainer にインストールすることはできない。
+
+一方、この設定で導入する `obsidian-headless` のコマンド名は `ob` で、デスクトップアプリなしで
+Sync / Publish を操作できる。デスクトップアプリ内のコマンドやプラグインを操作する
+`obsidian` CLI の完全な代替ではない点に注意する。
+
+## バージョン更新
+
+`dot_config/devcontainer/mise.toml` のバージョンを更新して devcontainer をリビルドする。
+Renovate も npm のリリースを検出して更新 PR を作成する。

--- a/dot_config/devcontainer/mise.toml
+++ b/dot_config/devcontainer/mise.toml
@@ -21,6 +21,7 @@ experimental = true
 "github:tomasz-tomczyk/crit"     = "0.18.2"
 "npm:@typescript/native-preview" = "7.0.0-dev.20260519.1"
 "npm:ccusage"                    = "20.0.1"
+"npm:obsidian-headless"          = "0.0.14"
 "npm:oxfmt"                      = "0.59.0"
 "npm:oxlint"                     = "1.76.0"
 


### PR DESCRIPTION
### Motivation
- デスクトップ版 Obsidian に同梱される `obsidian` コマンドではなく、devcontainer 内でデスクトップアプリなしに利用できる公式 CLI を mise で個別管理するため。

### Description
- devcontainer の mise 設定に `npm:obsidian-headless` 0.0.14 を追加した。
- `ob` コマンドの導入確認、Sync 初期設定、永続化、およびデスクトップ版 `obsidian` CLI との違いを文書化した。
- README から導入ガイドへリンクした。

### Testing
- `python` の `tomllib` で `dot_config/devcontainer/mise.toml` を解析。
- Node.js 22 で `obsidian-headless` 0.0.14 の `ob --version` を確認。
- `npx --yes oxfmt@0.59.0 --check '**/*.md'`。
- `npx --yes @taplo/cli@0.7.0 format --check dot_config/devcontainer/mise.toml`。
- `git diff --check`。


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Obsidian Headless CLI to the devcontainer via `mise` so you can run `ob` without the desktop app. This enables Sync/Publish workflows and adds a short guide for setup and differences vs the desktop `obsidian` CLI.

- **New Features**
  - Added `npm:obsidian-headless` 0.0.14 to `dot_config/devcontainer/mise.toml`; installed on devcontainer rebuild.
  - Added `docs/obsidian.md` with `ob` setup, Sync init, persistence tips, and differences from `obsidian`.
  - Linked the new guide from README.

<sup>Written for commit c2f62736613adbaf4715f5ee81407100fdebaf2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

Obsidian Headless CLI `obsidian-headless` 0.0.14 を、mise 管理の npm パッケージとして devcontainer に追加しました。導入方法、初期設定、Sync の継続実行、設定情報と vault の永続化方法を文書化しました。README から導入ガイドへリンクしました。

## 変更理由

デスクトップ版 Obsidian なしで、devcontainer から公式 CLI の `ob` コマンドを利用できるようにするためです。デスクトップ版の `obsidian` CLI との違いと機能上の制限も明確にしました。

## 確認した項目

- `mise.toml` の `tomllib` による解析
- Node.js 22 での `ob --version` 確認
- Markdown のフォーマットチェック
- `mise.toml` の Taplo フォーマットチェック
- `git diff --check`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->