### PR TITLE
devcontainerからホストのObsidian CLIを操作可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@
 # Setup
 
 - [setup](docs/setup.md)
+- [Obsidian CLI from devcontainer](docs/obsidian.md)

--- a/docs/obsidian.md
+++ b/docs/obsidian.md
@@ -1,0 +1,55 @@
+# Obsidian CLI from devcontainer
+
+devcontainer 内の `obsidian` は、SSH 経由で macOS ホストの Obsidian CLI を呼び出すラッパーである。
+CLI の stdout、stderr、終了ステータスをそのままコンテナへ返すため、通常の CLI と同様に使用できる。
+
+```sh
+obsidian version
+obsidian vaults
+obsidian search query="TODO"
+```
+
+引数なしで実行した場合は SSH の PTY を割り当て、Obsidian CLI の対話 TUI を開く。
+
+## ホスト側の初期設定
+
+1. macOS の Obsidian installer を 1.12.7 以降へ更新する。このリポジトリでは
+   `dot_config/mise/config.mac.toml` の `brew-cask:obsidian` を mise で管理している。
+2. Obsidian を起動し、**Settings → General → Command line interface** から CLI を登録する。
+3. ホストのターミナルで CLI と symlink を確認する。
+
+```sh
+obsidian version
+ls -l /usr/local/bin/obsidian
+```
+
+登録に失敗する場合は、公式手順に従ってホスト上で symlink を作成する。
+
+```sh
+sudo ln -sf /Applications/Obsidian.app/Contents/MacOS/obsidian-cli /usr/local/bin/obsidian
+```
+
+Obsidian CLI はホストのデスクトップアプリを操作する。アプリが停止中の場合、最初のコマンドで起動する。
+
+## SSH の初期設定
+
+この bridge は、devcontainer のホスト通知でも使用している `mac-host` SSH 接続を再利用する。
+先に [devcontainer の通知設定](devcontainer.md#devcontainer-からホストへの通知設定macos-のみ) に従い、
+専用鍵の作成、`authorized_keys` への登録、macOS のリモートログイン有効化を行う。
+
+devcontainer をリビルドまたは再起動すると `post-start.sh` が `mac-host` を設定し、
+`~/.config/devcontainer/scripts` が `PATH` の先頭にあるためラッパーを `obsidian` として利用できる。
+
+```sh
+# コンテナ内で SSH と CLI を順番に確認
+ssh -F ~/.config/ssh/config mac-host 'test -x /usr/local/bin/obsidian && echo OK'
+obsidian version
+```
+
+## バージョン管理
+
+コンテナには Obsidian 本体や Headless CLI を重複インストールしない。実際に動作する CLI はホストの
+Obsidian.app に同梱されているため、そのバージョンはホスト側の `brew-cask:obsidian` 宣言で管理する。
+bridge 自体はこの dotfiles のスクリプトとしてバージョン管理される。
+
+参考: [Obsidian CLI 公式ドキュメント](https://obsidian.md/help/cli)

--- a/dot_config/devcontainer/scripts/executable_obsidian
+++ b/dot_config/devcontainer/scripts/executable_obsidian
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# devcontainer から macOS ホストの Obsidian CLI を実行する SSH bridge。
+set -euo pipefail
+
+ssh_config="${HOME}/.config/ssh/config"
+
+if [[ ! -f "${ssh_config}" ]]; then
+	printf 'obsidian: SSH config not found: %s (restart the devcontainer)\n' "${ssh_config}" >&2
+	exit 1
+fi
+
+# 引数を remote shell が再解釈しても内容が変わらないよう、POSIX shell の single-quote
+# 形式へ変換する。改行を含む引数も保持する。
+quote_arg() {
+	printf "'%s'" "${1//\'/\'\\\'\'}"
+}
+
+remote_command="exec /usr/local/bin/obsidian"
+for arg in "$@"; do
+	remote_command+=" $(quote_arg "${arg}")"
+done
+
+ssh_opts=(-F "${ssh_config}" -o BatchMode=yes -o ConnectTimeout=5)
+if [[ -t 0 && -t 1 ]]; then
+	# 引数なしで起動する Obsidian CLI の TUI を利用できるよう PTY を割り当てる。
+	ssh_opts+=(-t)
+else
+	ssh_opts+=(-T)
+fi
+
+exec ssh "${ssh_opts[@]}" mac-host "${remote_command}"


### PR DESCRIPTION
### Motivation
- devcontainer に Headless Sync を入れるのではなく、macOS ホストで動作する Obsidian デスクトップアプリを公式 `obsidian` CLI でコンテナから操作できるようにするため。

### Description
- `~/.config/devcontainer/scripts/obsidian` として配布される SSH bridge を追加した。
- bridge は既存の `mac-host` SSH 設定を使い、ホストの `/usr/local/bin/obsidian` に引数を安全に転送し、stdout/stderr/終了ステータスを返す。
- 対話時には PTY を割り当てるため、引数なしの Obsidian CLI TUI にも対応する。
- ホスト側での mise/cask 管理、CLI 登録、SSH 初期設定、コンテナ内からの確認方法を文書化した。

### Testing
- `bash -n dot_config/devcontainer/scripts/executable_obsidian`
- `shellcheck dot_config/devcontainer/scripts/executable_obsidian`
- mock SSH による空白・single quote を含む引数の転送確認
- `npx --yes oxfmt@0.59.0 --check '**/*.md'`
- Python `tomllib` による macOS mise 設定と `brew-cask:obsidian` 宣言の確認
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable devcontainers to run the macOS host’s Obsidian desktop app via the official `obsidian` CLI through an SSH bridge. This removes the need to install Obsidian or headless sync in the container while keeping CLI and TUI behavior intact.

- **New Features**
  - Added SSH bridge wrapper installed as `~/.config/devcontainer/scripts/obsidian` to call host `/usr/local/bin/obsidian`.
  - Reuses `mac-host` SSH config, safely forwards args, and preserves stdout/stderr/exit code.
  - Allocates a PTY when interactive so the `obsidian` TUI works; added `docs/obsidian.md` and a README link.

- **Migration**
  - On macOS, manage Obsidian via `mise` with `brew-cask:obsidian` (v1.12.7+), then register the CLI or symlink to `/usr/local/bin/obsidian`.
  - Ensure `mac-host` SSH is set up (keys, authorized_keys, Remote Login on).
  - Rebuild/restart the devcontainer, then run `obsidian version` from the container to verify.

<sup>Written for commit 8e36d4b562b65ed202efde8f1a74f29337b3e659. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

