### PR TITLE
Install diagram-design and document external skills

### DIFF
--- a/docs/skill.md
+++ b/docs/skill.md
@@ -140,7 +140,16 @@ docs/architecture.html の図を SVG と PNG に export してください。
 ```
 
 SVG は standalone file として生成されます。PNG export には Python 版 Playwright と Chromium が必要です。
-diagram 生成時は、要素を詰め込みすぎず、複雑な場合は overview と detail に分割してください。
+未導入の場合は、export を依頼する前に次のコマンドを実行します。
+
+```bash
+pip install playwright
+playwright install chromium
+```
+
+SVG は Google Fonts を外部参照するため、font を取得しないoffline viewerなどでは代替fontで表示される可能性が
+あります。pixel-perfectな持ち運びが必要な場合はPNGを使用してください。diagram生成時は、要素を詰め込みすぎず、
+複雑な場合はoverviewとdetailに分割してください。
 
 ## `find-skills`
 

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -250,9 +250,9 @@ pip install playwright
 playwright install chromium
 ```
 
-SVG は Google Fonts を外部参照するため、font を取得しないoffline viewerなどでは代替fontで表示される可能性が
-あります。pixel-perfectな持ち運びが必要な場合はPNGを使用してください。diagram生成時は、要素を詰め込みすぎず、
-複雑な場合はoverviewとdetailに分割してください。
+SVG は Google Fonts を外部参照するため、font を取得しない offline viewer などでは代替 font で表示される可能性が
+あります。pixel-perfect な持ち運びが必要な場合は PNG を使用してください。diagram 生成時は、要素を詰め込みすぎず、
+複雑な場合は overview と detail に分割してください。
 
 ## `find-skills`
 

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -2,6 +2,10 @@
 
 このページでは、`dot_apm/apm.yml` で導入している次の skill の使い方を説明します。
 
+- `crit` / `crit-cli`
+- `terminal-browser`
+- Tsumikiの14 skill
+- `ctx-agent-history-search`
 - `resolving-merge-conflicts`
 - `grill-me`（内部で `grilling` を使用）
 - `diagram-design`
@@ -22,6 +26,105 @@ mise run apm:install
 
 依存先は再現性のため `dot_apm/apm.yml` で commit SHA に pin しています。更新時は upstream の内容を確認して
 `ref` を変更し、もう一度 `chezmoi apply` と `mise run apm:install` を実行します。
+
+## `crit` / `crit-cli`
+
+### 用途
+
+`crit`はcode diff、plan、ローカルHTML、実行中のWeb applicationをbrowser UIで確認し、行や要素へcommentを付けて
+エージェントへ戻すreview skillです。`crit-cli`はcommentの作成・返信、reviewの共有、GitHub PRとの同期などを
+エージェントがCLIから操作するための補助skillであり、通常は直接起動しません。
+
+### 使い方
+
+`crit`はユーザーが明示的に起動します。Claude Codeでは`/crit`、Codexでは`$crit`を使い、必要に応じてreview対象を
+指定します。
+
+```text
+/crit docs/plan.md
+```
+
+```text
+$crit を使って、現在のgit diffをreviewできるようにしてください。
+```
+
+devcontainerでは`crit`を起動した後、表示されたhost側URLをbrowserで開きます。commentを送信するとエージェントが
+修正し、再reviewできます。CLIの構成やhost portの確認方法は[`docs/crit.md`](crit.md)を参照してください。
+
+## `terminal-browser`
+
+### 用途
+
+terminal pane内に実browserを表示し、エージェントが同じtabに対してsnapshot、click、入力、JavaScript評価を行うskillです。
+Web applicationの動作確認、生成したHTMLの可視化、browser上でしか確認できない状態の調査に使用します。
+
+### 使い方
+
+browserで確認したいURLと操作内容を自然言語で伝えます。明示的に指定する場合は、Claude Codeでは
+`/terminal-browser`、Codexでは`$terminal-browser`を使用します。
+
+```text
+$terminal-browser を使って http://localhost:3000 を開き、login formを操作してerrorがないか確認してください。
+```
+
+skillは必要に応じてterminalを分割し、`terminal-browser action`で開いているtabを操作します。認証情報や個人情報を
+入力させる場合は、実行する操作と送信先を事前に確認してください。
+
+## Tsumiki skills
+
+Tsumikiは、project初期化、context生成、plan作成、TDD実装、検証、debug、Web test、security checkをつなぐ開発workflowです。
+依頼内容に応じて自動選択されますが、Claude Codeでは`/<skill-name>`、Codexでは`$<skill-name>`で明示できます。
+
+| skill                | 用途                                                                                         |
+| -------------------- | -------------------------------------------------------------------------------------------- |
+| `dev-context`        | projectの技術stack、test framework、規約、architectureを分析し、context fileを生成・更新する |
+| `dev-debug`          | test失敗、build・compile error、環境問題を分類し、原因を絞って修正する                       |
+| `dev-impl`           | plan内のtaskまたは直接指定した小規模変更を、TDDをguardrailとして実装する                     |
+| `dev-init`           | 対話で新規projectの技術stackを決め、承認後にscaffoldとcontextを生成する                      |
+| `dev-navigate`       | 目的を聞き取り、使用するTsumiki skillと実行順序を案内する                                    |
+| `dev-plan`           | 要件をinterface-firstの設計とtest可能なtaskへ分解し、`docs/dev/plans/`へ保存する             |
+| `dev-run`            | plan内のtask範囲を`dev-impl`、`dev-verify`、`dev-debug`のflowで連続実行する                  |
+| `dev-screen-spec`    | source codeまたはplanから画面仕様を生成し、既存仕様を差分更新する                            |
+| `dev-verify`         | planの完了状態とtest・build・lintの整合性を検証し、reportを出力する                          |
+| `dev-webtest-plan`   | dev planや画面仕様からPlaywright用のWeb test planを生成・更新する                            |
+| `dev-webtest`        | Playwrightで画面動作、visual、accessibility、responsive、formをtestする                      |
+| `ipa-security-check` | IPAの公開資料に基づいてsource codeを静的検査し、出典付きで脆弱性候補を報告する               |
+| `ipa-security-guide` | security診断reportを読み、優先順位付きの`dev-debug`依頼リストへ変換する                      |
+| `kairo-implement`    | 分割済みtaskを指定順に実装し、TDD commandを使って完了まで検証する                            |
+
+最初にどのskillを使うべきか分からない場合は、次のように`dev-navigate`へ相談します。
+
+```text
+/dev-navigate
+既存Web applicationへ決済機能を追加したいです。どの順番で進めるべきですか。
+```
+
+```text
+$dev-plan checkout "決済providerを追加し、失敗時に安全にretryできるようにする"
+```
+
+既存projectで一連のworkflowを始める場合は、通常`dev-context` → `dev-plan` → `dev-impl`または`dev-run` →
+`dev-verify`の順で使用します。Web UIを含む場合は`dev-webtest-plan`と`dev-webtest`、security確認が必要な場合は
+`ipa-security-check`と`ipa-security-guide`を組み合わせます。
+
+## `ctx-agent-history-search`
+
+### 用途
+
+ローカルに保存された過去のcoding-agent sessionを`ctx` CLIで検索し、以前の判断、試行、失敗理由、関連する会話を
+現在の作業前に確認するskillです。同じrepositoryで過去の経緯が役立つ可能性があるときに自動的に使用されます。
+
+### 使い方
+
+初回だけ`ctx setup`でindexを作成します。明示的に使う場合は、Claude Codeでは`/ctx-agent-history-search`、Codexでは
+`$ctx-agent-history-search`を指定します。
+
+```text
+$ctx-agent-history-search を使って、以前database migrationに失敗したsessionとその原因を調べてください。
+```
+
+手動検索では`ctx search "query"`、詳細表示では`ctx show session <session-id>`などを使用します。setup、主要command、
+local historyに含まれる秘密情報の注意点は[`docs/ctx.md`](ctx.md)を参照してください。
 
 ## `resolving-merge-conflicts`
 

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -5,6 +5,7 @@
 - `resolving-merge-conflicts`
 - `grill-me`（内部で `grilling` を使用）
 - `diagram-design`
+- `find-skills`
 
 ## インストール
 
@@ -140,3 +141,39 @@ docs/architecture.html の図を SVG と PNG に export してください。
 
 SVG は standalone file として生成されます。PNG export には Python 版 Playwright と Chromium が必要です。
 diagram 生成時は、要素を詰め込みすぎず、複雑な場合は overview と detail に分割してください。
+
+## `find-skills`
+
+### 用途
+
+実現したい作業に利用できる既存のagent skillを検索し、候補の品質を確認して提案するskillです。「この作業に使える
+skillはあるか」「エージェントへ特定分野の能力を追加したい」といった依頼で使用します。
+
+検索結果をそのまま勧めるのではなく、install数、配布元の信頼性、GitHub starsなどを確認してから候補を提示します。
+適切なskillが見つからなかった場合は、通常のエージェント機能で作業を続けるか、独自skillを作る方法を提案します。
+
+### 使い方
+
+skillは該当する依頼から自動的に選択されます。明示的に指定する場合は、Claude Codeでは`/find-skills`、Codexでは
+`$find-skills`を使用し、探したい分野と具体的な作業を伝えます。
+
+```text
+/find-skills
+Playwrightを使ったE2E testの設計と実装を支援するskillを探してください。
+```
+
+```text
+$find-skills を使って、Pull Requestのreviewに利用できるskillを探してください。
+```
+
+skillは最初に[skills.sh](https://skills.sh/)のleaderboardを確認し、必要に応じてSkills CLIで検索します。
+
+```bash
+npx skills find "react performance"
+npx skills find "pr review"
+npx skills find testing --owner vercel-labs
+```
+
+候補が見つかると、用途、install数、配布元、install command、詳細ページが提示されます。提示されたskillをこの
+dotfilesで継続管理する場合は、提案された`npx skills add`を直接実行するのではなく、upstreamを確認して
+`dot_apm/apm.yml`へcommit SHAまたはrelease tagでpinし、APMでインストールしてください。

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -5,6 +5,7 @@
 - `crit` / `crit-cli`
 - `terminal-browser`
 - Tsumikiの14 skill
+- Ponytailの6 skill
 - `ctx-agent-history-search`
 - `resolving-merge-conflicts`
 - `grill-me`（内部で `grilling` を使用）
@@ -106,6 +107,45 @@ $dev-plan checkout "決済providerを追加し、失敗時に安全にretryで�
 既存projectで一連のworkflowを始める場合は、通常`dev-context` → `dev-plan` → `dev-impl`または`dev-run` →
 `dev-verify`の順で使用します。Web UIを含む場合は`dev-webtest-plan`と`dev-webtest`、security確認が必要な場合は
 `ipa-security-check`と`ipa-security-guide`を組み合わせます。
+
+## Ponytail skills
+
+Ponytailは、YAGNI、standard library、native platform機能、既存dependencyの順に検討し、要件を満たす最小の実装を
+選ぶcoding workflowです。短いcodeを目的化するのではなく、security、accessibility、trust boundaryのvalidation、
+data lossを防ぐerror handlingは省略しません。
+
+| skill             | 用途                                                                                |
+| ----------------- | ----------------------------------------------------------------------------------- |
+| `ponytail`        | 最小の正しい実装を選ぶmode。`lite`、`full`、`ultra`の3段階を切り替えられる          |
+| `ponytail-review` | 現在のdiffから過剰なabstraction、不要なdependency、再実装されたstdlibなどを探す     |
+| `ponytail-audit`  | repository全体を対象に、削除・単純化できる箇所を優先順位付きで報告する              |
+| `ponytail-debt`   | source内の`ponytail:` commentを収集し、意図的に先送りした制約と改善条件を一覧化する |
+| `ponytail-gain`   | 公開benchmarkに基づくcode量、cost、処理時間への影響をscoreboardで表示する           |
+| `ponytail-help`   | mode、skill、command、無効化方法をquick referenceとして表示する                     |
+
+### 使い方
+
+通常modeは`full`です。Claude Codeでは`/ponytail`、Codexでは`$ponytail`を使い、必要に応じてlevelを指定します。
+
+```text
+/ponytail lite
+このAPI clientへretryを追加してください。
+```
+
+```text
+$ponytail ultra を使って、この変更を実現する最小のdiffを作ってください。
+```
+
+過剰実装だけをreviewするときは`ponytail-review`、repository全体を調べるときは`ponytail-audit`を使用します。これらは
+correctness、security、performanceのreviewを置き換えないため、必要に応じて通常のcode reviewと併用してください。
+
+```text
+$ponytail-review を使って、現在のdiffから削除できるabstractionを探してください。
+```
+
+Ponytailを止めるときは「stop ponytail」または「normal mode」と伝えます。default levelを変える場合は
+`PONYTAIL_DEFAULT_MODE`へ`lite`、`full`、`ultra`、`off`のいずれかを設定します。pluginのalways-on activationには
+Node.jsで動くlifecycle hookを使用するため、非対話shellの`PATH`から`node`を実行できる必要があります。
 
 ## `ctx-agent-history-search`
 

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -108,6 +108,168 @@ $dev-plan checkout "決済providerを追加し、失敗時に安全にretryで�
 `dev-verify`の順で使用します。Web UIを含む場合は`dev-webtest-plan`と`dev-webtest`、security確認が必要な場合は
 `ipa-security-check`と`ipa-security-guide`を組み合わせます。
 
+## tsumiki 入門ガイド
+
+### 1. tsumikiとは何か
+
+tsumikiは「**要件定義 → 設計 → タスク分割 → 実装（TDD）**」という開発プロセスを、Claude Codeのスラッシュコマンド／スキルとして一気通貫でサポートするフレームワークです。
+
+大きく分けて以下のコマンド群があります。
+
+| カテゴリ                     | 何をするか                                              | 本プロジェクトで使うか               |
+| ---------------------------- | ------------------------------------------------------- | ------------------------------------ |
+| **Kairo**                    | 要件定義〜実装までの包括的フロー                        | ◎ メインで使用                       |
+| **TDD**                      | Red/Green/Refactorの個別実行（Kairoの内部でも使われる） | △ 必要に応じて個別実行               |
+| **Dev Skills**               | コンテキスト分析・計画・実装・検証の統合ワークフロー    | △ 代替案として利用可                 |
+| **DCS**                      | 既存コードの分析・調査・PRD作成支援                     | △ 途中の調査で利用可                 |
+| **ユーティリティ**           | ヘルプ・自動デバッグ・小規模修正など                    | ○ 困ったときに利用                   |
+| **リバースエンジニアリング** | 既存コードから設計書・要件定義書を逆生成                | – 今回はゼロからの開発なので基本不要 |
+
+ポイントは、**各ステップの成果物がすべて `docs/` 配下にMarkdown等のドキュメントとして残る**ことです。これは今回の課題が必須としている「Design Doc」や「判断理由の記録」とも相性が良い仕組みです。
+
+---
+
+### 2. 全体のワークフロー（Kairo）
+
+tsumikiのメインフローは次の5ステップです。
+
+```mermaid
+flowchart TD
+    A[要件概要を伝える] --> B["/tsumiki:kairo-requirements"]
+    B --> C{要件を確認}
+    C -->|修正必要| B
+    C -->|OK| D["/tsumiki:kairo-design"]
+    D --> E{設計を確認}
+    E -->|修正必要| D
+    E -->|OK| F["/tsumiki:kairo-tasks"]
+    F --> G{タスクを確認}
+    G -->|OK| H["/tsumiki:kairo-implement もしくは kairo-loop"]
+    H --> I{全タスク完了?}
+    I -->|No| H
+    I -->|Yes| J[完了]
+```
+
+**重要な考え方**: 各ステップの後には必ず人間（自分）が生成物をレビューし、必要なら修正を指示してから次のステップに進みます。生成AIに丸投げするのではなく、「AIの提案を検証・レビューする過程」自体が今回の課題で評価されるポイントでもあります。
+
+---
+
+### 3. 各コマンドの詳細
+
+#### 3-1. `/tsumiki:init-tech-stack` — 技術スタックの決定
+
+プロジェクトで使うフレームワーク・ライブラリを対話的に決めます。
+
+- 生成物: `docs/tech-stack.md`
+- 今回は非機能要件で「フロントエンド: TypeScript + React」「バックエンド: Go」と指定されているため、その制約を踏まえた選定を行うことになります（React内でのラッパーフレームワークやUIライブラリ、Goでのフレームワーク・APIスキーマ形式など、指定がない部分をここで決定していきます）。
+
+#### 3-2. `/tsumiki:kairo-requirements` — 要件定義
+
+要件の概要を渡すと、EARS記法（Easy Approach to Requirements Syntax）で詳細な要件定義書を作ってくれます。
+
+```
+/tsumiki:kairo-requirements 要件概要
+```
+
+- 生成物: `docs/spec/{要件名}-requirements.md`
+- 含まれる内容: ユーザーストーリー、EARS記法の詳細要件、エッジケース、受け入れ基準
+- 課題側の「Design Doc に要件の整理（自分で補った要件を含む）を書く」という要求と直結する部分です。README.mdの機能要件（ツイート・フォロー・タイムライン）や非機能要件をここでインプットします。
+
+#### 3-3. `/tsumiki:kairo-design` — 設計
+
+要件を承認した後に実行します（省略しても直前の要件定義を引き継いで実行可能）。
+
+- 生成物: `docs/design/{要件名}/` 配下
+  - アーキテクチャ設計書
+  - データフロー図（Mermaid）
+  - TypeScriptインターフェース定義
+  - データベーススキーマ
+  - APIエンドポイント仕様
+- **注意点**: 課題が求める「Design Doc」には「検討した選択肢とトレードオフ」「最終的に選んだ方針とその理由」という比較検討のセクションが必須です。`kairo-design` はそのまま「決定した設計」を出力する傾向があるため、この比較検討部分は生成後に自分で加筆するか、設計を依頼する際のプロンプトで「複数の選択肢とトレードオフも明記してほしい」と明示的に指示するのがおすすめです。
+
+#### 3-4. `/tsumiki:kairo-tasks` — タスク分割
+
+設計を確認した後に実行します。
+
+- 生成物: `docs/tasks/{要件名}/overview.md`、`docs/tasks/{要件名}/TASK-XXXX.md`
+- 依存関係を考慮した実装順序、各タスクのテスト要件・UI/UX要件まで含めて分割してくれます。
+- `/tsumiki:kairo-task-verify`（タスク内容の確認用コマンド）を実行してから実装に進むと安全です。
+
+#### 3-5. 実装コマンド
+
+タスクができたら実装に入ります。2つのやり方があります。
+
+```bash
+# 全タスクを順番に実装
+/tsumiki:kairo-implement
+
+# 特定タスクだけ実装（タスクファイル名 TASK番号 を指定）
+/tsumiki:kairo-implement タスクファイル名 TASK番号
+
+# タスク範囲を指定して自動連続実装（長時間実行・compact対応）
+/tsumiki:kairo-loop
+```
+
+内部的には各タスクごとに以下のTDDサイクルが自動で回ります。
+
+1. `tdd-requirements`（TDD要件定義）
+2. `tdd-testcases`（テストケース作成）
+3. `tdd-red`（失敗するテストを書く）
+4. `tdd-green`（テストを通す最小実装）
+5. `tdd-refactor`（リファクタリング）
+6. `tdd-verify-complete`（完了確認）
+
+このサイクルを個別に手動で回したい場合は `/tsumiki:tdd-requirements` 〜 `/tsumiki:tdd-verify-complete` を1つずつ呼び出すこともできます。
+
+---
+
+### 4. 生成物が置かれるディレクトリ構成
+
+```
+./
+├── docs/
+│   ├── tech-stack.md        # 技術スタック選定
+│   ├── spec/{要件名}/        # 要件定義書（requirements.md 等）
+│   ├── design/{要件名}/      # 設計書（architecture.md, api-endpoints.md, database-schema.sql 等）
+│   ├── tasks/{要件名}/       # タスク一覧（overview.md, TASK-XXXX.md）
+│   └── implements/{要件名}/{タスクID}/  # 実装に関する記録
+├── frontend/                # フロントエンド（TypeScript + React）
+├── backend/                 # バックエンド（Go）
+└── database/                # DB関連
+```
+
+プロジェクト固有のルールを追加したい場合は `docs/rule/{種類1}/{種類2}/*.md` にMarkdownを置くと、対応するコマンド実行時に自動で読み込まれます（例: `docs/rule/kairo/requirements/` は `kairo-requirements` 実行時のみ読み込まれる）。
+
+---
+
+### 5. 困ったときは
+
+```bash
+# コマンド一覧・使い方を表示
+/tsumiki:help
+
+# 特定コマンドの詳細ヘルプ
+/tsumiki:help kairo-requirements
+
+# 「〜が分からない」で検索
+/tsumiki:help テストが失敗して原因がわからない
+```
+
+その他、テストやビルドで詰まった場合は `/tsumiki:auto-debug`（テストエラー自動デバッグ）、`/tsumiki:build-fix`（ビルドエラー修正）なども用意されています。
+
+---
+
+### 6. 本プロジェクト（ENG-1100課題）での想定進行イメージ
+
+`ENG-1100/README.md` の要件（ツイート・フォロー・タイムライン、TypeScript+React／Go、Design Doc必須）を踏まえると、次の順序で進めるのが自然です。
+
+1. `/tsumiki:init-tech-stack` — React側のフレームワークやUIライブラリ、Go側のWebフレームワークやAPIスキーマ形式（OpenAPI等）を決定
+2. `/tsumiki:kairo-requirements` — 機能要件・非機能要件・自分で補った要件をEARS記法で整理
+3. `/tsumiki:kairo-design` — アーキテクチャ、データフロー、API仕様、DBスキーマを設計。**比較検討したトレードオフと決定理由は別途加筆**して課題の「Design Doc」要件を満たす
+4. `/tsumiki:kairo-tasks` → `/tsumiki:kairo-task-verify` — 実装タスクへ分割・確認
+5. `/tsumiki:kairo-implement` または `/tsumiki:kairo-loop` — TDDサイクルで実装を進行
+
+各ステップの成果物は必ず内容を読んでレビューし、必要な修正指示を出してから次に進むことをおすすめします（AIに任せた部分と自分で判断した部分を分けて記録する、という課題の評価観点にも合致します）。
+
 ## Ponytail skills
 
 Ponytailは、YAGNI、standard library、native platform機能、既存dependencyの順に検討し、要件を満たす最小の実装を

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -1,0 +1,142 @@
+# 外部 skill の使い方
+
+このページでは、`dot_apm/apm.yml` で導入している次の skill の使い方を説明します。
+
+- `resolving-merge-conflicts`
+- `grill-me`（内部で `grilling` を使用）
+- `diagram-design`
+
+## インストール
+
+設定を反映してから APM を実行します。
+
+```bash
+chezmoi apply
+mise run apm:install
+```
+
+`mise run apm:install` は user scope で skill をインストールします。Claude Code では
+`~/.claude/skills/`、Codex・GitHub Copilot・Cursor では共通の `~/.agents/skills/` に配置されます。
+インストール後は、エージェントを新しいセッションで起動してください。
+
+依存先は再現性のため `dot_apm/apm.yml` で commit SHA に pin しています。更新時は upstream の内容を確認して
+`ref` を変更し、もう一度 `chezmoi apply` と `mise run apm:install` を実行します。
+
+## `resolving-merge-conflicts`
+
+### 用途
+
+進行中の `git merge` または `git rebase` で発生した conflict を、両方の変更意図を調べながら解消する skill です。
+単に片側を採用するのではなく、commit・PR・issue などの一次情報を確認し、可能な限り双方の意図を保ちます。
+
+### 使い方
+
+conflict が発生した状態で、エージェントに自然言語で依頼します。明示的に指定する場合は、Claude Code では
+`/resolving-merge-conflicts`、Codex では `$resolving-merge-conflicts` を使用します。
+
+```text
+/resolving-merge-conflicts
+現在の rebase conflict を、各 commit の意図を確認して解消してください。
+```
+
+```text
+$resolving-merge-conflicts を使って、この merge conflict を解消してください。
+```
+
+skill は次の順に作業します。
+
+1. merge/rebase の状態、履歴、conflict 対象を確認する。
+2. 各変更の commit・PR・issue を調べ、意図を特定する。
+3. conflict を hunk 単位で解消する。
+4. リポジトリの typecheck・test・format などを実行する。
+5. ファイルを stage し、merge commit または `git rebase --continue` まで完了する。
+
+> [!IMPORTANT]
+> この skill は進行中の merge/rebase を `--abort` せず、最後まで完了させる方針です。中断したい場合は、実行前に
+> その旨を明示してください。また、作業ツリーに退避していない変更がないか事前に確認してください。
+
+## `grill-me`
+
+### 用途
+
+計画、設計、意思決定を実行に移す前に、未決定事項や暗黙の前提を質問によって洗い出す skill です。質問を
+decision tree として扱い、前提が確定した時点で回答可能になる質問を round ごとに提示します。
+
+`grill-me` はユーザーが明示的に起動する skill です。質問処理の本体である `grilling` も APM で一緒に
+インストールされます。
+
+### 使い方
+
+Claude Code では `/grill-me`、Codex では `$grill-me` に続けて検討対象を渡します。
+
+```text
+/grill-me
+社内 API を外部パートナーへ公開する計画について、実装前に不足している判断を洗い出してください。
+```
+
+```text
+$grill-me を使って、新しい CLI の配布方法を固めたいです。
+```
+
+各 round では複数の質問と推奨回答が提示されます。質問へ回答すると、その回答に依存する次の質問が提示されます。
+すべての branch が解決すると interview は終了しますが、合意内容を実装へ移すのはユーザーが明示的に確認した後です。
+
+効果的に使うため、最初の依頼には次を含めます。
+
+- 達成したい結果と対象ユーザー
+- 既に決まっていること
+- 変更できない制約（期限、互換性、予算など）
+- 特に不安な判断
+
+## `diagram-design`
+
+### 用途
+
+architecture、flowchart、sequence、ER、timeline、swimlane、quadrant、Gantt などの図を、inline SVG/CSS を含む
+self-contained HTML として生成する skill です。文章や表より図の方が理解しやすい情報に使用します。
+
+### 初回セットアップ
+
+最初の図を作るとき、skill は同梱の `references/style-guide.md` がデフォルトのままか確認します。デフォルトの場合は、
+次のいずれかを選択します。
+
+1. Web サイトの URL から色と font を抽出する。
+2. インストール済み skill の design token を参照する。
+3. ローカルの design system directory から抽出する。
+4. token を手動で渡す。
+5. デフォルトテーマをそのまま使う。
+
+APM の再インストールや更新では配布先が再生成される可能性があります。ブランド設定を継続的に管理したい場合は、
+upstream skill を直接編集せず、生成時に URL・design system・token を指定してください。
+
+### 使い方
+
+作りたい図、含める要素、要素間の関係、出力先を自然言語で依頼します。skill は依頼内容から図の種類を選択します。
+明示的に指定する場合は、Claude Code では `/diagram-design`、Codex では `$diagram-design` を使用します。
+
+```text
+/diagram-design
+Web、API、PostgreSQL、Redis、外部決済サービスを含む architecture diagram を作り、
+docs/architecture.html に保存してください。主要な request と data flow も表示してください。
+```
+
+```text
+$diagram-design を使って、OAuth authorization code flow の sequence diagram を
+docs/oauth-sequence.html に作成してください。
+```
+
+出力は build step や外部画像を必要としない HTML なので、browser で直接確認できます。
+
+```bash
+open docs/architecture.html # macOS
+xdg-open docs/architecture.html # Linux
+```
+
+PNG または SVG が必要な場合は、生成後に自然言語で対象ファイルと形式を指定します。
+
+```text
+docs/architecture.html の図を SVG と PNG に export してください。
+```
+
+SVG は standalone file として生成されます。PNG export には Python 版 Playwright と Chromium が必要です。
+diagram 生成時は、要素を詰め込みすぎず、複雑な場合は overview と detail に分割してください。

--- a/dot_apm/apm.lock.yaml
+++ b/dot_apm/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-08-08T11:15:32.205710+00:00'
+generated_at: '2026-08-08T11:39:18.985161+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: cathrynlavery/diagram-design
@@ -1239,6 +1239,127 @@ dependencies:
     .agents/skills/ctx-agent-history-search/SKILL.md: sha256:d76cd55f506f6d8605f2fed933a16e4ab995b3a4ab8e6d96bfd84d469872b3d6
     .claude/skills/ctx-agent-history-search/SKILL.md: sha256:d76cd55f506f6d8605f2fed933a16e4ab995b3a4ab8e6d96bfd84d469872b3d6
   content_hash: sha256:b9ee8ae28832c0058d21c16f1dc1cad4e72ad70597359033d18b6b7e556c40ce
+- repo_url: dietrichgebert/ponytail
+  name: ponytail
+  host: github.com
+  resolved_commit: 0a4dd63ad4541f4f655c4108a295916f3c1d8fda
+  resolved_ref: v4.9.0
+  version: 4.9.0
+  package_type: marketplace_plugin
+  deployed_files:
+  - .agents/skills/ponytail
+  - .agents/skills/ponytail-audit
+  - .agents/skills/ponytail-audit/SKILL.md
+  - .agents/skills/ponytail-debt
+  - .agents/skills/ponytail-debt/SKILL.md
+  - .agents/skills/ponytail-gain
+  - .agents/skills/ponytail-gain/SKILL.md
+  - .agents/skills/ponytail-help
+  - .agents/skills/ponytail-help/SKILL.md
+  - .agents/skills/ponytail-review
+  - .agents/skills/ponytail-review/SKILL.md
+  - .agents/skills/ponytail/SKILL.md
+  - .claude/hooks/ponytail/hooks/package.json
+  - .claude/hooks/ponytail/hooks/ponytail-activate.js
+  - .claude/hooks/ponytail/hooks/ponytail-config.js
+  - .claude/hooks/ponytail/hooks/ponytail-instructions.js
+  - .claude/hooks/ponytail/hooks/ponytail-mode-tracker.js
+  - .claude/hooks/ponytail/hooks/ponytail-runtime.js
+  - .claude/hooks/ponytail/hooks/ponytail-statusline.ps1
+  - .claude/hooks/ponytail/hooks/ponytail-statusline.sh
+  - .claude/hooks/ponytail/hooks/ponytail-subagent.js
+  - .claude/skills/ponytail
+  - .claude/skills/ponytail-audit
+  - .claude/skills/ponytail-audit/SKILL.md
+  - .claude/skills/ponytail-debt
+  - .claude/skills/ponytail-debt/SKILL.md
+  - .claude/skills/ponytail-gain
+  - .claude/skills/ponytail-gain/SKILL.md
+  - .claude/skills/ponytail-help
+  - .claude/skills/ponytail-help/SKILL.md
+  - .claude/skills/ponytail-review
+  - .claude/skills/ponytail-review/SKILL.md
+  - .claude/skills/ponytail/SKILL.md
+  - .codex/hooks/ponytail/hooks/package.json
+  - .codex/hooks/ponytail/hooks/ponytail-activate.js
+  - .codex/hooks/ponytail/hooks/ponytail-config.js
+  - .codex/hooks/ponytail/hooks/ponytail-instructions.js
+  - .codex/hooks/ponytail/hooks/ponytail-mode-tracker.js
+  - .codex/hooks/ponytail/hooks/ponytail-runtime.js
+  - .codex/hooks/ponytail/hooks/ponytail-statusline.ps1
+  - .codex/hooks/ponytail/hooks/ponytail-statusline.sh
+  - .codex/hooks/ponytail/hooks/ponytail-subagent.js
+  - .copilot/hooks/ponytail-copilot-hooks.json
+  - .copilot/hooks/scripts/ponytail/hooks/package.json
+  - .copilot/hooks/scripts/ponytail/hooks/ponytail-activate.js
+  - .copilot/hooks/scripts/ponytail/hooks/ponytail-config.js
+  - .copilot/hooks/scripts/ponytail/hooks/ponytail-instructions.js
+  - .copilot/hooks/scripts/ponytail/hooks/ponytail-mode-tracker.js
+  - .copilot/hooks/scripts/ponytail/hooks/ponytail-runtime.js
+  - .copilot/hooks/scripts/ponytail/hooks/ponytail-statusline.ps1
+  - .copilot/hooks/scripts/ponytail/hooks/ponytail-statusline.sh
+  - .copilot/hooks/scripts/ponytail/hooks/ponytail-subagent.js
+  - .cursor/hooks/ponytail/hooks/package.json
+  - .cursor/hooks/ponytail/hooks/ponytail-activate.js
+  - .cursor/hooks/ponytail/hooks/ponytail-config.js
+  - .cursor/hooks/ponytail/hooks/ponytail-instructions.js
+  - .cursor/hooks/ponytail/hooks/ponytail-mode-tracker.js
+  - .cursor/hooks/ponytail/hooks/ponytail-runtime.js
+  - .cursor/hooks/ponytail/hooks/ponytail-statusline.ps1
+  - .cursor/hooks/ponytail/hooks/ponytail-statusline.sh
+  - .cursor/hooks/ponytail/hooks/ponytail-subagent.js
+  deployed_file_hashes:
+    .agents/skills/ponytail-audit/SKILL.md: sha256:5560b8e383dbe2ddfddc873a1e2bf2e586e23e0cd7d995537482b2315331f6d1
+    .agents/skills/ponytail-debt/SKILL.md: sha256:c84fba75f0ca12bfe83f9a78ea02fd125c5dd3f1fbb18124105a489937f284e6
+    .agents/skills/ponytail-gain/SKILL.md: sha256:24e01d1c9715cb136ba1c4f1e52a95940c0193558b876828e537736480d6408b
+    .agents/skills/ponytail-help/SKILL.md: sha256:2264d1615117b02b0fd5a69ec84cd2757006471a78e4d6c22eed6d581c1d37a4
+    .agents/skills/ponytail-review/SKILL.md: sha256:40df33b58fc6ef889b93585733feb9566b76e9586efa7f376785c1e995197ac0
+    .agents/skills/ponytail/SKILL.md: sha256:1316a2f3f95741d2300b116fe0c2d81ce4a9568656ed0a62643f54aaf09957f2
+    .claude/hooks/ponytail/hooks/package.json: sha256:8005a3491db7d92f36ac66369861589f9c47123d3a7c71e643fc2c06168cd45a
+    .claude/hooks/ponytail/hooks/ponytail-activate.js: sha256:1c428c4ee9687c2f4321924109ee92e8f8b06fd6600cb6be9ec5b59633cafab1
+    .claude/hooks/ponytail/hooks/ponytail-config.js: sha256:0a8daf96cf9ac703dc4cb7b5065253567e513c951d60b8eb94a0fe727514aeca
+    .claude/hooks/ponytail/hooks/ponytail-instructions.js: sha256:23c050103f28dbe6bad953ae21d98cd06d720a20f33d4716e9de419f947d495e
+    .claude/hooks/ponytail/hooks/ponytail-mode-tracker.js: sha256:5d1a960ff01b73f651ec0242052a8cf1e064cb88147806bf6e13f92798aca251
+    .claude/hooks/ponytail/hooks/ponytail-runtime.js: sha256:80e4a13db4eca13f8cfca5237a46c34220c7c1f9ec841297191c0a46e49ca33e
+    .claude/hooks/ponytail/hooks/ponytail-statusline.ps1: sha256:6138f15bc7651ee7e5ced2a2a2280f5c810d58cad3e9f3252c628f4c923e48c9
+    .claude/hooks/ponytail/hooks/ponytail-statusline.sh: sha256:f1dbfa5997a5d4b5339619709053eff557ab16d71af75eb3041c3d3e3dca42ec
+    .claude/hooks/ponytail/hooks/ponytail-subagent.js: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e
+    .claude/skills/ponytail-audit/SKILL.md: sha256:5560b8e383dbe2ddfddc873a1e2bf2e586e23e0cd7d995537482b2315331f6d1
+    .claude/skills/ponytail-debt/SKILL.md: sha256:c84fba75f0ca12bfe83f9a78ea02fd125c5dd3f1fbb18124105a489937f284e6
+    .claude/skills/ponytail-gain/SKILL.md: sha256:24e01d1c9715cb136ba1c4f1e52a95940c0193558b876828e537736480d6408b
+    .claude/skills/ponytail-help/SKILL.md: sha256:2264d1615117b02b0fd5a69ec84cd2757006471a78e4d6c22eed6d581c1d37a4
+    .claude/skills/ponytail-review/SKILL.md: sha256:40df33b58fc6ef889b93585733feb9566b76e9586efa7f376785c1e995197ac0
+    .claude/skills/ponytail/SKILL.md: sha256:1316a2f3f95741d2300b116fe0c2d81ce4a9568656ed0a62643f54aaf09957f2
+    .codex/hooks/ponytail/hooks/package.json: sha256:8005a3491db7d92f36ac66369861589f9c47123d3a7c71e643fc2c06168cd45a
+    .codex/hooks/ponytail/hooks/ponytail-activate.js: sha256:1c428c4ee9687c2f4321924109ee92e8f8b06fd6600cb6be9ec5b59633cafab1
+    .codex/hooks/ponytail/hooks/ponytail-config.js: sha256:0a8daf96cf9ac703dc4cb7b5065253567e513c951d60b8eb94a0fe727514aeca
+    .codex/hooks/ponytail/hooks/ponytail-instructions.js: sha256:23c050103f28dbe6bad953ae21d98cd06d720a20f33d4716e9de419f947d495e
+    .codex/hooks/ponytail/hooks/ponytail-mode-tracker.js: sha256:5d1a960ff01b73f651ec0242052a8cf1e064cb88147806bf6e13f92798aca251
+    .codex/hooks/ponytail/hooks/ponytail-runtime.js: sha256:80e4a13db4eca13f8cfca5237a46c34220c7c1f9ec841297191c0a46e49ca33e
+    .codex/hooks/ponytail/hooks/ponytail-statusline.ps1: sha256:6138f15bc7651ee7e5ced2a2a2280f5c810d58cad3e9f3252c628f4c923e48c9
+    .codex/hooks/ponytail/hooks/ponytail-statusline.sh: sha256:f1dbfa5997a5d4b5339619709053eff557ab16d71af75eb3041c3d3e3dca42ec
+    .codex/hooks/ponytail/hooks/ponytail-subagent.js: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e
+    .copilot/hooks/ponytail-copilot-hooks.json: sha256:18ee3902e119c2ed993b4be16a09770defcc1cce60707c0dc33d6915d7331e1d
+    .copilot/hooks/scripts/ponytail/hooks/package.json: sha256:8005a3491db7d92f36ac66369861589f9c47123d3a7c71e643fc2c06168cd45a
+    .copilot/hooks/scripts/ponytail/hooks/ponytail-activate.js: sha256:1c428c4ee9687c2f4321924109ee92e8f8b06fd6600cb6be9ec5b59633cafab1
+    .copilot/hooks/scripts/ponytail/hooks/ponytail-config.js: sha256:0a8daf96cf9ac703dc4cb7b5065253567e513c951d60b8eb94a0fe727514aeca
+    .copilot/hooks/scripts/ponytail/hooks/ponytail-instructions.js: sha256:23c050103f28dbe6bad953ae21d98cd06d720a20f33d4716e9de419f947d495e
+    .copilot/hooks/scripts/ponytail/hooks/ponytail-mode-tracker.js: sha256:5d1a960ff01b73f651ec0242052a8cf1e064cb88147806bf6e13f92798aca251
+    .copilot/hooks/scripts/ponytail/hooks/ponytail-runtime.js: sha256:80e4a13db4eca13f8cfca5237a46c34220c7c1f9ec841297191c0a46e49ca33e
+    .copilot/hooks/scripts/ponytail/hooks/ponytail-statusline.ps1: sha256:6138f15bc7651ee7e5ced2a2a2280f5c810d58cad3e9f3252c628f4c923e48c9
+    .copilot/hooks/scripts/ponytail/hooks/ponytail-statusline.sh: sha256:f1dbfa5997a5d4b5339619709053eff557ab16d71af75eb3041c3d3e3dca42ec
+    .copilot/hooks/scripts/ponytail/hooks/ponytail-subagent.js: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e
+    .cursor/hooks/ponytail/hooks/package.json: sha256:8005a3491db7d92f36ac66369861589f9c47123d3a7c71e643fc2c06168cd45a
+    .cursor/hooks/ponytail/hooks/ponytail-activate.js: sha256:1c428c4ee9687c2f4321924109ee92e8f8b06fd6600cb6be9ec5b59633cafab1
+    .cursor/hooks/ponytail/hooks/ponytail-config.js: sha256:0a8daf96cf9ac703dc4cb7b5065253567e513c951d60b8eb94a0fe727514aeca
+    .cursor/hooks/ponytail/hooks/ponytail-instructions.js: sha256:23c050103f28dbe6bad953ae21d98cd06d720a20f33d4716e9de419f947d495e
+    .cursor/hooks/ponytail/hooks/ponytail-mode-tracker.js: sha256:5d1a960ff01b73f651ec0242052a8cf1e064cb88147806bf6e13f92798aca251
+    .cursor/hooks/ponytail/hooks/ponytail-runtime.js: sha256:80e4a13db4eca13f8cfca5237a46c34220c7c1f9ec841297191c0a46e49ca33e
+    .cursor/hooks/ponytail/hooks/ponytail-statusline.ps1: sha256:6138f15bc7651ee7e5ced2a2a2280f5c810d58cad3e9f3252c628f4c923e48c9
+    .cursor/hooks/ponytail/hooks/ponytail-statusline.sh: sha256:f1dbfa5997a5d4b5339619709053eff557ab16d71af75eb3041c3d3e3dca42ec
+    .cursor/hooks/ponytail/hooks/ponytail-subagent.js: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e
+  content_hash: sha256:60e98997d4ac457d49152a04c08ab31b3f91a94d451fb1bba73c3d1301ee630e
+  declared_license: MIT
 - repo_url: mattpocock/skills
   name: resolving-merge-conflicts
   host: github.com
@@ -1661,6 +1782,87 @@ deployments:
   - classmethod/tsumiki
   active_owner: classmethod/tsumiki
   content_hash: sha256:cb40a98d985fdc02524ba40935f0de2cfdd2b1b6b1872921c7fba15cf0a715c2
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/package.json
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:8005a3491db7d92f36ac66369861589f9c47123d3a7c71e643fc2c06168cd45a
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-activate.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:1c428c4ee9687c2f4321924109ee92e8f8b06fd6600cb6be9ec5b59633cafab1
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-config.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:0a8daf96cf9ac703dc4cb7b5065253567e513c951d60b8eb94a0fe727514aeca
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-instructions.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:23c050103f28dbe6bad953ae21d98cd06d720a20f33d4716e9de419f947d495e
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-mode-tracker.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:5d1a960ff01b73f651ec0242052a8cf1e064cb88147806bf6e13f92798aca251
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-runtime.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:80e4a13db4eca13f8cfca5237a46c34220c7c1f9ec841297191c0a46e49ca33e
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-statusline.ps1
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:6138f15bc7651ee7e5ced2a2a2280f5c810d58cad3e9f3252c628f4c923e48c9
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-statusline.sh
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:f1dbfa5997a5d4b5339619709053eff557ab16d71af75eb3041c3d3e3dca42ec
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/ponytail/hooks/ponytail-subagent.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e
 - kind: project-relative
   target: claude
   value: .claude/skills/crit
@@ -4127,6 +4329,114 @@ deployments:
   - classmethod/tsumiki
   active_owner: classmethod/tsumiki
   content_hash: sha256:04c48c9c682045264d6c5e7743dbf49768c8ed3daf66e4a82747e3c8b5787479
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-audit
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-audit/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:5560b8e383dbe2ddfddc873a1e2bf2e586e23e0cd7d995537482b2315331f6d1
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-debt
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-debt/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:c84fba75f0ca12bfe83f9a78ea02fd125c5dd3f1fbb18124105a489937f284e6
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-gain
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-gain/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:24e01d1c9715cb136ba1c4f1e52a95940c0193558b876828e537736480d6408b
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-help
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-help/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:2264d1615117b02b0fd5a69ec84cd2757006471a78e4d6c22eed6d581c1d37a4
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-review
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail-review/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:40df33b58fc6ef889b93585733feb9566b76e9586efa7f376785c1e995197ac0
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ponytail/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:1316a2f3f95741d2300b116fe0c2d81ce4a9568656ed0a62643f54aaf09957f2
 - kind: project-relative
   target: claude
   value: .claude/skills/resolving-merge-conflicts
@@ -6649,6 +6959,114 @@ deployments:
   content_hash: sha256:04c48c9c682045264d6c5e7743dbf49768c8ed3daf66e4a82747e3c8b5787479
 - kind: project-relative
   target: codex
+  value: .agents/skills/ponytail
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ponytail-audit
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ponytail-audit/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:5560b8e383dbe2ddfddc873a1e2bf2e586e23e0cd7d995537482b2315331f6d1
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ponytail-debt
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ponytail-debt/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:c84fba75f0ca12bfe83f9a78ea02fd125c5dd3f1fbb18124105a489937f284e6
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ponytail-gain
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ponytail-gain/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:24e01d1c9715cb136ba1c4f1e52a95940c0193558b876828e537736480d6408b
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ponytail-help
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ponytail-help/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:2264d1615117b02b0fd5a69ec84cd2757006471a78e4d6c22eed6d581c1d37a4
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ponytail-review
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ponytail-review/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:40df33b58fc6ef889b93585733feb9566b76e9586efa7f376785c1e995197ac0
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ponytail/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:1316a2f3f95741d2300b116fe0c2d81ce4a9568656ed0a62643f54aaf09957f2
+- kind: project-relative
+  target: codex
   value: .agents/skills/resolving-merge-conflicts
   runtime: null
   scope: project
@@ -6701,6 +7119,177 @@ deployments:
   - zenbu-labs/terminal-browser/skill
   active_owner: zenbu-labs/terminal-browser/skill
   content_hash: sha256:1ba1350404b762fe869cdcdf8658b0f0d1dd29d1a90a53d734b6bce77c2e1f47
+- kind: project-relative
+  target: codex
+  value: .codex/hooks/ponytail/hooks/package.json
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:8005a3491db7d92f36ac66369861589f9c47123d3a7c71e643fc2c06168cd45a
+- kind: project-relative
+  target: codex
+  value: .codex/hooks/ponytail/hooks/ponytail-activate.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:1c428c4ee9687c2f4321924109ee92e8f8b06fd6600cb6be9ec5b59633cafab1
+- kind: project-relative
+  target: codex
+  value: .codex/hooks/ponytail/hooks/ponytail-config.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:0a8daf96cf9ac703dc4cb7b5065253567e513c951d60b8eb94a0fe727514aeca
+- kind: project-relative
+  target: codex
+  value: .codex/hooks/ponytail/hooks/ponytail-instructions.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:23c050103f28dbe6bad953ae21d98cd06d720a20f33d4716e9de419f947d495e
+- kind: project-relative
+  target: codex
+  value: .codex/hooks/ponytail/hooks/ponytail-mode-tracker.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:5d1a960ff01b73f651ec0242052a8cf1e064cb88147806bf6e13f92798aca251
+- kind: project-relative
+  target: codex
+  value: .codex/hooks/ponytail/hooks/ponytail-runtime.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:80e4a13db4eca13f8cfca5237a46c34220c7c1f9ec841297191c0a46e49ca33e
+- kind: project-relative
+  target: codex
+  value: .codex/hooks/ponytail/hooks/ponytail-statusline.ps1
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:6138f15bc7651ee7e5ced2a2a2280f5c810d58cad3e9f3252c628f4c923e48c9
+- kind: project-relative
+  target: codex
+  value: .codex/hooks/ponytail/hooks/ponytail-statusline.sh
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:f1dbfa5997a5d4b5339619709053eff557ab16d71af75eb3041c3d3e3dca42ec
+- kind: project-relative
+  target: codex
+  value: .codex/hooks/ponytail/hooks/ponytail-subagent.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e
+- kind: project-relative
+  target: copilot
+  value: .copilot/hooks/ponytail-copilot-hooks.json
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:18ee3902e119c2ed993b4be16a09770defcc1cce60707c0dc33d6915d7331e1d
+- kind: project-relative
+  target: copilot
+  value: .copilot/hooks/scripts/ponytail/hooks/package.json
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:8005a3491db7d92f36ac66369861589f9c47123d3a7c71e643fc2c06168cd45a
+- kind: project-relative
+  target: copilot
+  value: .copilot/hooks/scripts/ponytail/hooks/ponytail-activate.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:1c428c4ee9687c2f4321924109ee92e8f8b06fd6600cb6be9ec5b59633cafab1
+- kind: project-relative
+  target: copilot
+  value: .copilot/hooks/scripts/ponytail/hooks/ponytail-config.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:0a8daf96cf9ac703dc4cb7b5065253567e513c951d60b8eb94a0fe727514aeca
+- kind: project-relative
+  target: copilot
+  value: .copilot/hooks/scripts/ponytail/hooks/ponytail-instructions.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:23c050103f28dbe6bad953ae21d98cd06d720a20f33d4716e9de419f947d495e
+- kind: project-relative
+  target: copilot
+  value: .copilot/hooks/scripts/ponytail/hooks/ponytail-mode-tracker.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:5d1a960ff01b73f651ec0242052a8cf1e064cb88147806bf6e13f92798aca251
+- kind: project-relative
+  target: copilot
+  value: .copilot/hooks/scripts/ponytail/hooks/ponytail-runtime.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:80e4a13db4eca13f8cfca5237a46c34220c7c1f9ec841297191c0a46e49ca33e
+- kind: project-relative
+  target: copilot
+  value: .copilot/hooks/scripts/ponytail/hooks/ponytail-statusline.ps1
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:6138f15bc7651ee7e5ced2a2a2280f5c810d58cad3e9f3252c628f4c923e48c9
+- kind: project-relative
+  target: copilot
+  value: .copilot/hooks/scripts/ponytail/hooks/ponytail-statusline.sh
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:f1dbfa5997a5d4b5339619709053eff557ab16d71af75eb3041c3d3e3dca42ec
+- kind: project-relative
+  target: copilot
+  value: .copilot/hooks/scripts/ponytail/hooks/ponytail-subagent.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e
 - kind: project-relative
   target: copilot
   value: .copilot/prompts/auto-debug.prompt.md
@@ -7259,3 +7848,84 @@ deployments:
   - classmethod/tsumiki
   active_owner: classmethod/tsumiki
   content_hash: sha256:cb40a98d985fdc02524ba40935f0de2cfdd2b1b6b1872921c7fba15cf0a715c2
+- kind: project-relative
+  target: cursor
+  value: .cursor/hooks/ponytail/hooks/package.json
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:8005a3491db7d92f36ac66369861589f9c47123d3a7c71e643fc2c06168cd45a
+- kind: project-relative
+  target: cursor
+  value: .cursor/hooks/ponytail/hooks/ponytail-activate.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:1c428c4ee9687c2f4321924109ee92e8f8b06fd6600cb6be9ec5b59633cafab1
+- kind: project-relative
+  target: cursor
+  value: .cursor/hooks/ponytail/hooks/ponytail-config.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:0a8daf96cf9ac703dc4cb7b5065253567e513c951d60b8eb94a0fe727514aeca
+- kind: project-relative
+  target: cursor
+  value: .cursor/hooks/ponytail/hooks/ponytail-instructions.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:23c050103f28dbe6bad953ae21d98cd06d720a20f33d4716e9de419f947d495e
+- kind: project-relative
+  target: cursor
+  value: .cursor/hooks/ponytail/hooks/ponytail-mode-tracker.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:5d1a960ff01b73f651ec0242052a8cf1e064cb88147806bf6e13f92798aca251
+- kind: project-relative
+  target: cursor
+  value: .cursor/hooks/ponytail/hooks/ponytail-runtime.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:80e4a13db4eca13f8cfca5237a46c34220c7c1f9ec841297191c0a46e49ca33e
+- kind: project-relative
+  target: cursor
+  value: .cursor/hooks/ponytail/hooks/ponytail-statusline.ps1
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:6138f15bc7651ee7e5ced2a2a2280f5c810d58cad3e9f3252c628f4c923e48c9
+- kind: project-relative
+  target: cursor
+  value: .cursor/hooks/ponytail/hooks/ponytail-statusline.sh
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:f1dbfa5997a5d4b5339619709053eff557ab16d71af75eb3041c3d3e3dca42ec
+- kind: project-relative
+  target: cursor
+  value: .cursor/hooks/ponytail/hooks/ponytail-subagent.js
+  runtime: null
+  scope: project
+  owners:
+  - dietrichgebert/ponytail
+  active_owner: dietrichgebert/ponytail
+  content_hash: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e

--- a/dot_apm/apm.lock.yaml
+++ b/dot_apm/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-08-08T08:11:55.852076+00:00'
+generated_at: '2026-08-08T11:15:32.205710+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: cathrynlavery/diagram-design
@@ -1341,6 +1341,24 @@ dependencies:
     .agents/skills/crit-cli/SKILL.md: sha256:3e6bf2be5eb2e441b85329e5d8ab44ccaac50220d5f51ed6a7af7c650d7e272f
     .claude/skills/crit-cli/SKILL.md: sha256:3e6bf2be5eb2e441b85329e5d8ab44ccaac50220d5f51ed6a7af7c650d7e272f
   content_hash: sha256:c62c3b4d93667eb2f8046f5ee7f8a51a3a2c5ac574faad108501e05747bf0f7a
+- repo_url: vercel-labs/skills
+  name: find-skills
+  host: github.com
+  resolved_commit: 941a7bcfeca4bf07913b9fb6f8ed81f20ff5297c
+  resolved_ref: 941a7bcfeca4bf07913b9fb6f8ed81f20ff5297c
+  version: unknown
+  virtual_path: skills/find-skills
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .agents/skills/find-skills
+  - .agents/skills/find-skills/SKILL.md
+  - .claude/skills/find-skills
+  - .claude/skills/find-skills/SKILL.md
+  deployed_file_hashes:
+    .agents/skills/find-skills/SKILL.md: sha256:c00eeea0e13e74fe4a9d84ba0a8542205a1b736d65f13134fe1a6647eb14976f
+    .claude/skills/find-skills/SKILL.md: sha256:c00eeea0e13e74fe4a9d84ba0a8542205a1b736d65f13134fe1a6647eb14976f
+  content_hash: sha256:913b9d37d0d54047dd65222bb8c67b2bf04e3cb87dcad1729068d7a8b2c8c396
 - repo_url: zenbu-labs/terminal-browser
   name: terminal-browser
   host: github.com
@@ -3452,6 +3470,24 @@ deployments:
   - cathrynlavery/diagram-design/skills/diagram-design
   active_owner: cathrynlavery/diagram-design/skills/diagram-design
   content_hash: sha256:f8d5d4f0506160e0502f932140306b12d25adea1d1f6f319fb38c2345b0c6b42
+- kind: project-relative
+  target: claude
+  value: .claude/skills/find-skills
+  runtime: null
+  scope: project
+  owners:
+  - vercel-labs/skills/skills/find-skills
+  active_owner: vercel-labs/skills/skills/find-skills
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/find-skills/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - vercel-labs/skills/skills/find-skills
+  active_owner: vercel-labs/skills/skills/find-skills
+  content_hash: sha256:c00eeea0e13e74fe4a9d84ba0a8542205a1b736d65f13134fe1a6647eb14976f
 - kind: project-relative
   target: claude
   value: .claude/skills/grill-me
@@ -5954,6 +5990,24 @@ deployments:
   - cathrynlavery/diagram-design/skills/diagram-design
   active_owner: cathrynlavery/diagram-design/skills/diagram-design
   content_hash: sha256:f8d5d4f0506160e0502f932140306b12d25adea1d1f6f319fb38c2345b0c6b42
+- kind: project-relative
+  target: codex
+  value: .agents/skills/find-skills
+  runtime: null
+  scope: project
+  owners:
+  - vercel-labs/skills/skills/find-skills
+  active_owner: vercel-labs/skills/skills/find-skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/find-skills/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - vercel-labs/skills/skills/find-skills
+  active_owner: vercel-labs/skills/skills/find-skills
+  content_hash: sha256:c00eeea0e13e74fe4a9d84ba0a8542205a1b736d65f13134fe1a6647eb14976f
 - kind: project-relative
   target: codex
   value: .agents/skills/grill-me

--- a/dot_apm/apm.lock.yaml
+++ b/dot_apm/apm.lock.yaml
@@ -1,7 +1,541 @@
 lockfile_version: '1'
-generated_at: '2026-08-07T15:45:36.867413+00:00'
+generated_at: '2026-08-08T08:11:55.852076+00:00'
 apm_version: 0.26.0
 dependencies:
+- repo_url: cathrynlavery/diagram-design
+  name: diagram-design
+  host: github.com
+  resolved_commit: a157f7616473d966d6f433cf0b4d4f1880603504
+  resolved_ref: a157f7616473d966d6f433cf0b4d4f1880603504
+  version: unknown
+  virtual_path: skills/diagram-design
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .agents/skills/diagram-design
+  - .agents/skills/diagram-design/SKILL.md
+  - .agents/skills/diagram-design/assets/example-architecture-dark.html
+  - .agents/skills/diagram-design/assets/example-architecture-full.html
+  - .agents/skills/diagram-design/assets/example-architecture.html
+  - .agents/skills/diagram-design/assets/example-bar-dark.html
+  - .agents/skills/diagram-design/assets/example-bar-full.html
+  - .agents/skills/diagram-design/assets/example-bar.html
+  - .agents/skills/diagram-design/assets/example-data-flow-dark.html
+  - .agents/skills/diagram-design/assets/example-data-flow-full.html
+  - .agents/skills/diagram-design/assets/example-data-flow.html
+  - .agents/skills/diagram-design/assets/example-datalake-dark.html
+  - .agents/skills/diagram-design/assets/example-datalake-full.html
+  - .agents/skills/diagram-design/assets/example-datalake.html
+  - .agents/skills/diagram-design/assets/example-dp-integration-dark.html
+  - .agents/skills/diagram-design/assets/example-dp-integration-full.html
+  - .agents/skills/diagram-design/assets/example-dp-integration.html
+  - .agents/skills/diagram-design/assets/example-dp-security-matrix-dark.html
+  - .agents/skills/diagram-design/assets/example-dp-security-matrix-full.html
+  - .agents/skills/diagram-design/assets/example-dp-security-matrix.html
+  - .agents/skills/diagram-design/assets/example-er-dark.html
+  - .agents/skills/diagram-design/assets/example-er-full.html
+  - .agents/skills/diagram-design/assets/example-er.html
+  - .agents/skills/diagram-design/assets/example-flowchart-dark.html
+  - .agents/skills/diagram-design/assets/example-flowchart-full.html
+  - .agents/skills/diagram-design/assets/example-flowchart.html
+  - .agents/skills/diagram-design/assets/example-gantt-dark.html
+  - .agents/skills/diagram-design/assets/example-gantt-full.html
+  - .agents/skills/diagram-design/assets/example-gantt.html
+  - .agents/skills/diagram-design/assets/example-high-level-dark.html
+  - .agents/skills/diagram-design/assets/example-high-level-full.html
+  - .agents/skills/diagram-design/assets/example-high-level-vertical-dark.html
+  - .agents/skills/diagram-design/assets/example-high-level-vertical-full.html
+  - .agents/skills/diagram-design/assets/example-high-level-vertical.html
+  - .agents/skills/diagram-design/assets/example-high-level.html
+  - .agents/skills/diagram-design/assets/example-it-state-dark.html
+  - .agents/skills/diagram-design/assets/example-it-state-full.html
+  - .agents/skills/diagram-design/assets/example-it-state.html
+  - .agents/skills/diagram-design/assets/example-layers-dark.html
+  - .agents/skills/diagram-design/assets/example-layers-full.html
+  - .agents/skills/diagram-design/assets/example-layers.html
+  - .agents/skills/diagram-design/assets/example-line-dark.html
+  - .agents/skills/diagram-design/assets/example-line-full.html
+  - .agents/skills/diagram-design/assets/example-line.html
+  - .agents/skills/diagram-design/assets/example-loop-dark.html
+  - .agents/skills/diagram-design/assets/example-loop-full.html
+  - .agents/skills/diagram-design/assets/example-loop-terminal.html
+  - .agents/skills/diagram-design/assets/example-loop.html
+  - .agents/skills/diagram-design/assets/example-medallion-dark.html
+  - .agents/skills/diagram-design/assets/example-medallion-full.html
+  - .agents/skills/diagram-design/assets/example-medallion.html
+  - .agents/skills/diagram-design/assets/example-nested-dark.html
+  - .agents/skills/diagram-design/assets/example-nested-full.html
+  - .agents/skills/diagram-design/assets/example-nested.html
+  - .agents/skills/diagram-design/assets/example-org-chart-dark.html
+  - .agents/skills/diagram-design/assets/example-org-chart-full.html
+  - .agents/skills/diagram-design/assets/example-org-chart.html
+  - .agents/skills/diagram-design/assets/example-process-dark.html
+  - .agents/skills/diagram-design/assets/example-process-full.html
+  - .agents/skills/diagram-design/assets/example-process.html
+  - .agents/skills/diagram-design/assets/example-pyramid-dark.html
+  - .agents/skills/diagram-design/assets/example-pyramid-full.html
+  - .agents/skills/diagram-design/assets/example-pyramid.html
+  - .agents/skills/diagram-design/assets/example-quadrant-consultant.html
+  - .agents/skills/diagram-design/assets/example-quadrant-dark.html
+  - .agents/skills/diagram-design/assets/example-quadrant-full.html
+  - .agents/skills/diagram-design/assets/example-quadrant.html
+  - .agents/skills/diagram-design/assets/example-radar-dark.html
+  - .agents/skills/diagram-design/assets/example-radar-full.html
+  - .agents/skills/diagram-design/assets/example-radar.html
+  - .agents/skills/diagram-design/assets/example-scatter-dark.html
+  - .agents/skills/diagram-design/assets/example-scatter-full.html
+  - .agents/skills/diagram-design/assets/example-scatter.html
+  - .agents/skills/diagram-design/assets/example-sequence-dark.html
+  - .agents/skills/diagram-design/assets/example-sequence-full.html
+  - .agents/skills/diagram-design/assets/example-sequence.html
+  - .agents/skills/diagram-design/assets/example-state-dark.html
+  - .agents/skills/diagram-design/assets/example-state-full.html
+  - .agents/skills/diagram-design/assets/example-state.html
+  - .agents/skills/diagram-design/assets/example-swimlane-dark.html
+  - .agents/skills/diagram-design/assets/example-swimlane-full.html
+  - .agents/skills/diagram-design/assets/example-swimlane.html
+  - .agents/skills/diagram-design/assets/example-timeline-dark.html
+  - .agents/skills/diagram-design/assets/example-timeline-full.html
+  - .agents/skills/diagram-design/assets/example-timeline.html
+  - .agents/skills/diagram-design/assets/example-tree-dark.html
+  - .agents/skills/diagram-design/assets/example-tree-full.html
+  - .agents/skills/diagram-design/assets/example-tree.html
+  - .agents/skills/diagram-design/assets/example-venn-dark.html
+  - .agents/skills/diagram-design/assets/example-venn-full.html
+  - .agents/skills/diagram-design/assets/example-venn.html
+  - .agents/skills/diagram-design/assets/icons.html
+  - .agents/skills/diagram-design/assets/index.html
+  - .agents/skills/diagram-design/assets/template-dark.html
+  - .agents/skills/diagram-design/assets/template-full.html
+  - .agents/skills/diagram-design/assets/template-terminal.html
+  - .agents/skills/diagram-design/assets/template.html
+  - .agents/skills/diagram-design/references/export.md
+  - .agents/skills/diagram-design/references/onboarding.md
+  - .agents/skills/diagram-design/references/primitive-annotation.md
+  - .agents/skills/diagram-design/references/primitive-icons.md
+  - .agents/skills/diagram-design/references/primitive-sketchy.md
+  - .agents/skills/diagram-design/references/primitive-terminal.md
+  - .agents/skills/diagram-design/references/style-guide.md
+  - .agents/skills/diagram-design/references/type-architecture.md
+  - .agents/skills/diagram-design/references/type-bar.md
+  - .agents/skills/diagram-design/references/type-data-flow.md
+  - .agents/skills/diagram-design/references/type-dp-integration.md
+  - .agents/skills/diagram-design/references/type-dp-security-matrix.md
+  - .agents/skills/diagram-design/references/type-er.md
+  - .agents/skills/diagram-design/references/type-flowchart.md
+  - .agents/skills/diagram-design/references/type-gantt.md
+  - .agents/skills/diagram-design/references/type-high-level.md
+  - .agents/skills/diagram-design/references/type-it-state.md
+  - .agents/skills/diagram-design/references/type-layers.md
+  - .agents/skills/diagram-design/references/type-line.md
+  - .agents/skills/diagram-design/references/type-loop.md
+  - .agents/skills/diagram-design/references/type-medallion.md
+  - .agents/skills/diagram-design/references/type-nested.md
+  - .agents/skills/diagram-design/references/type-org-chart.md
+  - .agents/skills/diagram-design/references/type-process.md
+  - .agents/skills/diagram-design/references/type-pyramid.md
+  - .agents/skills/diagram-design/references/type-quadrant.md
+  - .agents/skills/diagram-design/references/type-radar.md
+  - .agents/skills/diagram-design/references/type-scatter.md
+  - .agents/skills/diagram-design/references/type-sequence.md
+  - .agents/skills/diagram-design/references/type-state.md
+  - .agents/skills/diagram-design/references/type-swimlane.md
+  - .agents/skills/diagram-design/references/type-timeline.md
+  - .agents/skills/diagram-design/references/type-tree.md
+  - .agents/skills/diagram-design/references/type-venn.md
+  - .claude/skills/diagram-design
+  - .claude/skills/diagram-design/SKILL.md
+  - .claude/skills/diagram-design/assets/example-architecture-dark.html
+  - .claude/skills/diagram-design/assets/example-architecture-full.html
+  - .claude/skills/diagram-design/assets/example-architecture.html
+  - .claude/skills/diagram-design/assets/example-bar-dark.html
+  - .claude/skills/diagram-design/assets/example-bar-full.html
+  - .claude/skills/diagram-design/assets/example-bar.html
+  - .claude/skills/diagram-design/assets/example-data-flow-dark.html
+  - .claude/skills/diagram-design/assets/example-data-flow-full.html
+  - .claude/skills/diagram-design/assets/example-data-flow.html
+  - .claude/skills/diagram-design/assets/example-datalake-dark.html
+  - .claude/skills/diagram-design/assets/example-datalake-full.html
+  - .claude/skills/diagram-design/assets/example-datalake.html
+  - .claude/skills/diagram-design/assets/example-dp-integration-dark.html
+  - .claude/skills/diagram-design/assets/example-dp-integration-full.html
+  - .claude/skills/diagram-design/assets/example-dp-integration.html
+  - .claude/skills/diagram-design/assets/example-dp-security-matrix-dark.html
+  - .claude/skills/diagram-design/assets/example-dp-security-matrix-full.html
+  - .claude/skills/diagram-design/assets/example-dp-security-matrix.html
+  - .claude/skills/diagram-design/assets/example-er-dark.html
+  - .claude/skills/diagram-design/assets/example-er-full.html
+  - .claude/skills/diagram-design/assets/example-er.html
+  - .claude/skills/diagram-design/assets/example-flowchart-dark.html
+  - .claude/skills/diagram-design/assets/example-flowchart-full.html
+  - .claude/skills/diagram-design/assets/example-flowchart.html
+  - .claude/skills/diagram-design/assets/example-gantt-dark.html
+  - .claude/skills/diagram-design/assets/example-gantt-full.html
+  - .claude/skills/diagram-design/assets/example-gantt.html
+  - .claude/skills/diagram-design/assets/example-high-level-dark.html
+  - .claude/skills/diagram-design/assets/example-high-level-full.html
+  - .claude/skills/diagram-design/assets/example-high-level-vertical-dark.html
+  - .claude/skills/diagram-design/assets/example-high-level-vertical-full.html
+  - .claude/skills/diagram-design/assets/example-high-level-vertical.html
+  - .claude/skills/diagram-design/assets/example-high-level.html
+  - .claude/skills/diagram-design/assets/example-it-state-dark.html
+  - .claude/skills/diagram-design/assets/example-it-state-full.html
+  - .claude/skills/diagram-design/assets/example-it-state.html
+  - .claude/skills/diagram-design/assets/example-layers-dark.html
+  - .claude/skills/diagram-design/assets/example-layers-full.html
+  - .claude/skills/diagram-design/assets/example-layers.html
+  - .claude/skills/diagram-design/assets/example-line-dark.html
+  - .claude/skills/diagram-design/assets/example-line-full.html
+  - .claude/skills/diagram-design/assets/example-line.html
+  - .claude/skills/diagram-design/assets/example-loop-dark.html
+  - .claude/skills/diagram-design/assets/example-loop-full.html
+  - .claude/skills/diagram-design/assets/example-loop-terminal.html
+  - .claude/skills/diagram-design/assets/example-loop.html
+  - .claude/skills/diagram-design/assets/example-medallion-dark.html
+  - .claude/skills/diagram-design/assets/example-medallion-full.html
+  - .claude/skills/diagram-design/assets/example-medallion.html
+  - .claude/skills/diagram-design/assets/example-nested-dark.html
+  - .claude/skills/diagram-design/assets/example-nested-full.html
+  - .claude/skills/diagram-design/assets/example-nested.html
+  - .claude/skills/diagram-design/assets/example-org-chart-dark.html
+  - .claude/skills/diagram-design/assets/example-org-chart-full.html
+  - .claude/skills/diagram-design/assets/example-org-chart.html
+  - .claude/skills/diagram-design/assets/example-process-dark.html
+  - .claude/skills/diagram-design/assets/example-process-full.html
+  - .claude/skills/diagram-design/assets/example-process.html
+  - .claude/skills/diagram-design/assets/example-pyramid-dark.html
+  - .claude/skills/diagram-design/assets/example-pyramid-full.html
+  - .claude/skills/diagram-design/assets/example-pyramid.html
+  - .claude/skills/diagram-design/assets/example-quadrant-consultant.html
+  - .claude/skills/diagram-design/assets/example-quadrant-dark.html
+  - .claude/skills/diagram-design/assets/example-quadrant-full.html
+  - .claude/skills/diagram-design/assets/example-quadrant.html
+  - .claude/skills/diagram-design/assets/example-radar-dark.html
+  - .claude/skills/diagram-design/assets/example-radar-full.html
+  - .claude/skills/diagram-design/assets/example-radar.html
+  - .claude/skills/diagram-design/assets/example-scatter-dark.html
+  - .claude/skills/diagram-design/assets/example-scatter-full.html
+  - .claude/skills/diagram-design/assets/example-scatter.html
+  - .claude/skills/diagram-design/assets/example-sequence-dark.html
+  - .claude/skills/diagram-design/assets/example-sequence-full.html
+  - .claude/skills/diagram-design/assets/example-sequence.html
+  - .claude/skills/diagram-design/assets/example-state-dark.html
+  - .claude/skills/diagram-design/assets/example-state-full.html
+  - .claude/skills/diagram-design/assets/example-state.html
+  - .claude/skills/diagram-design/assets/example-swimlane-dark.html
+  - .claude/skills/diagram-design/assets/example-swimlane-full.html
+  - .claude/skills/diagram-design/assets/example-swimlane.html
+  - .claude/skills/diagram-design/assets/example-timeline-dark.html
+  - .claude/skills/diagram-design/assets/example-timeline-full.html
+  - .claude/skills/diagram-design/assets/example-timeline.html
+  - .claude/skills/diagram-design/assets/example-tree-dark.html
+  - .claude/skills/diagram-design/assets/example-tree-full.html
+  - .claude/skills/diagram-design/assets/example-tree.html
+  - .claude/skills/diagram-design/assets/example-venn-dark.html
+  - .claude/skills/diagram-design/assets/example-venn-full.html
+  - .claude/skills/diagram-design/assets/example-venn.html
+  - .claude/skills/diagram-design/assets/icons.html
+  - .claude/skills/diagram-design/assets/index.html
+  - .claude/skills/diagram-design/assets/template-dark.html
+  - .claude/skills/diagram-design/assets/template-full.html
+  - .claude/skills/diagram-design/assets/template-terminal.html
+  - .claude/skills/diagram-design/assets/template.html
+  - .claude/skills/diagram-design/references/export.md
+  - .claude/skills/diagram-design/references/onboarding.md
+  - .claude/skills/diagram-design/references/primitive-annotation.md
+  - .claude/skills/diagram-design/references/primitive-icons.md
+  - .claude/skills/diagram-design/references/primitive-sketchy.md
+  - .claude/skills/diagram-design/references/primitive-terminal.md
+  - .claude/skills/diagram-design/references/style-guide.md
+  - .claude/skills/diagram-design/references/type-architecture.md
+  - .claude/skills/diagram-design/references/type-bar.md
+  - .claude/skills/diagram-design/references/type-data-flow.md
+  - .claude/skills/diagram-design/references/type-dp-integration.md
+  - .claude/skills/diagram-design/references/type-dp-security-matrix.md
+  - .claude/skills/diagram-design/references/type-er.md
+  - .claude/skills/diagram-design/references/type-flowchart.md
+  - .claude/skills/diagram-design/references/type-gantt.md
+  - .claude/skills/diagram-design/references/type-high-level.md
+  - .claude/skills/diagram-design/references/type-it-state.md
+  - .claude/skills/diagram-design/references/type-layers.md
+  - .claude/skills/diagram-design/references/type-line.md
+  - .claude/skills/diagram-design/references/type-loop.md
+  - .claude/skills/diagram-design/references/type-medallion.md
+  - .claude/skills/diagram-design/references/type-nested.md
+  - .claude/skills/diagram-design/references/type-org-chart.md
+  - .claude/skills/diagram-design/references/type-process.md
+  - .claude/skills/diagram-design/references/type-pyramid.md
+  - .claude/skills/diagram-design/references/type-quadrant.md
+  - .claude/skills/diagram-design/references/type-radar.md
+  - .claude/skills/diagram-design/references/type-scatter.md
+  - .claude/skills/diagram-design/references/type-sequence.md
+  - .claude/skills/diagram-design/references/type-state.md
+  - .claude/skills/diagram-design/references/type-swimlane.md
+  - .claude/skills/diagram-design/references/type-timeline.md
+  - .claude/skills/diagram-design/references/type-tree.md
+  - .claude/skills/diagram-design/references/type-venn.md
+  deployed_file_hashes:
+    .agents/skills/diagram-design/SKILL.md: sha256:46a18ae012ab85a068029a879469af0e6b25fc04b169a23384c31800339f9b35
+    .agents/skills/diagram-design/assets/example-architecture-dark.html: sha256:14e466b6387604f321d4e96b8ca4b6639f80c26024ede0c5bb39949cd1a32cc5
+    .agents/skills/diagram-design/assets/example-architecture-full.html: sha256:c8ac40086badd9201ee03ac9d818fbe9b1997ea865779af1032712ab6cec624b
+    .agents/skills/diagram-design/assets/example-architecture.html: sha256:9af905822a9d063bc09d2163e66eb074fe4b7f30e5051a092ffed727d29101d5
+    .agents/skills/diagram-design/assets/example-bar-dark.html: sha256:6c607e0b03ef7fb8a2d8a22423afb132c328e1187eab0ad1623206409eb4e831
+    .agents/skills/diagram-design/assets/example-bar-full.html: sha256:3280667df209f4ec58f03f7e1f2b773116e8c30ce503006fcf6ed2c3e64f33de
+    .agents/skills/diagram-design/assets/example-bar.html: sha256:21f72f45664e18d0a42f0c6f0dc7f28d4571cafe717363f0a1fa05b3dd3f38de
+    .agents/skills/diagram-design/assets/example-data-flow-dark.html: sha256:c8b34aa655bcf13bc2508ad4bdd50210f6f9640f82c8b7987b1a9c0bd66e7a2c
+    .agents/skills/diagram-design/assets/example-data-flow-full.html: sha256:0304a4a37ae29f82b9a2f9c9746e61bbd74802413643b51fb0fa20c50470eb4f
+    .agents/skills/diagram-design/assets/example-data-flow.html: sha256:ac61ac5a261036dab400772b3f25255af9745ea0ac2938e5f04d5016b55f7e2f
+    .agents/skills/diagram-design/assets/example-datalake-dark.html: sha256:a2b8f462cffc834cbc7ed2a4f1a514ab711e053351ecc1e74bc9c728f9961183
+    .agents/skills/diagram-design/assets/example-datalake-full.html: sha256:8a15428f7fac75cd46c5e46cfc31edc4e1ae98fccc7f16b7e939437f6597de4f
+    .agents/skills/diagram-design/assets/example-datalake.html: sha256:ed29ecf58a4d44a2f5d515eb6329572547350a71bae1c7e5a92ca9c95f4226c2
+    .agents/skills/diagram-design/assets/example-dp-integration-dark.html: sha256:7344bdb2d620d4cd4791f70a4a567dfad1c0e0c14b867e6c9f5d7c827e39b24a
+    .agents/skills/diagram-design/assets/example-dp-integration-full.html: sha256:e776a743d79629907b77bd1b8bc414a2267321ebc6031879884231131fdecaa9
+    .agents/skills/diagram-design/assets/example-dp-integration.html: sha256:ce279e7ee27974e5fdb33b7e353c898d8921899987070fd86ecacde5e3b3d51b
+    .agents/skills/diagram-design/assets/example-dp-security-matrix-dark.html: sha256:59f2979ab14dde59419778a5255aa7a7ec45cb928c38d1e85ae2ae842cbf14eb
+    .agents/skills/diagram-design/assets/example-dp-security-matrix-full.html: sha256:01212696d2eaa636d73326894303c999fa7c50f5c89ca59198ae3bc01f163241
+    .agents/skills/diagram-design/assets/example-dp-security-matrix.html: sha256:0eff6e77f955b0a48da7dc0bf71a4149ea86ee192e25a40585a99e21a7f8d48a
+    .agents/skills/diagram-design/assets/example-er-dark.html: sha256:5cd84d1251e1560ab57ea1e42c8bb800171fe1d8b58a5509537a4ca28fd7dde1
+    .agents/skills/diagram-design/assets/example-er-full.html: sha256:e5370a73fee461151cde458fb98beca0c2fface648944e2c92a7e24cff316d53
+    .agents/skills/diagram-design/assets/example-er.html: sha256:739ea5c309b957b7659f1734a6181395ce7bcf498aafcda7bf1c94c62e0e1ee1
+    .agents/skills/diagram-design/assets/example-flowchart-dark.html: sha256:8705626d625867f5874bb10a39b26ac9e2fb20efd7c230010a23d6e001901d84
+    .agents/skills/diagram-design/assets/example-flowchart-full.html: sha256:0b41288a01bd725879024bec043666552856eec0971f6c0afa16fbd9cc998280
+    .agents/skills/diagram-design/assets/example-flowchart.html: sha256:3c87a089606ad091b86150977338a6459d23578b6631da468977fbbf95f92368
+    .agents/skills/diagram-design/assets/example-gantt-dark.html: sha256:6104dce10605a9fc76d4222e29a85af8aa848c0e1fdec8a29e5c64e8bd7173ef
+    .agents/skills/diagram-design/assets/example-gantt-full.html: sha256:32345104d63824ab0033d2b7f43ea1a6d16774e74a69af7aac418b34e67222f2
+    .agents/skills/diagram-design/assets/example-gantt.html: sha256:115c2d89df52cab6f82c1163a81507fcc43e27356bbbd68d2d010a20abf9520b
+    .agents/skills/diagram-design/assets/example-high-level-dark.html: sha256:83d6764fde5d855c8e02b754be52489adaec81ea37ecb5115d67ca2f6fce7fbb
+    .agents/skills/diagram-design/assets/example-high-level-full.html: sha256:dcc38d53e4c987adae7cf6ae9b7f2ca589d3e68999f8b9aca9be2d0cd8e83996
+    .agents/skills/diagram-design/assets/example-high-level-vertical-dark.html: sha256:3836cda0879097ecdce89bb4cd0700aaca07d51c0a4df01e569181a0787fad47
+    .agents/skills/diagram-design/assets/example-high-level-vertical-full.html: sha256:5f83c312dd0fce70107b23700a46ea4c18433002027509337a341244d24d1880
+    .agents/skills/diagram-design/assets/example-high-level-vertical.html: sha256:b13b288e463403090cb3df5c76b8801b1a121764e888432c65e41a639702a2a1
+    .agents/skills/diagram-design/assets/example-high-level.html: sha256:ae9d402874cbeda42c483e4fbeb26db59558c3c52c2d16a7980d9a4186ff17c0
+    .agents/skills/diagram-design/assets/example-it-state-dark.html: sha256:6fcd86987c04c3c93e994ff7b1f2fba0099fc727e3e531c1fe705e4dec1f1c24
+    .agents/skills/diagram-design/assets/example-it-state-full.html: sha256:0c776f5b2e579570b1ca8e660204906696fb5ba3464ecc7ef348a7231173591a
+    .agents/skills/diagram-design/assets/example-it-state.html: sha256:b57ae2771baa0dce39d22fb4df650598a0f47eca673e8f9c63e33652584abd26
+    .agents/skills/diagram-design/assets/example-layers-dark.html: sha256:b3bb7809bf220c795870879b153b9541dfa844e97ad5864bc2ff2e92c955dcfb
+    .agents/skills/diagram-design/assets/example-layers-full.html: sha256:c862b6da22a9c1849a3b89aed9916f8a8362d55441d14d18847938914623b6a7
+    .agents/skills/diagram-design/assets/example-layers.html: sha256:1165a07d2a6f7c8a9c2668586f6b8332126dbe371892ee3d50f8ff3895081b8c
+    .agents/skills/diagram-design/assets/example-line-dark.html: sha256:4058742b355dfdf410cef5bfbf4805ec2e912a2951cb55ab3ee2e5ea97b81898
+    .agents/skills/diagram-design/assets/example-line-full.html: sha256:ff0fe49c173c908150d70ef6b5b4fe99e6c12ce5751df4c4f23e6cc61ee31dd3
+    .agents/skills/diagram-design/assets/example-line.html: sha256:8cbe8756319dda43bcd808a636c95cd62fc8707749b220aef1b711192aacad89
+    .agents/skills/diagram-design/assets/example-loop-dark.html: sha256:301599db7f9f3ee7ec6fc7f5f3b0b83f76c6cfb12056fc2b187f7c350d45e6aa
+    .agents/skills/diagram-design/assets/example-loop-full.html: sha256:26962347b7469a05696592d75af22c0d2e6b2bc9a47ce0a837e61bda733ccf72
+    .agents/skills/diagram-design/assets/example-loop-terminal.html: sha256:8291a189b1426f2468c37008f12c1cb35d9bb36fb707c27715e90dbb57c4eba8
+    .agents/skills/diagram-design/assets/example-loop.html: sha256:b5d0e37b14614ba95d95cdbc5ecdfb84c6c03d7cf664124e029cecb97af340bc
+    .agents/skills/diagram-design/assets/example-medallion-dark.html: sha256:b6f5322a74120cff46202fb16fcbcaf452aa9a4a121a2abfb39862478f3ab0c9
+    .agents/skills/diagram-design/assets/example-medallion-full.html: sha256:ffe0d8e7005826873a25812e7edb2679b79aa0e6edbb59dadb782b2522117953
+    .agents/skills/diagram-design/assets/example-medallion.html: sha256:e88a5b1f1f67a7bf6ad83c5144a7f79973a732f68972ba648ec81968579032eb
+    .agents/skills/diagram-design/assets/example-nested-dark.html: sha256:ed39986cdbe9661efba8bb868db5fcd63ef0077d56ec2a19bccbdd843dccb364
+    .agents/skills/diagram-design/assets/example-nested-full.html: sha256:c39d554d896c23a04b8007e836b7dccc97c7e07d1a40815620e6997e404a72d3
+    .agents/skills/diagram-design/assets/example-nested.html: sha256:835c09dc5004189aa980da0906473e155859a9ffb7d8e0242ee88f9192c409b0
+    .agents/skills/diagram-design/assets/example-org-chart-dark.html: sha256:27f76807e6847383012b5bfdfc8d34f2fd4a812204c1c0346461090217f3df6d
+    .agents/skills/diagram-design/assets/example-org-chart-full.html: sha256:990869b33894bc29dda9cee79736108f5e14aa22f67a8f5ecbf2fdfcd186aadf
+    .agents/skills/diagram-design/assets/example-org-chart.html: sha256:1ec336286416fe42c1843862633146af1b835da166269c907f199d5967576476
+    .agents/skills/diagram-design/assets/example-process-dark.html: sha256:262e6b8a2d6853dd9ed7a89f832f2a89e9e66d24fb93c1ad91d67c3115a1864a
+    .agents/skills/diagram-design/assets/example-process-full.html: sha256:f241b2686b87652aee0c9aac74fab2dffe10735123abfd2889442ca3d8b8fbc7
+    .agents/skills/diagram-design/assets/example-process.html: sha256:373ea85a5601c39c362f525abdb0f66a4230501e2b10a59b3c35456f81d99617
+    .agents/skills/diagram-design/assets/example-pyramid-dark.html: sha256:33163ade3dba029c65f88be3ec184281853de72044108ad88f73046e177185f7
+    .agents/skills/diagram-design/assets/example-pyramid-full.html: sha256:f49757a58400245a5d87f49a207287c421615a5b48b6ea40313adf59bb9837fa
+    .agents/skills/diagram-design/assets/example-pyramid.html: sha256:c2a37a438eb08b4b760c5f1c88726348a9da4b375853738ec9eef5002e14ef5e
+    .agents/skills/diagram-design/assets/example-quadrant-consultant.html: sha256:6cf47eb3bf125b4dcb2607e2e9cf0c4990ed9282ed090f65a0c5b66e3266165a
+    .agents/skills/diagram-design/assets/example-quadrant-dark.html: sha256:5dc82cfe5bde2100005c226ec98c9c99d7b4d081c0fd4869bf2eff62f516c731
+    .agents/skills/diagram-design/assets/example-quadrant-full.html: sha256:53dce246160452e5e1f75a6b76ed24c52b9f9928c4c225ee052306ca063a7c38
+    .agents/skills/diagram-design/assets/example-quadrant.html: sha256:40e7974f08a70910a940ece5ae9421a2005b81e6648401b70c104c777370729c
+    .agents/skills/diagram-design/assets/example-radar-dark.html: sha256:91f3d2d96c7eb31c5da0b8860af2375950d196371d8530b3db033d055bf38648
+    .agents/skills/diagram-design/assets/example-radar-full.html: sha256:18366036bd621556cfbc5a3d9a9e9772fbf7ac89e32b4447ec6a0b8fc825761a
+    .agents/skills/diagram-design/assets/example-radar.html: sha256:9a64d8ebd3cf61b994a0ad9d8bf2a02d33525aadf17d436dcde067625018cd94
+    .agents/skills/diagram-design/assets/example-scatter-dark.html: sha256:6eae3f07b520304cf8d21e590df8eb5a0974a09ea1398760e01fb11e33859daf
+    .agents/skills/diagram-design/assets/example-scatter-full.html: sha256:7e8b6d8a1f22311bb5631ef363e1e62278d3c03693865e91b39d386136de8207
+    .agents/skills/diagram-design/assets/example-scatter.html: sha256:84592a80c7ac97502d664a3ace58e4b150bfe9bf06f4b4c5f330524529a3b55e
+    .agents/skills/diagram-design/assets/example-sequence-dark.html: sha256:d1014b4515a3342e97fbb40a91c51eecc14ef6b90fe416857065b1f2a6369b52
+    .agents/skills/diagram-design/assets/example-sequence-full.html: sha256:baae19ba8be16ef27b92dd0288be7014c9d1fe4148cbd7eb28fa413cbf53a57b
+    .agents/skills/diagram-design/assets/example-sequence.html: sha256:13f7143a122e0a936f84da3e0e7c2f1141276318ddff0c989bfe3bb4e0c30ed9
+    .agents/skills/diagram-design/assets/example-state-dark.html: sha256:ec5f41153a7215b79e8b96a3457ec36e2a8ea20c7a70baf0efc226df9814f893
+    .agents/skills/diagram-design/assets/example-state-full.html: sha256:0aa6907ba096d3829585a68ca1cfe6a04cdaaaf5461ca07b1fec7e42414c2b4d
+    .agents/skills/diagram-design/assets/example-state.html: sha256:51d515b172eb331db253a4e7b28a70dc5c499f61f7e2f5bc9ba9b32942ef8d16
+    .agents/skills/diagram-design/assets/example-swimlane-dark.html: sha256:f5bd0e3857acc8d861c77b1e16b24bee23e90b2d1c6bff1cd7986864f1e65b9a
+    .agents/skills/diagram-design/assets/example-swimlane-full.html: sha256:b7b251c27ff7ad79fe7515b18e68c1f1309d47b29bd3c0306cd39f97e6ba2659
+    .agents/skills/diagram-design/assets/example-swimlane.html: sha256:c1735b46ae7878b75b87db07c766703a4ab31a5f11e27b841c3382fcc68de3b4
+    .agents/skills/diagram-design/assets/example-timeline-dark.html: sha256:0b76400220d2bcd0d2153d4e746c84563717c03f3c3fe5d38472f6f12bc662b1
+    .agents/skills/diagram-design/assets/example-timeline-full.html: sha256:2c41ce28a3cd7560b9fd6a8319605b4a8517fd58a61ec6d9e158322bbb0234f6
+    .agents/skills/diagram-design/assets/example-timeline.html: sha256:3a0d6ff568835c0e7545f3c15c23c9a2466489b45dc047c8d4bba375e3dadb8a
+    .agents/skills/diagram-design/assets/example-tree-dark.html: sha256:70fc7697184509641f409c934a9a1bfa4e0c27d756319f2a8bdd043632406e6b
+    .agents/skills/diagram-design/assets/example-tree-full.html: sha256:64cbce5bd7aec26c536fedd732474fb9affc36b2bfb2acccc6c80a0c855cea26
+    .agents/skills/diagram-design/assets/example-tree.html: sha256:18164267ccb3ad0e8a96e6b327d319f4704d226526eb9c4658d63b7425ee07b8
+    .agents/skills/diagram-design/assets/example-venn-dark.html: sha256:a4d01c1ffafb678fb3a5cf5f2d92028e7da9e797cffdde23d641c94e29ebc0d3
+    .agents/skills/diagram-design/assets/example-venn-full.html: sha256:e571dfc778bca7bf0c3843aad18583f54a94d71f288b6424094f04b56633348c
+    .agents/skills/diagram-design/assets/example-venn.html: sha256:c2c839e4748144fcde8b5390b60462063864767cfb526756213e9e5b70ffd5bf
+    .agents/skills/diagram-design/assets/icons.html: sha256:3c0a8f8b19cfec208cd4f77def500b6a57700ba861f137339573c26eecff77ff
+    .agents/skills/diagram-design/assets/index.html: sha256:e46d40a4362dfcd7a941bc75a59688e88b53bfc12877b1a182c2b955b83feb0d
+    .agents/skills/diagram-design/assets/template-dark.html: sha256:730b3f6bf24589b6826cdec73c479ee00fe511042eb1ca7dcb0cc687eab14615
+    .agents/skills/diagram-design/assets/template-full.html: sha256:63e4071ffccb6c8f0581adc6adce333d619aa645082783a7807a39e362eb373f
+    .agents/skills/diagram-design/assets/template-terminal.html: sha256:7517b55a8380cb38a2c383e8b44e863a2e907abcf06b9db630351d09453c5f35
+    .agents/skills/diagram-design/assets/template.html: sha256:a645ec2293ab0850e932b6075f727fe68f800baf6d530233b8a5a326c20a25e3
+    .agents/skills/diagram-design/references/export.md: sha256:7f3eef1cb9fac7b99fbf894346105d2892957deef6fd462af4a29b60d3e38b62
+    .agents/skills/diagram-design/references/onboarding.md: sha256:e2ef79edef4d6851590f1dabd2b1ae3f33d257e6a3c59c672931733beb3b39e2
+    .agents/skills/diagram-design/references/primitive-annotation.md: sha256:f78cac0af423ead9b74926fa669e9227efc21f15d0f51ea46bc93e79c55a121a
+    .agents/skills/diagram-design/references/primitive-icons.md: sha256:8b3d1a6ef29684058eb330724b4e9f31a7f4d06f4b6bc79a2603a1e00be87ed3
+    .agents/skills/diagram-design/references/primitive-sketchy.md: sha256:8859f0d70c10f46f59817cb348346e7fb9e1609b70a4a513d297b8c850c866a4
+    .agents/skills/diagram-design/references/primitive-terminal.md: sha256:7b52c2fb229c822a60b0061caa64ae6a68aacd4f1c22a1a98d1d0eaaa2333b55
+    .agents/skills/diagram-design/references/style-guide.md: sha256:45cb06a3b6b3cfaf0cf557a9c234d94dacbb8f3469b0c75d0406ba2ec638b23f
+    .agents/skills/diagram-design/references/type-architecture.md: sha256:cb5672b5c69cbe24a0b18d144f8b2e4507a124ebb0dbc0bc898ceafb27612caa
+    .agents/skills/diagram-design/references/type-bar.md: sha256:6ccd07efe40e2e0ab85eda5aa274c55b03236f17f532625a0235c7d9cce8cc01
+    .agents/skills/diagram-design/references/type-data-flow.md: sha256:9453c838d2ea7fc199659a369475b3141234e51921d4d4282fac8af9765effc7
+    .agents/skills/diagram-design/references/type-dp-integration.md: sha256:d808c354591ec9b751c662efd187ba4920b1861d4a484d8548f4efcb9d897987
+    .agents/skills/diagram-design/references/type-dp-security-matrix.md: sha256:209f4870ec19d90eff1ab80ecfe0062f3a5075c3b666b1a3a900a27260ba8832
+    .agents/skills/diagram-design/references/type-er.md: sha256:61ee3643c9e3a1e2c3a329640132ede2c193bfabaebbbb5fa486be800b6afa29
+    .agents/skills/diagram-design/references/type-flowchart.md: sha256:c2af5e2b849255ae4859125db7b101b74bfb9b201204725c1e83fac51a98ebab
+    .agents/skills/diagram-design/references/type-gantt.md: sha256:83a84cdd4b2880debd9e602f1d27ffc54197a6c783eb46228711641956f858ee
+    .agents/skills/diagram-design/references/type-high-level.md: sha256:035a0eac7d4b38452a324d9421457400dfe1a109d43f6acd377ba2c47f873a89
+    .agents/skills/diagram-design/references/type-it-state.md: sha256:ac3ceb94c4e8083130d5373654e150f1c9b3f0a5e3857a00c8e251f1086bf7b1
+    .agents/skills/diagram-design/references/type-layers.md: sha256:393a65464f1189a2244c989a7448a8be5446d5932c907bbdba57d10997729534
+    .agents/skills/diagram-design/references/type-line.md: sha256:31e51069ede341fa9992fcc34c12888651bbcfdb8c10c560c7790d050d138177
+    .agents/skills/diagram-design/references/type-loop.md: sha256:c7e98b8eda1e6d6904920f4d96310745deb0651920e9d531c8f40e54304ab60d
+    .agents/skills/diagram-design/references/type-medallion.md: sha256:a1af03521adb53431766a559e05c984ee07871fd3cf495cf63146999f56f6f42
+    .agents/skills/diagram-design/references/type-nested.md: sha256:e8c61323d96cd085e52750e90a989f9ad321600da6814b8926502b4484aced31
+    .agents/skills/diagram-design/references/type-org-chart.md: sha256:9905c67d6cf884f4537b9f86f893e6a90b4dc4134ff8bf8ce6187d151efbd6ab
+    .agents/skills/diagram-design/references/type-process.md: sha256:46fe29384b5004a7e79c21f093ed2724e58f258e543f45ed64f871bed6d31eda
+    .agents/skills/diagram-design/references/type-pyramid.md: sha256:a07536682478832fbf552aaa066dc827eaa1a072c538766387c8b900ae7add38
+    .agents/skills/diagram-design/references/type-quadrant.md: sha256:2346caba0370beaf8b33efd5d9a3e24f3d555b7160a3d523d9d07a37ce6c353a
+    .agents/skills/diagram-design/references/type-radar.md: sha256:8379b0313afbfdbb5a641c98f8ac6668419b4add6cea0749a646365fad02c1d3
+    .agents/skills/diagram-design/references/type-scatter.md: sha256:8c09a935f990ae2455d40962793aade3b9a14f7ec5c12e4f15ad0770cdaf8b38
+    .agents/skills/diagram-design/references/type-sequence.md: sha256:2b08647192d9eb8ab20707de2aea59a9bf47825c05997ce45e3c23495d31d459
+    .agents/skills/diagram-design/references/type-state.md: sha256:7fed5690161e6f75d510cf89d1e989885b2d900fdadca5116e7f5b49ad8529a5
+    .agents/skills/diagram-design/references/type-swimlane.md: sha256:4b689b9dd72078dc76fd2fbb1eb6c0bf0304fee667ae7cd56fab5f19b535f250
+    .agents/skills/diagram-design/references/type-timeline.md: sha256:9102e61347b17b303eafad52d4f8941d507faf889d9316ed0325e5e0f0ba01ca
+    .agents/skills/diagram-design/references/type-tree.md: sha256:cde49c571463bfbb3b91a5ba6abf91a4eb00f1deadc717947a9584fca189e57b
+    .agents/skills/diagram-design/references/type-venn.md: sha256:f8d5d4f0506160e0502f932140306b12d25adea1d1f6f319fb38c2345b0c6b42
+    .claude/skills/diagram-design/SKILL.md: sha256:46a18ae012ab85a068029a879469af0e6b25fc04b169a23384c31800339f9b35
+    .claude/skills/diagram-design/assets/example-architecture-dark.html: sha256:14e466b6387604f321d4e96b8ca4b6639f80c26024ede0c5bb39949cd1a32cc5
+    .claude/skills/diagram-design/assets/example-architecture-full.html: sha256:c8ac40086badd9201ee03ac9d818fbe9b1997ea865779af1032712ab6cec624b
+    .claude/skills/diagram-design/assets/example-architecture.html: sha256:9af905822a9d063bc09d2163e66eb074fe4b7f30e5051a092ffed727d29101d5
+    .claude/skills/diagram-design/assets/example-bar-dark.html: sha256:6c607e0b03ef7fb8a2d8a22423afb132c328e1187eab0ad1623206409eb4e831
+    .claude/skills/diagram-design/assets/example-bar-full.html: sha256:3280667df209f4ec58f03f7e1f2b773116e8c30ce503006fcf6ed2c3e64f33de
+    .claude/skills/diagram-design/assets/example-bar.html: sha256:21f72f45664e18d0a42f0c6f0dc7f28d4571cafe717363f0a1fa05b3dd3f38de
+    .claude/skills/diagram-design/assets/example-data-flow-dark.html: sha256:c8b34aa655bcf13bc2508ad4bdd50210f6f9640f82c8b7987b1a9c0bd66e7a2c
+    .claude/skills/diagram-design/assets/example-data-flow-full.html: sha256:0304a4a37ae29f82b9a2f9c9746e61bbd74802413643b51fb0fa20c50470eb4f
+    .claude/skills/diagram-design/assets/example-data-flow.html: sha256:ac61ac5a261036dab400772b3f25255af9745ea0ac2938e5f04d5016b55f7e2f
+    .claude/skills/diagram-design/assets/example-datalake-dark.html: sha256:a2b8f462cffc834cbc7ed2a4f1a514ab711e053351ecc1e74bc9c728f9961183
+    .claude/skills/diagram-design/assets/example-datalake-full.html: sha256:8a15428f7fac75cd46c5e46cfc31edc4e1ae98fccc7f16b7e939437f6597de4f
+    .claude/skills/diagram-design/assets/example-datalake.html: sha256:ed29ecf58a4d44a2f5d515eb6329572547350a71bae1c7e5a92ca9c95f4226c2
+    .claude/skills/diagram-design/assets/example-dp-integration-dark.html: sha256:7344bdb2d620d4cd4791f70a4a567dfad1c0e0c14b867e6c9f5d7c827e39b24a
+    .claude/skills/diagram-design/assets/example-dp-integration-full.html: sha256:e776a743d79629907b77bd1b8bc414a2267321ebc6031879884231131fdecaa9
+    .claude/skills/diagram-design/assets/example-dp-integration.html: sha256:ce279e7ee27974e5fdb33b7e353c898d8921899987070fd86ecacde5e3b3d51b
+    .claude/skills/diagram-design/assets/example-dp-security-matrix-dark.html: sha256:59f2979ab14dde59419778a5255aa7a7ec45cb928c38d1e85ae2ae842cbf14eb
+    .claude/skills/diagram-design/assets/example-dp-security-matrix-full.html: sha256:01212696d2eaa636d73326894303c999fa7c50f5c89ca59198ae3bc01f163241
+    .claude/skills/diagram-design/assets/example-dp-security-matrix.html: sha256:0eff6e77f955b0a48da7dc0bf71a4149ea86ee192e25a40585a99e21a7f8d48a
+    .claude/skills/diagram-design/assets/example-er-dark.html: sha256:5cd84d1251e1560ab57ea1e42c8bb800171fe1d8b58a5509537a4ca28fd7dde1
+    .claude/skills/diagram-design/assets/example-er-full.html: sha256:e5370a73fee461151cde458fb98beca0c2fface648944e2c92a7e24cff316d53
+    .claude/skills/diagram-design/assets/example-er.html: sha256:739ea5c309b957b7659f1734a6181395ce7bcf498aafcda7bf1c94c62e0e1ee1
+    .claude/skills/diagram-design/assets/example-flowchart-dark.html: sha256:8705626d625867f5874bb10a39b26ac9e2fb20efd7c230010a23d6e001901d84
+    .claude/skills/diagram-design/assets/example-flowchart-full.html: sha256:0b41288a01bd725879024bec043666552856eec0971f6c0afa16fbd9cc998280
+    .claude/skills/diagram-design/assets/example-flowchart.html: sha256:3c87a089606ad091b86150977338a6459d23578b6631da468977fbbf95f92368
+    .claude/skills/diagram-design/assets/example-gantt-dark.html: sha256:6104dce10605a9fc76d4222e29a85af8aa848c0e1fdec8a29e5c64e8bd7173ef
+    .claude/skills/diagram-design/assets/example-gantt-full.html: sha256:32345104d63824ab0033d2b7f43ea1a6d16774e74a69af7aac418b34e67222f2
+    .claude/skills/diagram-design/assets/example-gantt.html: sha256:115c2d89df52cab6f82c1163a81507fcc43e27356bbbd68d2d010a20abf9520b
+    .claude/skills/diagram-design/assets/example-high-level-dark.html: sha256:83d6764fde5d855c8e02b754be52489adaec81ea37ecb5115d67ca2f6fce7fbb
+    .claude/skills/diagram-design/assets/example-high-level-full.html: sha256:dcc38d53e4c987adae7cf6ae9b7f2ca589d3e68999f8b9aca9be2d0cd8e83996
+    .claude/skills/diagram-design/assets/example-high-level-vertical-dark.html: sha256:3836cda0879097ecdce89bb4cd0700aaca07d51c0a4df01e569181a0787fad47
+    .claude/skills/diagram-design/assets/example-high-level-vertical-full.html: sha256:5f83c312dd0fce70107b23700a46ea4c18433002027509337a341244d24d1880
+    .claude/skills/diagram-design/assets/example-high-level-vertical.html: sha256:b13b288e463403090cb3df5c76b8801b1a121764e888432c65e41a639702a2a1
+    .claude/skills/diagram-design/assets/example-high-level.html: sha256:ae9d402874cbeda42c483e4fbeb26db59558c3c52c2d16a7980d9a4186ff17c0
+    .claude/skills/diagram-design/assets/example-it-state-dark.html: sha256:6fcd86987c04c3c93e994ff7b1f2fba0099fc727e3e531c1fe705e4dec1f1c24
+    .claude/skills/diagram-design/assets/example-it-state-full.html: sha256:0c776f5b2e579570b1ca8e660204906696fb5ba3464ecc7ef348a7231173591a
+    .claude/skills/diagram-design/assets/example-it-state.html: sha256:b57ae2771baa0dce39d22fb4df650598a0f47eca673e8f9c63e33652584abd26
+    .claude/skills/diagram-design/assets/example-layers-dark.html: sha256:b3bb7809bf220c795870879b153b9541dfa844e97ad5864bc2ff2e92c955dcfb
+    .claude/skills/diagram-design/assets/example-layers-full.html: sha256:c862b6da22a9c1849a3b89aed9916f8a8362d55441d14d18847938914623b6a7
+    .claude/skills/diagram-design/assets/example-layers.html: sha256:1165a07d2a6f7c8a9c2668586f6b8332126dbe371892ee3d50f8ff3895081b8c
+    .claude/skills/diagram-design/assets/example-line-dark.html: sha256:4058742b355dfdf410cef5bfbf4805ec2e912a2951cb55ab3ee2e5ea97b81898
+    .claude/skills/diagram-design/assets/example-line-full.html: sha256:ff0fe49c173c908150d70ef6b5b4fe99e6c12ce5751df4c4f23e6cc61ee31dd3
+    .claude/skills/diagram-design/assets/example-line.html: sha256:8cbe8756319dda43bcd808a636c95cd62fc8707749b220aef1b711192aacad89
+    .claude/skills/diagram-design/assets/example-loop-dark.html: sha256:301599db7f9f3ee7ec6fc7f5f3b0b83f76c6cfb12056fc2b187f7c350d45e6aa
+    .claude/skills/diagram-design/assets/example-loop-full.html: sha256:26962347b7469a05696592d75af22c0d2e6b2bc9a47ce0a837e61bda733ccf72
+    .claude/skills/diagram-design/assets/example-loop-terminal.html: sha256:8291a189b1426f2468c37008f12c1cb35d9bb36fb707c27715e90dbb57c4eba8
+    .claude/skills/diagram-design/assets/example-loop.html: sha256:b5d0e37b14614ba95d95cdbc5ecdfb84c6c03d7cf664124e029cecb97af340bc
+    .claude/skills/diagram-design/assets/example-medallion-dark.html: sha256:b6f5322a74120cff46202fb16fcbcaf452aa9a4a121a2abfb39862478f3ab0c9
+    .claude/skills/diagram-design/assets/example-medallion-full.html: sha256:ffe0d8e7005826873a25812e7edb2679b79aa0e6edbb59dadb782b2522117953
+    .claude/skills/diagram-design/assets/example-medallion.html: sha256:e88a5b1f1f67a7bf6ad83c5144a7f79973a732f68972ba648ec81968579032eb
+    .claude/skills/diagram-design/assets/example-nested-dark.html: sha256:ed39986cdbe9661efba8bb868db5fcd63ef0077d56ec2a19bccbdd843dccb364
+    .claude/skills/diagram-design/assets/example-nested-full.html: sha256:c39d554d896c23a04b8007e836b7dccc97c7e07d1a40815620e6997e404a72d3
+    .claude/skills/diagram-design/assets/example-nested.html: sha256:835c09dc5004189aa980da0906473e155859a9ffb7d8e0242ee88f9192c409b0
+    .claude/skills/diagram-design/assets/example-org-chart-dark.html: sha256:27f76807e6847383012b5bfdfc8d34f2fd4a812204c1c0346461090217f3df6d
+    .claude/skills/diagram-design/assets/example-org-chart-full.html: sha256:990869b33894bc29dda9cee79736108f5e14aa22f67a8f5ecbf2fdfcd186aadf
+    .claude/skills/diagram-design/assets/example-org-chart.html: sha256:1ec336286416fe42c1843862633146af1b835da166269c907f199d5967576476
+    .claude/skills/diagram-design/assets/example-process-dark.html: sha256:262e6b8a2d6853dd9ed7a89f832f2a89e9e66d24fb93c1ad91d67c3115a1864a
+    .claude/skills/diagram-design/assets/example-process-full.html: sha256:f241b2686b87652aee0c9aac74fab2dffe10735123abfd2889442ca3d8b8fbc7
+    .claude/skills/diagram-design/assets/example-process.html: sha256:373ea85a5601c39c362f525abdb0f66a4230501e2b10a59b3c35456f81d99617
+    .claude/skills/diagram-design/assets/example-pyramid-dark.html: sha256:33163ade3dba029c65f88be3ec184281853de72044108ad88f73046e177185f7
+    .claude/skills/diagram-design/assets/example-pyramid-full.html: sha256:f49757a58400245a5d87f49a207287c421615a5b48b6ea40313adf59bb9837fa
+    .claude/skills/diagram-design/assets/example-pyramid.html: sha256:c2a37a438eb08b4b760c5f1c88726348a9da4b375853738ec9eef5002e14ef5e
+    .claude/skills/diagram-design/assets/example-quadrant-consultant.html: sha256:6cf47eb3bf125b4dcb2607e2e9cf0c4990ed9282ed090f65a0c5b66e3266165a
+    .claude/skills/diagram-design/assets/example-quadrant-dark.html: sha256:5dc82cfe5bde2100005c226ec98c9c99d7b4d081c0fd4869bf2eff62f516c731
+    .claude/skills/diagram-design/assets/example-quadrant-full.html: sha256:53dce246160452e5e1f75a6b76ed24c52b9f9928c4c225ee052306ca063a7c38
+    .claude/skills/diagram-design/assets/example-quadrant.html: sha256:40e7974f08a70910a940ece5ae9421a2005b81e6648401b70c104c777370729c
+    .claude/skills/diagram-design/assets/example-radar-dark.html: sha256:91f3d2d96c7eb31c5da0b8860af2375950d196371d8530b3db033d055bf38648
+    .claude/skills/diagram-design/assets/example-radar-full.html: sha256:18366036bd621556cfbc5a3d9a9e9772fbf7ac89e32b4447ec6a0b8fc825761a
+    .claude/skills/diagram-design/assets/example-radar.html: sha256:9a64d8ebd3cf61b994a0ad9d8bf2a02d33525aadf17d436dcde067625018cd94
+    .claude/skills/diagram-design/assets/example-scatter-dark.html: sha256:6eae3f07b520304cf8d21e590df8eb5a0974a09ea1398760e01fb11e33859daf
+    .claude/skills/diagram-design/assets/example-scatter-full.html: sha256:7e8b6d8a1f22311bb5631ef363e1e62278d3c03693865e91b39d386136de8207
+    .claude/skills/diagram-design/assets/example-scatter.html: sha256:84592a80c7ac97502d664a3ace58e4b150bfe9bf06f4b4c5f330524529a3b55e
+    .claude/skills/diagram-design/assets/example-sequence-dark.html: sha256:d1014b4515a3342e97fbb40a91c51eecc14ef6b90fe416857065b1f2a6369b52
+    .claude/skills/diagram-design/assets/example-sequence-full.html: sha256:baae19ba8be16ef27b92dd0288be7014c9d1fe4148cbd7eb28fa413cbf53a57b
+    .claude/skills/diagram-design/assets/example-sequence.html: sha256:13f7143a122e0a936f84da3e0e7c2f1141276318ddff0c989bfe3bb4e0c30ed9
+    .claude/skills/diagram-design/assets/example-state-dark.html: sha256:ec5f41153a7215b79e8b96a3457ec36e2a8ea20c7a70baf0efc226df9814f893
+    .claude/skills/diagram-design/assets/example-state-full.html: sha256:0aa6907ba096d3829585a68ca1cfe6a04cdaaaf5461ca07b1fec7e42414c2b4d
+    .claude/skills/diagram-design/assets/example-state.html: sha256:51d515b172eb331db253a4e7b28a70dc5c499f61f7e2f5bc9ba9b32942ef8d16
+    .claude/skills/diagram-design/assets/example-swimlane-dark.html: sha256:f5bd0e3857acc8d861c77b1e16b24bee23e90b2d1c6bff1cd7986864f1e65b9a
+    .claude/skills/diagram-design/assets/example-swimlane-full.html: sha256:b7b251c27ff7ad79fe7515b18e68c1f1309d47b29bd3c0306cd39f97e6ba2659
+    .claude/skills/diagram-design/assets/example-swimlane.html: sha256:c1735b46ae7878b75b87db07c766703a4ab31a5f11e27b841c3382fcc68de3b4
+    .claude/skills/diagram-design/assets/example-timeline-dark.html: sha256:0b76400220d2bcd0d2153d4e746c84563717c03f3c3fe5d38472f6f12bc662b1
+    .claude/skills/diagram-design/assets/example-timeline-full.html: sha256:2c41ce28a3cd7560b9fd6a8319605b4a8517fd58a61ec6d9e158322bbb0234f6
+    .claude/skills/diagram-design/assets/example-timeline.html: sha256:3a0d6ff568835c0e7545f3c15c23c9a2466489b45dc047c8d4bba375e3dadb8a
+    .claude/skills/diagram-design/assets/example-tree-dark.html: sha256:70fc7697184509641f409c934a9a1bfa4e0c27d756319f2a8bdd043632406e6b
+    .claude/skills/diagram-design/assets/example-tree-full.html: sha256:64cbce5bd7aec26c536fedd732474fb9affc36b2bfb2acccc6c80a0c855cea26
+    .claude/skills/diagram-design/assets/example-tree.html: sha256:18164267ccb3ad0e8a96e6b327d319f4704d226526eb9c4658d63b7425ee07b8
+    .claude/skills/diagram-design/assets/example-venn-dark.html: sha256:a4d01c1ffafb678fb3a5cf5f2d92028e7da9e797cffdde23d641c94e29ebc0d3
+    .claude/skills/diagram-design/assets/example-venn-full.html: sha256:e571dfc778bca7bf0c3843aad18583f54a94d71f288b6424094f04b56633348c
+    .claude/skills/diagram-design/assets/example-venn.html: sha256:c2c839e4748144fcde8b5390b60462063864767cfb526756213e9e5b70ffd5bf
+    .claude/skills/diagram-design/assets/icons.html: sha256:3c0a8f8b19cfec208cd4f77def500b6a57700ba861f137339573c26eecff77ff
+    .claude/skills/diagram-design/assets/index.html: sha256:e46d40a4362dfcd7a941bc75a59688e88b53bfc12877b1a182c2b955b83feb0d
+    .claude/skills/diagram-design/assets/template-dark.html: sha256:730b3f6bf24589b6826cdec73c479ee00fe511042eb1ca7dcb0cc687eab14615
+    .claude/skills/diagram-design/assets/template-full.html: sha256:63e4071ffccb6c8f0581adc6adce333d619aa645082783a7807a39e362eb373f
+    .claude/skills/diagram-design/assets/template-terminal.html: sha256:7517b55a8380cb38a2c383e8b44e863a2e907abcf06b9db630351d09453c5f35
+    .claude/skills/diagram-design/assets/template.html: sha256:a645ec2293ab0850e932b6075f727fe68f800baf6d530233b8a5a326c20a25e3
+    .claude/skills/diagram-design/references/export.md: sha256:7f3eef1cb9fac7b99fbf894346105d2892957deef6fd462af4a29b60d3e38b62
+    .claude/skills/diagram-design/references/onboarding.md: sha256:e2ef79edef4d6851590f1dabd2b1ae3f33d257e6a3c59c672931733beb3b39e2
+    .claude/skills/diagram-design/references/primitive-annotation.md: sha256:f78cac0af423ead9b74926fa669e9227efc21f15d0f51ea46bc93e79c55a121a
+    .claude/skills/diagram-design/references/primitive-icons.md: sha256:8b3d1a6ef29684058eb330724b4e9f31a7f4d06f4b6bc79a2603a1e00be87ed3
+    .claude/skills/diagram-design/references/primitive-sketchy.md: sha256:8859f0d70c10f46f59817cb348346e7fb9e1609b70a4a513d297b8c850c866a4
+    .claude/skills/diagram-design/references/primitive-terminal.md: sha256:7b52c2fb229c822a60b0061caa64ae6a68aacd4f1c22a1a98d1d0eaaa2333b55
+    .claude/skills/diagram-design/references/style-guide.md: sha256:45cb06a3b6b3cfaf0cf557a9c234d94dacbb8f3469b0c75d0406ba2ec638b23f
+    .claude/skills/diagram-design/references/type-architecture.md: sha256:cb5672b5c69cbe24a0b18d144f8b2e4507a124ebb0dbc0bc898ceafb27612caa
+    .claude/skills/diagram-design/references/type-bar.md: sha256:6ccd07efe40e2e0ab85eda5aa274c55b03236f17f532625a0235c7d9cce8cc01
+    .claude/skills/diagram-design/references/type-data-flow.md: sha256:9453c838d2ea7fc199659a369475b3141234e51921d4d4282fac8af9765effc7
+    .claude/skills/diagram-design/references/type-dp-integration.md: sha256:d808c354591ec9b751c662efd187ba4920b1861d4a484d8548f4efcb9d897987
+    .claude/skills/diagram-design/references/type-dp-security-matrix.md: sha256:209f4870ec19d90eff1ab80ecfe0062f3a5075c3b666b1a3a900a27260ba8832
+    .claude/skills/diagram-design/references/type-er.md: sha256:61ee3643c9e3a1e2c3a329640132ede2c193bfabaebbbb5fa486be800b6afa29
+    .claude/skills/diagram-design/references/type-flowchart.md: sha256:c2af5e2b849255ae4859125db7b101b74bfb9b201204725c1e83fac51a98ebab
+    .claude/skills/diagram-design/references/type-gantt.md: sha256:83a84cdd4b2880debd9e602f1d27ffc54197a6c783eb46228711641956f858ee
+    .claude/skills/diagram-design/references/type-high-level.md: sha256:035a0eac7d4b38452a324d9421457400dfe1a109d43f6acd377ba2c47f873a89
+    .claude/skills/diagram-design/references/type-it-state.md: sha256:ac3ceb94c4e8083130d5373654e150f1c9b3f0a5e3857a00c8e251f1086bf7b1
+    .claude/skills/diagram-design/references/type-layers.md: sha256:393a65464f1189a2244c989a7448a8be5446d5932c907bbdba57d10997729534
+    .claude/skills/diagram-design/references/type-line.md: sha256:31e51069ede341fa9992fcc34c12888651bbcfdb8c10c560c7790d050d138177
+    .claude/skills/diagram-design/references/type-loop.md: sha256:c7e98b8eda1e6d6904920f4d96310745deb0651920e9d531c8f40e54304ab60d
+    .claude/skills/diagram-design/references/type-medallion.md: sha256:a1af03521adb53431766a559e05c984ee07871fd3cf495cf63146999f56f6f42
+    .claude/skills/diagram-design/references/type-nested.md: sha256:e8c61323d96cd085e52750e90a989f9ad321600da6814b8926502b4484aced31
+    .claude/skills/diagram-design/references/type-org-chart.md: sha256:9905c67d6cf884f4537b9f86f893e6a90b4dc4134ff8bf8ce6187d151efbd6ab
+    .claude/skills/diagram-design/references/type-process.md: sha256:46fe29384b5004a7e79c21f093ed2724e58f258e543f45ed64f871bed6d31eda
+    .claude/skills/diagram-design/references/type-pyramid.md: sha256:a07536682478832fbf552aaa066dc827eaa1a072c538766387c8b900ae7add38
+    .claude/skills/diagram-design/references/type-quadrant.md: sha256:2346caba0370beaf8b33efd5d9a3e24f3d555b7160a3d523d9d07a37ce6c353a
+    .claude/skills/diagram-design/references/type-radar.md: sha256:8379b0313afbfdbb5a641c98f8ac6668419b4add6cea0749a646365fad02c1d3
+    .claude/skills/diagram-design/references/type-scatter.md: sha256:8c09a935f990ae2455d40962793aade3b9a14f7ec5c12e4f15ad0770cdaf8b38
+    .claude/skills/diagram-design/references/type-sequence.md: sha256:2b08647192d9eb8ab20707de2aea59a9bf47825c05997ce45e3c23495d31d459
+    .claude/skills/diagram-design/references/type-state.md: sha256:7fed5690161e6f75d510cf89d1e989885b2d900fdadca5116e7f5b49ad8529a5
+    .claude/skills/diagram-design/references/type-swimlane.md: sha256:4b689b9dd72078dc76fd2fbb1eb6c0bf0304fee667ae7cd56fab5f19b535f250
+    .claude/skills/diagram-design/references/type-timeline.md: sha256:9102e61347b17b303eafad52d4f8941d507faf889d9316ed0325e5e0f0ba01ca
+    .claude/skills/diagram-design/references/type-tree.md: sha256:cde49c571463bfbb3b91a5ba6abf91a4eb00f1deadc717947a9584fca189e57b
+    .claude/skills/diagram-design/references/type-venn.md: sha256:f8d5d4f0506160e0502f932140306b12d25adea1d1f6f319fb38c2345b0c6b42
+  content_hash: sha256:75c519b7b882b59faa14bb2da86cbb7de6cfc347ceb432bdbbcbbd1f90cdefac
 - repo_url: classmethod/tsumiki
   name: tsumiki
   host: github.com
@@ -139,6 +673,37 @@ dependencies:
   - .agents/skills/kairo-implement/SKILL.md
   - .agents/skills/kairo-implement/kairo-direct-process.md
   - .agents/skills/kairo-implement/kairo-tdd-process.md
+  - .claude/commands/auto-debug.md
+  - .claude/commands/build-fix.md
+  - .claude/commands/direct-setup.md
+  - .claude/commands/direct-verify.md
+  - .claude/commands/env-fix.md
+  - .claude/commands/flaky-fix.md
+  - .claude/commands/help.md
+  - .claude/commands/init-tech-stack.md
+  - .claude/commands/kairo-design.md
+  - .claude/commands/kairo-loop.md
+  - .claude/commands/kairo-requirements.md
+  - .claude/commands/kairo-tasknote.md
+  - .claude/commands/kairo-tasks.md
+  - .claude/commands/orchestrate.md
+  - .claude/commands/refine-execute.md
+  - .claude/commands/refine-plan.md
+  - .claude/commands/rev-design.md
+  - .claude/commands/rev-requirements.md
+  - .claude/commands/rev-specs.md
+  - .claude/commands/rev-tasks.md
+  - .claude/commands/tdd-green.md
+  - .claude/commands/tdd-red.md
+  - .claude/commands/tdd-refactor.md
+  - .claude/commands/tdd-requirements.md
+  - .claude/commands/tdd-tasknote.md
+  - .claude/commands/tdd-testcases.md
+  - .claude/commands/tdd-todo.md
+  - .claude/commands/tdd-verify-complete.md
+  - .claude/commands/tech-stack.md
+  - .claude/commands/test-optimization-patterns.md
+  - .claude/commands/timeout-fix.md
   - .claude/skills/dev-context
   - .claude/skills/dev-context/SKILL.md
   - .claude/skills/dev-context/references/context-template.md
@@ -299,6 +864,37 @@ dependencies:
   - .copilot/prompts/tech-stack.prompt.md
   - .copilot/prompts/test-optimization-patterns.prompt.md
   - .copilot/prompts/timeout-fix.prompt.md
+  - .cursor/commands/auto-debug.md
+  - .cursor/commands/build-fix.md
+  - .cursor/commands/direct-setup.md
+  - .cursor/commands/direct-verify.md
+  - .cursor/commands/env-fix.md
+  - .cursor/commands/flaky-fix.md
+  - .cursor/commands/help.md
+  - .cursor/commands/init-tech-stack.md
+  - .cursor/commands/kairo-design.md
+  - .cursor/commands/kairo-loop.md
+  - .cursor/commands/kairo-requirements.md
+  - .cursor/commands/kairo-tasknote.md
+  - .cursor/commands/kairo-tasks.md
+  - .cursor/commands/orchestrate.md
+  - .cursor/commands/refine-execute.md
+  - .cursor/commands/refine-plan.md
+  - .cursor/commands/rev-design.md
+  - .cursor/commands/rev-requirements.md
+  - .cursor/commands/rev-specs.md
+  - .cursor/commands/rev-tasks.md
+  - .cursor/commands/tdd-green.md
+  - .cursor/commands/tdd-red.md
+  - .cursor/commands/tdd-refactor.md
+  - .cursor/commands/tdd-requirements.md
+  - .cursor/commands/tdd-tasknote.md
+  - .cursor/commands/tdd-testcases.md
+  - .cursor/commands/tdd-todo.md
+  - .cursor/commands/tdd-verify-complete.md
+  - .cursor/commands/tech-stack.md
+  - .cursor/commands/test-optimization-patterns.md
+  - .cursor/commands/timeout-fix.md
   deployed_file_hashes:
     .agents/skills/dev-context/SKILL.md: sha256:a718cfef90957e8c8731f5bf333243c11f2c3e75ed31998f7bf82b0ac1db2ab6
     .agents/skills/dev-context/references/context-template.md: sha256:1b6db9752bbce16a472b4a9c62462e02ef6e12a642990925a4622f0d130c99b5
@@ -415,6 +1011,37 @@ dependencies:
     .agents/skills/kairo-implement/SKILL.md: sha256:f32321049a4ae8fe370f9be5762165ddc11efed4510c198dc4aa0019e544026b
     .agents/skills/kairo-implement/kairo-direct-process.md: sha256:d9ce7a4d94f51324381c746f5addd10fea0d043713282447b6f295f4880cd610
     .agents/skills/kairo-implement/kairo-tdd-process.md: sha256:04c48c9c682045264d6c5e7743dbf49768c8ed3daf66e4a82747e3c8b5787479
+    .claude/commands/auto-debug.md: sha256:8cefbd76a7bab0a355f9348fbb2b91716c7c15cf22079a62bd7dd8f9c41f632f
+    .claude/commands/build-fix.md: sha256:813bf6cdf28748b817d0cbe12e519c9c7aece087691ff87bb47767bff562fa21
+    .claude/commands/direct-setup.md: sha256:a9857efb5b5944dce742487dfb0436825c39e3dae7386dbe090f0b6c20732f6e
+    .claude/commands/direct-verify.md: sha256:d70b1e7e488563f28de405b9697b952ad4561b1be46dc67bb64aed91dba02d64
+    .claude/commands/env-fix.md: sha256:9fb156c69a7b06d0f8b6bade353a45f2e68a0d2f4c9e2e432046d6568a835557
+    .claude/commands/flaky-fix.md: sha256:84d69d46755ef5b4568cef1646dd6451c85dde5046b19b872d66723a4ed78b16
+    .claude/commands/help.md: sha256:6f15e7fc9afc82942a7582b19ce88c7d695040c50032e5c11e06612eb3444e15
+    .claude/commands/init-tech-stack.md: sha256:f86ee21f38136ed316a6b95a6aaaa5ec5ec4322087124866ac761ea92edc2692
+    .claude/commands/kairo-design.md: sha256:91fef77ddef3508669bf1956032456dfb208c3589830e37385513607dd3a234f
+    .claude/commands/kairo-loop.md: sha256:699acb01249b469661a82db74ee36f97475a71669a679a6eac64c36bdf38023e
+    .claude/commands/kairo-requirements.md: sha256:36b71c4a6fe05d7791c839bb92024b29a4b4761f983417cbfbc930c92d8265d9
+    .claude/commands/kairo-tasknote.md: sha256:27c5f6e9e7e27aeb82e78adfd3feaff79d842c2fa3d78d01e418d3c12faf896c
+    .claude/commands/kairo-tasks.md: sha256:e19b49714c721129b3c764cde0c56b134ced0bca9e5055edd413917c6055018f
+    .claude/commands/orchestrate.md: sha256:dfdc205a8ca36a4dfd060b1f7b3fbee5534b7a8a0e03e3923e578e8c44665c2e
+    .claude/commands/refine-execute.md: sha256:f6bf6206b9acacd5c228c602ab1603d350939b7287e12459325b452db0eb4a28
+    .claude/commands/refine-plan.md: sha256:82c6c8773e4e43f4f47df7d871adfa3ba3f76fd10c51e719f3f13b7f3a850445
+    .claude/commands/rev-design.md: sha256:471b31f5d27c2f66e95e6f575343a03a57e351e675f77ce85431f80d88e4198d
+    .claude/commands/rev-requirements.md: sha256:81a97613747391a54b75fcf2daae363be6d8027a70ad39f993f3d39139ea80c7
+    .claude/commands/rev-specs.md: sha256:9bf5bb13be95313f1f6fbf615880d0faf2e4f70a1293ad7bc81dfb33956c6816
+    .claude/commands/rev-tasks.md: sha256:7a39c830821c1d1a819c109f6020b48e599e3e960f5c17d4b01974a9017b275f
+    .claude/commands/tdd-green.md: sha256:690b189e76aae0f7979125ee8744fcf3a0d428ff4668d8f4f3b3d5aea46e8d3f
+    .claude/commands/tdd-red.md: sha256:8f87f48114d55990a047325d4cdf5d58c744a712c17f827322a1259b1c5cebf3
+    .claude/commands/tdd-refactor.md: sha256:9bb5878e8736d1bf7f553503f876ecb747e7c12a1416a47b5437120771446e60
+    .claude/commands/tdd-requirements.md: sha256:2eaa0f256c82a9f325437c31455e8e5c378fa436fa796b953c25348450498548
+    .claude/commands/tdd-tasknote.md: sha256:6edf0c0c26f8a43b86c1979efe344543ca2c580fc8fccbdf8f4b6270c880e153
+    .claude/commands/tdd-testcases.md: sha256:9e20f5c3c498898cef91621d2b9b66fd781c39f62ae613d0b23efbe8314fb859
+    .claude/commands/tdd-todo.md: sha256:e96543aa31b66764c194dd17ae266338ed480eada11751c51d11a476549f5c67
+    .claude/commands/tdd-verify-complete.md: sha256:7db3c028bc4148a88f9708a9b8f940c9ded0f18d494976f07a00b11568ad0b74
+    .claude/commands/tech-stack.md: sha256:a2fee065b3db125d768c09a2659ff20ddbc608c3a63a23621e93748d87422009
+    .claude/commands/test-optimization-patterns.md: sha256:0846e576d9570f2e3c743bc629b3d0fc701ededd3689b4e2fc77aefd3a416569
+    .claude/commands/timeout-fix.md: sha256:cb40a98d985fdc02524ba40935f0de2cfdd2b1b6b1872921c7fba15cf0a715c2
     .claude/skills/dev-context/SKILL.md: sha256:a718cfef90957e8c8731f5bf333243c11f2c3e75ed31998f7bf82b0ac1db2ab6
     .claude/skills/dev-context/references/context-template.md: sha256:1b6db9752bbce16a472b4a9c62462e02ef6e12a642990925a4622f0d130c99b5
     .claude/skills/dev-debug/SKILL.md: sha256:34a05be961ef8c2421754ef211e7a4a2509391b6c7911f7f89c2053d20314720
@@ -561,6 +1188,37 @@ dependencies:
     .copilot/prompts/tech-stack.prompt.md: sha256:50b2eff18e588b6ee392f769c1bb326825f48cf132b81f038578ba8ee10cc16c
     .copilot/prompts/test-optimization-patterns.prompt.md: sha256:584d958390939e07d9436cedf81bcc1d202d7fdfdf0758ad1e67553bc283c038
     .copilot/prompts/timeout-fix.prompt.md: sha256:582becab914324f43f61dec92a6c0cde1180fd8cae40730ed57cb275d715024b
+    .cursor/commands/auto-debug.md: sha256:8cefbd76a7bab0a355f9348fbb2b91716c7c15cf22079a62bd7dd8f9c41f632f
+    .cursor/commands/build-fix.md: sha256:813bf6cdf28748b817d0cbe12e519c9c7aece087691ff87bb47767bff562fa21
+    .cursor/commands/direct-setup.md: sha256:a9857efb5b5944dce742487dfb0436825c39e3dae7386dbe090f0b6c20732f6e
+    .cursor/commands/direct-verify.md: sha256:d70b1e7e488563f28de405b9697b952ad4561b1be46dc67bb64aed91dba02d64
+    .cursor/commands/env-fix.md: sha256:9fb156c69a7b06d0f8b6bade353a45f2e68a0d2f4c9e2e432046d6568a835557
+    .cursor/commands/flaky-fix.md: sha256:84d69d46755ef5b4568cef1646dd6451c85dde5046b19b872d66723a4ed78b16
+    .cursor/commands/help.md: sha256:6f15e7fc9afc82942a7582b19ce88c7d695040c50032e5c11e06612eb3444e15
+    .cursor/commands/init-tech-stack.md: sha256:f86ee21f38136ed316a6b95a6aaaa5ec5ec4322087124866ac761ea92edc2692
+    .cursor/commands/kairo-design.md: sha256:91fef77ddef3508669bf1956032456dfb208c3589830e37385513607dd3a234f
+    .cursor/commands/kairo-loop.md: sha256:699acb01249b469661a82db74ee36f97475a71669a679a6eac64c36bdf38023e
+    .cursor/commands/kairo-requirements.md: sha256:36b71c4a6fe05d7791c839bb92024b29a4b4761f983417cbfbc930c92d8265d9
+    .cursor/commands/kairo-tasknote.md: sha256:27c5f6e9e7e27aeb82e78adfd3feaff79d842c2fa3d78d01e418d3c12faf896c
+    .cursor/commands/kairo-tasks.md: sha256:e19b49714c721129b3c764cde0c56b134ced0bca9e5055edd413917c6055018f
+    .cursor/commands/orchestrate.md: sha256:dfdc205a8ca36a4dfd060b1f7b3fbee5534b7a8a0e03e3923e578e8c44665c2e
+    .cursor/commands/refine-execute.md: sha256:f6bf6206b9acacd5c228c602ab1603d350939b7287e12459325b452db0eb4a28
+    .cursor/commands/refine-plan.md: sha256:82c6c8773e4e43f4f47df7d871adfa3ba3f76fd10c51e719f3f13b7f3a850445
+    .cursor/commands/rev-design.md: sha256:471b31f5d27c2f66e95e6f575343a03a57e351e675f77ce85431f80d88e4198d
+    .cursor/commands/rev-requirements.md: sha256:81a97613747391a54b75fcf2daae363be6d8027a70ad39f993f3d39139ea80c7
+    .cursor/commands/rev-specs.md: sha256:9bf5bb13be95313f1f6fbf615880d0faf2e4f70a1293ad7bc81dfb33956c6816
+    .cursor/commands/rev-tasks.md: sha256:7a39c830821c1d1a819c109f6020b48e599e3e960f5c17d4b01974a9017b275f
+    .cursor/commands/tdd-green.md: sha256:690b189e76aae0f7979125ee8744fcf3a0d428ff4668d8f4f3b3d5aea46e8d3f
+    .cursor/commands/tdd-red.md: sha256:8f87f48114d55990a047325d4cdf5d58c744a712c17f827322a1259b1c5cebf3
+    .cursor/commands/tdd-refactor.md: sha256:9bb5878e8736d1bf7f553503f876ecb747e7c12a1416a47b5437120771446e60
+    .cursor/commands/tdd-requirements.md: sha256:2eaa0f256c82a9f325437c31455e8e5c378fa436fa796b953c25348450498548
+    .cursor/commands/tdd-tasknote.md: sha256:6edf0c0c26f8a43b86c1979efe344543ca2c580fc8fccbdf8f4b6270c880e153
+    .cursor/commands/tdd-testcases.md: sha256:9e20f5c3c498898cef91621d2b9b66fd781c39f62ae613d0b23efbe8314fb859
+    .cursor/commands/tdd-todo.md: sha256:e96543aa31b66764c194dd17ae266338ed480eada11751c51d11a476549f5c67
+    .cursor/commands/tdd-verify-complete.md: sha256:7db3c028bc4148a88f9708a9b8f940c9ded0f18d494976f07a00b11568ad0b74
+    .cursor/commands/tech-stack.md: sha256:a2fee065b3db125d768c09a2659ff20ddbc608c3a63a23621e93748d87422009
+    .cursor/commands/test-optimization-patterns.md: sha256:0846e576d9570f2e3c743bc629b3d0fc701ededd3689b4e2fc77aefd3a416569
+    .cursor/commands/timeout-fix.md: sha256:cb40a98d985fdc02524ba40935f0de2cfdd2b1b6b1872921c7fba15cf0a715c2
   content_hash: sha256:1ae0afc37f2baba6918a249de57c7c626fb166f3d5306b48de9dcd7b36726862
   declared_license: MIT
 - repo_url: ctxrs/ctx
@@ -581,6 +1239,72 @@ dependencies:
     .agents/skills/ctx-agent-history-search/SKILL.md: sha256:d76cd55f506f6d8605f2fed933a16e4ab995b3a4ab8e6d96bfd84d469872b3d6
     .claude/skills/ctx-agent-history-search/SKILL.md: sha256:d76cd55f506f6d8605f2fed933a16e4ab995b3a4ab8e6d96bfd84d469872b3d6
   content_hash: sha256:b9ee8ae28832c0058d21c16f1dc1cad4e72ad70597359033d18b6b7e556c40ce
+- repo_url: mattpocock/skills
+  name: resolving-merge-conflicts
+  host: github.com
+  resolved_commit: 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+  resolved_ref: 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+  version: unknown
+  virtual_path: skills/engineering/resolving-merge-conflicts
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .agents/skills/resolving-merge-conflicts
+  - .agents/skills/resolving-merge-conflicts/SKILL.md
+  - .agents/skills/resolving-merge-conflicts/agents/openai.yaml
+  - .claude/skills/resolving-merge-conflicts
+  - .claude/skills/resolving-merge-conflicts/SKILL.md
+  - .claude/skills/resolving-merge-conflicts/agents/openai.yaml
+  deployed_file_hashes:
+    .agents/skills/resolving-merge-conflicts/SKILL.md: sha256:c7c9ba81362a786aac05d2223123bf1bd2f8a99c3243a72882ede9c68bedfb24
+    .agents/skills/resolving-merge-conflicts/agents/openai.yaml: sha256:a1f4f96838f2ed6282eb28abbbf99029cb8fadce552baf53da90a025b8bffddf
+    .claude/skills/resolving-merge-conflicts/SKILL.md: sha256:c7c9ba81362a786aac05d2223123bf1bd2f8a99c3243a72882ede9c68bedfb24
+    .claude/skills/resolving-merge-conflicts/agents/openai.yaml: sha256:a1f4f96838f2ed6282eb28abbbf99029cb8fadce552baf53da90a025b8bffddf
+  content_hash: sha256:bfafce942f3d1264eb6bb931cd39b66cf8889f08072ba6264b5b111b141d2354
+- repo_url: mattpocock/skills
+  name: grill-me
+  host: github.com
+  resolved_commit: 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+  resolved_ref: 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+  version: unknown
+  virtual_path: skills/productivity/grill-me
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .agents/skills/grill-me
+  - .agents/skills/grill-me/SKILL.md
+  - .agents/skills/grill-me/agents/openai.yaml
+  - .claude/skills/grill-me
+  - .claude/skills/grill-me/SKILL.md
+  - .claude/skills/grill-me/agents/openai.yaml
+  deployed_file_hashes:
+    .agents/skills/grill-me/SKILL.md: sha256:6189dfceb7304a6e5558f75d87e68fa3bc7fcf7ba120e44f21f8a61fe01eba54
+    .agents/skills/grill-me/agents/openai.yaml: sha256:c061e39c3e0f9d865fb1b97556d485704af2a8a58f4b8221a8917a5c2074a32b
+    .claude/skills/grill-me/SKILL.md: sha256:6189dfceb7304a6e5558f75d87e68fa3bc7fcf7ba120e44f21f8a61fe01eba54
+    .claude/skills/grill-me/agents/openai.yaml: sha256:c061e39c3e0f9d865fb1b97556d485704af2a8a58f4b8221a8917a5c2074a32b
+  content_hash: sha256:0ac1a28d5e7ab05c4a51046c9d74fd7bfc070ba6a3b9ec8451bd274e746d67b6
+- repo_url: mattpocock/skills
+  name: grilling
+  host: github.com
+  resolved_commit: 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+  resolved_ref: 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+  version: unknown
+  virtual_path: skills/productivity/grilling
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .agents/skills/grilling
+  - .agents/skills/grilling/SKILL.md
+  - .agents/skills/grilling/agents/openai.yaml
+  - .claude/skills/grilling
+  - .claude/skills/grilling/SKILL.md
+  - .claude/skills/grilling/agents/openai.yaml
+  deployed_file_hashes:
+    .agents/skills/grilling/SKILL.md: sha256:fa5c1e5ee76b1c8f1ae56101f52c9e239de75d5c578adc61227b92d10b7e52ef
+    .agents/skills/grilling/agents/openai.yaml: sha256:1411d7df7d99b7e621a1ff8283c8133cc2464be63d064e52d8ce169c6800ee9b
+    .claude/skills/grilling/SKILL.md: sha256:fa5c1e5ee76b1c8f1ae56101f52c9e239de75d5c578adc61227b92d10b7e52ef
+    .claude/skills/grilling/agents/openai.yaml: sha256:1411d7df7d99b7e621a1ff8283c8133cc2464be63d064e52d8ce169c6800ee9b
+  content_hash: sha256:6f3a681f493ac92bf3c0f1263a9bf89f10f8f406623f3fbe5c87268e6d09e91e
 - repo_url: tomasz-tomczyk/crit
   name: crit
   host: github.com
@@ -640,6 +1364,285 @@ dependencies:
     .claude/skills/terminal-browser/SKILL.template.md: sha256:1ba1350404b762fe869cdcdf8658b0f0d1dd29d1a90a53d734b6bce77c2e1f47
   content_hash: sha256:ed3bc98ffc87d95320c8ec6064e53e4e27f8737d622cfd76d7645a53b725b396
 deployments:
+- kind: project-relative
+  target: claude
+  value: .claude/commands/auto-debug.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:8cefbd76a7bab0a355f9348fbb2b91716c7c15cf22079a62bd7dd8f9c41f632f
+- kind: project-relative
+  target: claude
+  value: .claude/commands/build-fix.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:813bf6cdf28748b817d0cbe12e519c9c7aece087691ff87bb47767bff562fa21
+- kind: project-relative
+  target: claude
+  value: .claude/commands/direct-setup.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:a9857efb5b5944dce742487dfb0436825c39e3dae7386dbe090f0b6c20732f6e
+- kind: project-relative
+  target: claude
+  value: .claude/commands/direct-verify.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:d70b1e7e488563f28de405b9697b952ad4561b1be46dc67bb64aed91dba02d64
+- kind: project-relative
+  target: claude
+  value: .claude/commands/env-fix.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:9fb156c69a7b06d0f8b6bade353a45f2e68a0d2f4c9e2e432046d6568a835557
+- kind: project-relative
+  target: claude
+  value: .claude/commands/flaky-fix.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:84d69d46755ef5b4568cef1646dd6451c85dde5046b19b872d66723a4ed78b16
+- kind: project-relative
+  target: claude
+  value: .claude/commands/help.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:6f15e7fc9afc82942a7582b19ce88c7d695040c50032e5c11e06612eb3444e15
+- kind: project-relative
+  target: claude
+  value: .claude/commands/init-tech-stack.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:f86ee21f38136ed316a6b95a6aaaa5ec5ec4322087124866ac761ea92edc2692
+- kind: project-relative
+  target: claude
+  value: .claude/commands/kairo-design.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:91fef77ddef3508669bf1956032456dfb208c3589830e37385513607dd3a234f
+- kind: project-relative
+  target: claude
+  value: .claude/commands/kairo-loop.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:699acb01249b469661a82db74ee36f97475a71669a679a6eac64c36bdf38023e
+- kind: project-relative
+  target: claude
+  value: .claude/commands/kairo-requirements.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:36b71c4a6fe05d7791c839bb92024b29a4b4761f983417cbfbc930c92d8265d9
+- kind: project-relative
+  target: claude
+  value: .claude/commands/kairo-tasknote.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:27c5f6e9e7e27aeb82e78adfd3feaff79d842c2fa3d78d01e418d3c12faf896c
+- kind: project-relative
+  target: claude
+  value: .claude/commands/kairo-tasks.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:e19b49714c721129b3c764cde0c56b134ced0bca9e5055edd413917c6055018f
+- kind: project-relative
+  target: claude
+  value: .claude/commands/orchestrate.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:dfdc205a8ca36a4dfd060b1f7b3fbee5534b7a8a0e03e3923e578e8c44665c2e
+- kind: project-relative
+  target: claude
+  value: .claude/commands/refine-execute.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:f6bf6206b9acacd5c228c602ab1603d350939b7287e12459325b452db0eb4a28
+- kind: project-relative
+  target: claude
+  value: .claude/commands/refine-plan.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:82c6c8773e4e43f4f47df7d871adfa3ba3f76fd10c51e719f3f13b7f3a850445
+- kind: project-relative
+  target: claude
+  value: .claude/commands/rev-design.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:471b31f5d27c2f66e95e6f575343a03a57e351e675f77ce85431f80d88e4198d
+- kind: project-relative
+  target: claude
+  value: .claude/commands/rev-requirements.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:81a97613747391a54b75fcf2daae363be6d8027a70ad39f993f3d39139ea80c7
+- kind: project-relative
+  target: claude
+  value: .claude/commands/rev-specs.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:9bf5bb13be95313f1f6fbf615880d0faf2e4f70a1293ad7bc81dfb33956c6816
+- kind: project-relative
+  target: claude
+  value: .claude/commands/rev-tasks.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:7a39c830821c1d1a819c109f6020b48e599e3e960f5c17d4b01974a9017b275f
+- kind: project-relative
+  target: claude
+  value: .claude/commands/tdd-green.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:690b189e76aae0f7979125ee8744fcf3a0d428ff4668d8f4f3b3d5aea46e8d3f
+- kind: project-relative
+  target: claude
+  value: .claude/commands/tdd-red.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:8f87f48114d55990a047325d4cdf5d58c744a712c17f827322a1259b1c5cebf3
+- kind: project-relative
+  target: claude
+  value: .claude/commands/tdd-refactor.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:9bb5878e8736d1bf7f553503f876ecb747e7c12a1416a47b5437120771446e60
+- kind: project-relative
+  target: claude
+  value: .claude/commands/tdd-requirements.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:2eaa0f256c82a9f325437c31455e8e5c378fa436fa796b953c25348450498548
+- kind: project-relative
+  target: claude
+  value: .claude/commands/tdd-tasknote.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:6edf0c0c26f8a43b86c1979efe344543ca2c580fc8fccbdf8f4b6270c880e153
+- kind: project-relative
+  target: claude
+  value: .claude/commands/tdd-testcases.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:9e20f5c3c498898cef91621d2b9b66fd781c39f62ae613d0b23efbe8314fb859
+- kind: project-relative
+  target: claude
+  value: .claude/commands/tdd-todo.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:e96543aa31b66764c194dd17ae266338ed480eada11751c51d11a476549f5c67
+- kind: project-relative
+  target: claude
+  value: .claude/commands/tdd-verify-complete.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:7db3c028bc4148a88f9708a9b8f940c9ded0f18d494976f07a00b11568ad0b74
+- kind: project-relative
+  target: claude
+  value: .claude/commands/tech-stack.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:a2fee065b3db125d768c09a2659ff20ddbc608c3a63a23621e93748d87422009
+- kind: project-relative
+  target: claude
+  value: .claude/commands/test-optimization-patterns.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:0846e576d9570f2e3c743bc629b3d0fc701ededd3689b4e2fc77aefd3a416569
+- kind: project-relative
+  target: claude
+  value: .claude/commands/timeout-fix.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:cb40a98d985fdc02524ba40935f0de2cfdd2b1b6b1872921c7fba15cf0a715c2
 - kind: project-relative
   target: claude
   value: .claude/skills/crit
@@ -1272,6 +2275,1239 @@ deployments:
   content_hash: sha256:f0b723789b681fce6f4296d2005c2218af92df5bffdff8177dea88fb4e2715dc
 - kind: project-relative
   target: claude
+  value: .claude/skills/diagram-design
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:46a18ae012ab85a068029a879469af0e6b25fc04b169a23384c31800339f9b35
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-architecture-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:14e466b6387604f321d4e96b8ca4b6639f80c26024ede0c5bb39949cd1a32cc5
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-architecture-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c8ac40086badd9201ee03ac9d818fbe9b1997ea865779af1032712ab6cec624b
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-architecture.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:9af905822a9d063bc09d2163e66eb074fe4b7f30e5051a092ffed727d29101d5
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-bar-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:6c607e0b03ef7fb8a2d8a22423afb132c328e1187eab0ad1623206409eb4e831
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-bar-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:3280667df209f4ec58f03f7e1f2b773116e8c30ce503006fcf6ed2c3e64f33de
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-bar.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:21f72f45664e18d0a42f0c6f0dc7f28d4571cafe717363f0a1fa05b3dd3f38de
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-data-flow-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c8b34aa655bcf13bc2508ad4bdd50210f6f9640f82c8b7987b1a9c0bd66e7a2c
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-data-flow-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:0304a4a37ae29f82b9a2f9c9746e61bbd74802413643b51fb0fa20c50470eb4f
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-data-flow.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ac61ac5a261036dab400772b3f25255af9745ea0ac2938e5f04d5016b55f7e2f
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-datalake-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:a2b8f462cffc834cbc7ed2a4f1a514ab711e053351ecc1e74bc9c728f9961183
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-datalake-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8a15428f7fac75cd46c5e46cfc31edc4e1ae98fccc7f16b7e939437f6597de4f
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-datalake.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ed29ecf58a4d44a2f5d515eb6329572547350a71bae1c7e5a92ca9c95f4226c2
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-dp-integration-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:7344bdb2d620d4cd4791f70a4a567dfad1c0e0c14b867e6c9f5d7c827e39b24a
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-dp-integration-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:e776a743d79629907b77bd1b8bc414a2267321ebc6031879884231131fdecaa9
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-dp-integration.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ce279e7ee27974e5fdb33b7e353c898d8921899987070fd86ecacde5e3b3d51b
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-dp-security-matrix-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:59f2979ab14dde59419778a5255aa7a7ec45cb928c38d1e85ae2ae842cbf14eb
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-dp-security-matrix-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:01212696d2eaa636d73326894303c999fa7c50f5c89ca59198ae3bc01f163241
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-dp-security-matrix.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:0eff6e77f955b0a48da7dc0bf71a4149ea86ee192e25a40585a99e21a7f8d48a
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-er-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:5cd84d1251e1560ab57ea1e42c8bb800171fe1d8b58a5509537a4ca28fd7dde1
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-er-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:e5370a73fee461151cde458fb98beca0c2fface648944e2c92a7e24cff316d53
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-er.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:739ea5c309b957b7659f1734a6181395ce7bcf498aafcda7bf1c94c62e0e1ee1
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-flowchart-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8705626d625867f5874bb10a39b26ac9e2fb20efd7c230010a23d6e001901d84
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-flowchart-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:0b41288a01bd725879024bec043666552856eec0971f6c0afa16fbd9cc998280
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-flowchart.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:3c87a089606ad091b86150977338a6459d23578b6631da468977fbbf95f92368
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-gantt-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:6104dce10605a9fc76d4222e29a85af8aa848c0e1fdec8a29e5c64e8bd7173ef
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-gantt-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:32345104d63824ab0033d2b7f43ea1a6d16774e74a69af7aac418b34e67222f2
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-gantt.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:115c2d89df52cab6f82c1163a81507fcc43e27356bbbd68d2d010a20abf9520b
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-high-level-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:83d6764fde5d855c8e02b754be52489adaec81ea37ecb5115d67ca2f6fce7fbb
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-high-level-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:dcc38d53e4c987adae7cf6ae9b7f2ca589d3e68999f8b9aca9be2d0cd8e83996
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-high-level-vertical-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:3836cda0879097ecdce89bb4cd0700aaca07d51c0a4df01e569181a0787fad47
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-high-level-vertical-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:5f83c312dd0fce70107b23700a46ea4c18433002027509337a341244d24d1880
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-high-level-vertical.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:b13b288e463403090cb3df5c76b8801b1a121764e888432c65e41a639702a2a1
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-high-level.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ae9d402874cbeda42c483e4fbeb26db59558c3c52c2d16a7980d9a4186ff17c0
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-it-state-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:6fcd86987c04c3c93e994ff7b1f2fba0099fc727e3e531c1fe705e4dec1f1c24
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-it-state-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:0c776f5b2e579570b1ca8e660204906696fb5ba3464ecc7ef348a7231173591a
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-it-state.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:b57ae2771baa0dce39d22fb4df650598a0f47eca673e8f9c63e33652584abd26
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-layers-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:b3bb7809bf220c795870879b153b9541dfa844e97ad5864bc2ff2e92c955dcfb
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-layers-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c862b6da22a9c1849a3b89aed9916f8a8362d55441d14d18847938914623b6a7
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-layers.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:1165a07d2a6f7c8a9c2668586f6b8332126dbe371892ee3d50f8ff3895081b8c
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-line-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:4058742b355dfdf410cef5bfbf4805ec2e912a2951cb55ab3ee2e5ea97b81898
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-line-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ff0fe49c173c908150d70ef6b5b4fe99e6c12ce5751df4c4f23e6cc61ee31dd3
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-line.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8cbe8756319dda43bcd808a636c95cd62fc8707749b220aef1b711192aacad89
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-loop-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:301599db7f9f3ee7ec6fc7f5f3b0b83f76c6cfb12056fc2b187f7c350d45e6aa
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-loop-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:26962347b7469a05696592d75af22c0d2e6b2bc9a47ce0a837e61bda733ccf72
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-loop-terminal.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8291a189b1426f2468c37008f12c1cb35d9bb36fb707c27715e90dbb57c4eba8
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-loop.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:b5d0e37b14614ba95d95cdbc5ecdfb84c6c03d7cf664124e029cecb97af340bc
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-medallion-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:b6f5322a74120cff46202fb16fcbcaf452aa9a4a121a2abfb39862478f3ab0c9
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-medallion-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ffe0d8e7005826873a25812e7edb2679b79aa0e6edbb59dadb782b2522117953
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-medallion.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:e88a5b1f1f67a7bf6ad83c5144a7f79973a732f68972ba648ec81968579032eb
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-nested-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ed39986cdbe9661efba8bb868db5fcd63ef0077d56ec2a19bccbdd843dccb364
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-nested-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c39d554d896c23a04b8007e836b7dccc97c7e07d1a40815620e6997e404a72d3
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-nested.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:835c09dc5004189aa980da0906473e155859a9ffb7d8e0242ee88f9192c409b0
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-org-chart-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:27f76807e6847383012b5bfdfc8d34f2fd4a812204c1c0346461090217f3df6d
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-org-chart-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:990869b33894bc29dda9cee79736108f5e14aa22f67a8f5ecbf2fdfcd186aadf
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-org-chart.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:1ec336286416fe42c1843862633146af1b835da166269c907f199d5967576476
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-process-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:262e6b8a2d6853dd9ed7a89f832f2a89e9e66d24fb93c1ad91d67c3115a1864a
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-process-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:f241b2686b87652aee0c9aac74fab2dffe10735123abfd2889442ca3d8b8fbc7
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-process.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:373ea85a5601c39c362f525abdb0f66a4230501e2b10a59b3c35456f81d99617
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-pyramid-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:33163ade3dba029c65f88be3ec184281853de72044108ad88f73046e177185f7
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-pyramid-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:f49757a58400245a5d87f49a207287c421615a5b48b6ea40313adf59bb9837fa
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-pyramid.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c2a37a438eb08b4b760c5f1c88726348a9da4b375853738ec9eef5002e14ef5e
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-quadrant-consultant.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:6cf47eb3bf125b4dcb2607e2e9cf0c4990ed9282ed090f65a0c5b66e3266165a
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-quadrant-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:5dc82cfe5bde2100005c226ec98c9c99d7b4d081c0fd4869bf2eff62f516c731
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-quadrant-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:53dce246160452e5e1f75a6b76ed24c52b9f9928c4c225ee052306ca063a7c38
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-quadrant.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:40e7974f08a70910a940ece5ae9421a2005b81e6648401b70c104c777370729c
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-radar-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:91f3d2d96c7eb31c5da0b8860af2375950d196371d8530b3db033d055bf38648
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-radar-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:18366036bd621556cfbc5a3d9a9e9772fbf7ac89e32b4447ec6a0b8fc825761a
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-radar.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:9a64d8ebd3cf61b994a0ad9d8bf2a02d33525aadf17d436dcde067625018cd94
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-scatter-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:6eae3f07b520304cf8d21e590df8eb5a0974a09ea1398760e01fb11e33859daf
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-scatter-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:7e8b6d8a1f22311bb5631ef363e1e62278d3c03693865e91b39d386136de8207
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-scatter.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:84592a80c7ac97502d664a3ace58e4b150bfe9bf06f4b4c5f330524529a3b55e
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-sequence-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:d1014b4515a3342e97fbb40a91c51eecc14ef6b90fe416857065b1f2a6369b52
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-sequence-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:baae19ba8be16ef27b92dd0288be7014c9d1fe4148cbd7eb28fa413cbf53a57b
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-sequence.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:13f7143a122e0a936f84da3e0e7c2f1141276318ddff0c989bfe3bb4e0c30ed9
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-state-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ec5f41153a7215b79e8b96a3457ec36e2a8ea20c7a70baf0efc226df9814f893
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-state-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:0aa6907ba096d3829585a68ca1cfe6a04cdaaaf5461ca07b1fec7e42414c2b4d
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-state.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:51d515b172eb331db253a4e7b28a70dc5c499f61f7e2f5bc9ba9b32942ef8d16
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-swimlane-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:f5bd0e3857acc8d861c77b1e16b24bee23e90b2d1c6bff1cd7986864f1e65b9a
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-swimlane-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:b7b251c27ff7ad79fe7515b18e68c1f1309d47b29bd3c0306cd39f97e6ba2659
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-swimlane.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c1735b46ae7878b75b87db07c766703a4ab31a5f11e27b841c3382fcc68de3b4
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-timeline-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:0b76400220d2bcd0d2153d4e746c84563717c03f3c3fe5d38472f6f12bc662b1
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-timeline-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:2c41ce28a3cd7560b9fd6a8319605b4a8517fd58a61ec6d9e158322bbb0234f6
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-timeline.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:3a0d6ff568835c0e7545f3c15c23c9a2466489b45dc047c8d4bba375e3dadb8a
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-tree-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:70fc7697184509641f409c934a9a1bfa4e0c27d756319f2a8bdd043632406e6b
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-tree-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:64cbce5bd7aec26c536fedd732474fb9affc36b2bfb2acccc6c80a0c855cea26
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-tree.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:18164267ccb3ad0e8a96e6b327d319f4704d226526eb9c4658d63b7425ee07b8
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-venn-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:a4d01c1ffafb678fb3a5cf5f2d92028e7da9e797cffdde23d641c94e29ebc0d3
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-venn-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:e571dfc778bca7bf0c3843aad18583f54a94d71f288b6424094f04b56633348c
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/example-venn.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c2c839e4748144fcde8b5390b60462063864767cfb526756213e9e5b70ffd5bf
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/icons.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:3c0a8f8b19cfec208cd4f77def500b6a57700ba861f137339573c26eecff77ff
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/index.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:e46d40a4362dfcd7a941bc75a59688e88b53bfc12877b1a182c2b955b83feb0d
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/template-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:730b3f6bf24589b6826cdec73c479ee00fe511042eb1ca7dcb0cc687eab14615
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/template-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:63e4071ffccb6c8f0581adc6adce333d619aa645082783a7807a39e362eb373f
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/template-terminal.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:7517b55a8380cb38a2c383e8b44e863a2e907abcf06b9db630351d09453c5f35
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/assets/template.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:a645ec2293ab0850e932b6075f727fe68f800baf6d530233b8a5a326c20a25e3
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/export.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:7f3eef1cb9fac7b99fbf894346105d2892957deef6fd462af4a29b60d3e38b62
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/onboarding.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:e2ef79edef4d6851590f1dabd2b1ae3f33d257e6a3c59c672931733beb3b39e2
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/primitive-annotation.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:f78cac0af423ead9b74926fa669e9227efc21f15d0f51ea46bc93e79c55a121a
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/primitive-icons.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8b3d1a6ef29684058eb330724b4e9f31a7f4d06f4b6bc79a2603a1e00be87ed3
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/primitive-sketchy.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8859f0d70c10f46f59817cb348346e7fb9e1609b70a4a513d297b8c850c866a4
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/primitive-terminal.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:7b52c2fb229c822a60b0061caa64ae6a68aacd4f1c22a1a98d1d0eaaa2333b55
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/style-guide.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:45cb06a3b6b3cfaf0cf557a9c234d94dacbb8f3469b0c75d0406ba2ec638b23f
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-architecture.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:cb5672b5c69cbe24a0b18d144f8b2e4507a124ebb0dbc0bc898ceafb27612caa
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-bar.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:6ccd07efe40e2e0ab85eda5aa274c55b03236f17f532625a0235c7d9cce8cc01
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-data-flow.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:9453c838d2ea7fc199659a369475b3141234e51921d4d4282fac8af9765effc7
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-dp-integration.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:d808c354591ec9b751c662efd187ba4920b1861d4a484d8548f4efcb9d897987
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-dp-security-matrix.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:209f4870ec19d90eff1ab80ecfe0062f3a5075c3b666b1a3a900a27260ba8832
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-er.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:61ee3643c9e3a1e2c3a329640132ede2c193bfabaebbbb5fa486be800b6afa29
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-flowchart.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c2af5e2b849255ae4859125db7b101b74bfb9b201204725c1e83fac51a98ebab
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-gantt.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:83a84cdd4b2880debd9e602f1d27ffc54197a6c783eb46228711641956f858ee
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-high-level.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:035a0eac7d4b38452a324d9421457400dfe1a109d43f6acd377ba2c47f873a89
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-it-state.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ac3ceb94c4e8083130d5373654e150f1c9b3f0a5e3857a00c8e251f1086bf7b1
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-layers.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:393a65464f1189a2244c989a7448a8be5446d5932c907bbdba57d10997729534
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-line.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:31e51069ede341fa9992fcc34c12888651bbcfdb8c10c560c7790d050d138177
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-loop.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c7e98b8eda1e6d6904920f4d96310745deb0651920e9d531c8f40e54304ab60d
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-medallion.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:a1af03521adb53431766a559e05c984ee07871fd3cf495cf63146999f56f6f42
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-nested.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:e8c61323d96cd085e52750e90a989f9ad321600da6814b8926502b4484aced31
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-org-chart.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:9905c67d6cf884f4537b9f86f893e6a90b4dc4134ff8bf8ce6187d151efbd6ab
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-process.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:46fe29384b5004a7e79c21f093ed2724e58f258e543f45ed64f871bed6d31eda
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-pyramid.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:a07536682478832fbf552aaa066dc827eaa1a072c538766387c8b900ae7add38
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-quadrant.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:2346caba0370beaf8b33efd5d9a3e24f3d555b7160a3d523d9d07a37ce6c353a
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-radar.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8379b0313afbfdbb5a641c98f8ac6668419b4add6cea0749a646365fad02c1d3
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-scatter.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8c09a935f990ae2455d40962793aade3b9a14f7ec5c12e4f15ad0770cdaf8b38
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-sequence.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:2b08647192d9eb8ab20707de2aea59a9bf47825c05997ce45e3c23495d31d459
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-state.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:7fed5690161e6f75d510cf89d1e989885b2d900fdadca5116e7f5b49ad8529a5
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-swimlane.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:4b689b9dd72078dc76fd2fbb1eb6c0bf0304fee667ae7cd56fab5f19b535f250
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-timeline.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:9102e61347b17b303eafad52d4f8941d507faf889d9316ed0325e5e0f0ba01ca
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-tree.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:cde49c571463bfbb3b91a5ba6abf91a4eb00f1deadc717947a9584fca189e57b
+- kind: project-relative
+  target: claude
+  value: .claude/skills/diagram-design/references/type-venn.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:f8d5d4f0506160e0502f932140306b12d25adea1d1f6f319fb38c2345b0c6b42
+- kind: project-relative
+  target: claude
+  value: .claude/skills/grill-me
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/productivity/grill-me
+  active_owner: mattpocock/skills/skills/productivity/grill-me
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/grill-me/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/productivity/grill-me
+  active_owner: mattpocock/skills/skills/productivity/grill-me
+  content_hash: sha256:6189dfceb7304a6e5558f75d87e68fa3bc7fcf7ba120e44f21f8a61fe01eba54
+- kind: project-relative
+  target: claude
+  value: .claude/skills/grill-me/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/productivity/grill-me
+  active_owner: mattpocock/skills/skills/productivity/grill-me
+  content_hash: sha256:c061e39c3e0f9d865fb1b97556d485704af2a8a58f4b8221a8917a5c2074a32b
+- kind: project-relative
+  target: claude
+  value: .claude/skills/grilling
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/productivity/grilling
+  active_owner: mattpocock/skills/skills/productivity/grilling
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/grilling/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/productivity/grilling
+  active_owner: mattpocock/skills/skills/productivity/grilling
+  content_hash: sha256:fa5c1e5ee76b1c8f1ae56101f52c9e239de75d5c578adc61227b92d10b7e52ef
+- kind: project-relative
+  target: claude
+  value: .claude/skills/grilling/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/productivity/grilling
+  active_owner: mattpocock/skills/skills/productivity/grilling
+  content_hash: sha256:1411d7df7d99b7e621a1ff8283c8133cc2464be63d064e52d8ce169c6800ee9b
+- kind: project-relative
+  target: claude
   value: .claude/skills/ipa-security-check
   runtime: null
   scope: project
@@ -1855,6 +4091,33 @@ deployments:
   - classmethod/tsumiki
   active_owner: classmethod/tsumiki
   content_hash: sha256:04c48c9c682045264d6c5e7743dbf49768c8ed3daf66e4a82747e3c8b5787479
+- kind: project-relative
+  target: claude
+  value: .claude/skills/resolving-merge-conflicts
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/engineering/resolving-merge-conflicts
+  active_owner: mattpocock/skills/skills/engineering/resolving-merge-conflicts
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/resolving-merge-conflicts/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/engineering/resolving-merge-conflicts
+  active_owner: mattpocock/skills/skills/engineering/resolving-merge-conflicts
+  content_hash: sha256:c7c9ba81362a786aac05d2223123bf1bd2f8a99c3243a72882ede9c68bedfb24
+- kind: project-relative
+  target: claude
+  value: .claude/skills/resolving-merge-conflicts/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/engineering/resolving-merge-conflicts
+  active_owner: mattpocock/skills/skills/engineering/resolving-merge-conflicts
+  content_hash: sha256:a1f4f96838f2ed6282eb28abbbf99029cb8fadce552baf53da90a025b8bffddf
 - kind: project-relative
   target: claude
   value: .claude/skills/terminal-browser
@@ -2514,6 +4777,1239 @@ deployments:
   content_hash: sha256:f0b723789b681fce6f4296d2005c2218af92df5bffdff8177dea88fb4e2715dc
 - kind: project-relative
   target: codex
+  value: .agents/skills/diagram-design
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:46a18ae012ab85a068029a879469af0e6b25fc04b169a23384c31800339f9b35
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-architecture-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:14e466b6387604f321d4e96b8ca4b6639f80c26024ede0c5bb39949cd1a32cc5
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-architecture-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c8ac40086badd9201ee03ac9d818fbe9b1997ea865779af1032712ab6cec624b
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-architecture.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:9af905822a9d063bc09d2163e66eb074fe4b7f30e5051a092ffed727d29101d5
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-bar-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:6c607e0b03ef7fb8a2d8a22423afb132c328e1187eab0ad1623206409eb4e831
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-bar-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:3280667df209f4ec58f03f7e1f2b773116e8c30ce503006fcf6ed2c3e64f33de
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-bar.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:21f72f45664e18d0a42f0c6f0dc7f28d4571cafe717363f0a1fa05b3dd3f38de
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-data-flow-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c8b34aa655bcf13bc2508ad4bdd50210f6f9640f82c8b7987b1a9c0bd66e7a2c
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-data-flow-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:0304a4a37ae29f82b9a2f9c9746e61bbd74802413643b51fb0fa20c50470eb4f
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-data-flow.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ac61ac5a261036dab400772b3f25255af9745ea0ac2938e5f04d5016b55f7e2f
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-datalake-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:a2b8f462cffc834cbc7ed2a4f1a514ab711e053351ecc1e74bc9c728f9961183
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-datalake-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8a15428f7fac75cd46c5e46cfc31edc4e1ae98fccc7f16b7e939437f6597de4f
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-datalake.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ed29ecf58a4d44a2f5d515eb6329572547350a71bae1c7e5a92ca9c95f4226c2
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-dp-integration-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:7344bdb2d620d4cd4791f70a4a567dfad1c0e0c14b867e6c9f5d7c827e39b24a
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-dp-integration-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:e776a743d79629907b77bd1b8bc414a2267321ebc6031879884231131fdecaa9
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-dp-integration.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ce279e7ee27974e5fdb33b7e353c898d8921899987070fd86ecacde5e3b3d51b
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-dp-security-matrix-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:59f2979ab14dde59419778a5255aa7a7ec45cb928c38d1e85ae2ae842cbf14eb
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-dp-security-matrix-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:01212696d2eaa636d73326894303c999fa7c50f5c89ca59198ae3bc01f163241
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-dp-security-matrix.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:0eff6e77f955b0a48da7dc0bf71a4149ea86ee192e25a40585a99e21a7f8d48a
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-er-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:5cd84d1251e1560ab57ea1e42c8bb800171fe1d8b58a5509537a4ca28fd7dde1
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-er-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:e5370a73fee461151cde458fb98beca0c2fface648944e2c92a7e24cff316d53
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-er.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:739ea5c309b957b7659f1734a6181395ce7bcf498aafcda7bf1c94c62e0e1ee1
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-flowchart-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8705626d625867f5874bb10a39b26ac9e2fb20efd7c230010a23d6e001901d84
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-flowchart-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:0b41288a01bd725879024bec043666552856eec0971f6c0afa16fbd9cc998280
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-flowchart.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:3c87a089606ad091b86150977338a6459d23578b6631da468977fbbf95f92368
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-gantt-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:6104dce10605a9fc76d4222e29a85af8aa848c0e1fdec8a29e5c64e8bd7173ef
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-gantt-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:32345104d63824ab0033d2b7f43ea1a6d16774e74a69af7aac418b34e67222f2
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-gantt.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:115c2d89df52cab6f82c1163a81507fcc43e27356bbbd68d2d010a20abf9520b
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-high-level-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:83d6764fde5d855c8e02b754be52489adaec81ea37ecb5115d67ca2f6fce7fbb
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-high-level-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:dcc38d53e4c987adae7cf6ae9b7f2ca589d3e68999f8b9aca9be2d0cd8e83996
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-high-level-vertical-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:3836cda0879097ecdce89bb4cd0700aaca07d51c0a4df01e569181a0787fad47
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-high-level-vertical-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:5f83c312dd0fce70107b23700a46ea4c18433002027509337a341244d24d1880
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-high-level-vertical.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:b13b288e463403090cb3df5c76b8801b1a121764e888432c65e41a639702a2a1
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-high-level.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ae9d402874cbeda42c483e4fbeb26db59558c3c52c2d16a7980d9a4186ff17c0
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-it-state-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:6fcd86987c04c3c93e994ff7b1f2fba0099fc727e3e531c1fe705e4dec1f1c24
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-it-state-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:0c776f5b2e579570b1ca8e660204906696fb5ba3464ecc7ef348a7231173591a
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-it-state.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:b57ae2771baa0dce39d22fb4df650598a0f47eca673e8f9c63e33652584abd26
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-layers-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:b3bb7809bf220c795870879b153b9541dfa844e97ad5864bc2ff2e92c955dcfb
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-layers-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c862b6da22a9c1849a3b89aed9916f8a8362d55441d14d18847938914623b6a7
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-layers.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:1165a07d2a6f7c8a9c2668586f6b8332126dbe371892ee3d50f8ff3895081b8c
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-line-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:4058742b355dfdf410cef5bfbf4805ec2e912a2951cb55ab3ee2e5ea97b81898
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-line-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ff0fe49c173c908150d70ef6b5b4fe99e6c12ce5751df4c4f23e6cc61ee31dd3
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-line.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8cbe8756319dda43bcd808a636c95cd62fc8707749b220aef1b711192aacad89
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-loop-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:301599db7f9f3ee7ec6fc7f5f3b0b83f76c6cfb12056fc2b187f7c350d45e6aa
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-loop-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:26962347b7469a05696592d75af22c0d2e6b2bc9a47ce0a837e61bda733ccf72
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-loop-terminal.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8291a189b1426f2468c37008f12c1cb35d9bb36fb707c27715e90dbb57c4eba8
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-loop.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:b5d0e37b14614ba95d95cdbc5ecdfb84c6c03d7cf664124e029cecb97af340bc
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-medallion-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:b6f5322a74120cff46202fb16fcbcaf452aa9a4a121a2abfb39862478f3ab0c9
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-medallion-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ffe0d8e7005826873a25812e7edb2679b79aa0e6edbb59dadb782b2522117953
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-medallion.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:e88a5b1f1f67a7bf6ad83c5144a7f79973a732f68972ba648ec81968579032eb
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-nested-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ed39986cdbe9661efba8bb868db5fcd63ef0077d56ec2a19bccbdd843dccb364
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-nested-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c39d554d896c23a04b8007e836b7dccc97c7e07d1a40815620e6997e404a72d3
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-nested.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:835c09dc5004189aa980da0906473e155859a9ffb7d8e0242ee88f9192c409b0
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-org-chart-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:27f76807e6847383012b5bfdfc8d34f2fd4a812204c1c0346461090217f3df6d
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-org-chart-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:990869b33894bc29dda9cee79736108f5e14aa22f67a8f5ecbf2fdfcd186aadf
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-org-chart.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:1ec336286416fe42c1843862633146af1b835da166269c907f199d5967576476
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-process-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:262e6b8a2d6853dd9ed7a89f832f2a89e9e66d24fb93c1ad91d67c3115a1864a
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-process-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:f241b2686b87652aee0c9aac74fab2dffe10735123abfd2889442ca3d8b8fbc7
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-process.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:373ea85a5601c39c362f525abdb0f66a4230501e2b10a59b3c35456f81d99617
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-pyramid-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:33163ade3dba029c65f88be3ec184281853de72044108ad88f73046e177185f7
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-pyramid-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:f49757a58400245a5d87f49a207287c421615a5b48b6ea40313adf59bb9837fa
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-pyramid.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c2a37a438eb08b4b760c5f1c88726348a9da4b375853738ec9eef5002e14ef5e
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-quadrant-consultant.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:6cf47eb3bf125b4dcb2607e2e9cf0c4990ed9282ed090f65a0c5b66e3266165a
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-quadrant-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:5dc82cfe5bde2100005c226ec98c9c99d7b4d081c0fd4869bf2eff62f516c731
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-quadrant-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:53dce246160452e5e1f75a6b76ed24c52b9f9928c4c225ee052306ca063a7c38
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-quadrant.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:40e7974f08a70910a940ece5ae9421a2005b81e6648401b70c104c777370729c
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-radar-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:91f3d2d96c7eb31c5da0b8860af2375950d196371d8530b3db033d055bf38648
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-radar-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:18366036bd621556cfbc5a3d9a9e9772fbf7ac89e32b4447ec6a0b8fc825761a
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-radar.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:9a64d8ebd3cf61b994a0ad9d8bf2a02d33525aadf17d436dcde067625018cd94
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-scatter-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:6eae3f07b520304cf8d21e590df8eb5a0974a09ea1398760e01fb11e33859daf
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-scatter-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:7e8b6d8a1f22311bb5631ef363e1e62278d3c03693865e91b39d386136de8207
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-scatter.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:84592a80c7ac97502d664a3ace58e4b150bfe9bf06f4b4c5f330524529a3b55e
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-sequence-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:d1014b4515a3342e97fbb40a91c51eecc14ef6b90fe416857065b1f2a6369b52
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-sequence-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:baae19ba8be16ef27b92dd0288be7014c9d1fe4148cbd7eb28fa413cbf53a57b
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-sequence.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:13f7143a122e0a936f84da3e0e7c2f1141276318ddff0c989bfe3bb4e0c30ed9
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-state-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ec5f41153a7215b79e8b96a3457ec36e2a8ea20c7a70baf0efc226df9814f893
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-state-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:0aa6907ba096d3829585a68ca1cfe6a04cdaaaf5461ca07b1fec7e42414c2b4d
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-state.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:51d515b172eb331db253a4e7b28a70dc5c499f61f7e2f5bc9ba9b32942ef8d16
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-swimlane-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:f5bd0e3857acc8d861c77b1e16b24bee23e90b2d1c6bff1cd7986864f1e65b9a
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-swimlane-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:b7b251c27ff7ad79fe7515b18e68c1f1309d47b29bd3c0306cd39f97e6ba2659
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-swimlane.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c1735b46ae7878b75b87db07c766703a4ab31a5f11e27b841c3382fcc68de3b4
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-timeline-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:0b76400220d2bcd0d2153d4e746c84563717c03f3c3fe5d38472f6f12bc662b1
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-timeline-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:2c41ce28a3cd7560b9fd6a8319605b4a8517fd58a61ec6d9e158322bbb0234f6
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-timeline.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:3a0d6ff568835c0e7545f3c15c23c9a2466489b45dc047c8d4bba375e3dadb8a
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-tree-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:70fc7697184509641f409c934a9a1bfa4e0c27d756319f2a8bdd043632406e6b
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-tree-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:64cbce5bd7aec26c536fedd732474fb9affc36b2bfb2acccc6c80a0c855cea26
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-tree.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:18164267ccb3ad0e8a96e6b327d319f4704d226526eb9c4658d63b7425ee07b8
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-venn-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:a4d01c1ffafb678fb3a5cf5f2d92028e7da9e797cffdde23d641c94e29ebc0d3
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-venn-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:e571dfc778bca7bf0c3843aad18583f54a94d71f288b6424094f04b56633348c
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/example-venn.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c2c839e4748144fcde8b5390b60462063864767cfb526756213e9e5b70ffd5bf
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/icons.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:3c0a8f8b19cfec208cd4f77def500b6a57700ba861f137339573c26eecff77ff
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/index.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:e46d40a4362dfcd7a941bc75a59688e88b53bfc12877b1a182c2b955b83feb0d
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/template-dark.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:730b3f6bf24589b6826cdec73c479ee00fe511042eb1ca7dcb0cc687eab14615
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/template-full.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:63e4071ffccb6c8f0581adc6adce333d619aa645082783a7807a39e362eb373f
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/template-terminal.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:7517b55a8380cb38a2c383e8b44e863a2e907abcf06b9db630351d09453c5f35
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/assets/template.html
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:a645ec2293ab0850e932b6075f727fe68f800baf6d530233b8a5a326c20a25e3
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/export.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:7f3eef1cb9fac7b99fbf894346105d2892957deef6fd462af4a29b60d3e38b62
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/onboarding.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:e2ef79edef4d6851590f1dabd2b1ae3f33d257e6a3c59c672931733beb3b39e2
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/primitive-annotation.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:f78cac0af423ead9b74926fa669e9227efc21f15d0f51ea46bc93e79c55a121a
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/primitive-icons.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8b3d1a6ef29684058eb330724b4e9f31a7f4d06f4b6bc79a2603a1e00be87ed3
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/primitive-sketchy.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8859f0d70c10f46f59817cb348346e7fb9e1609b70a4a513d297b8c850c866a4
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/primitive-terminal.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:7b52c2fb229c822a60b0061caa64ae6a68aacd4f1c22a1a98d1d0eaaa2333b55
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/style-guide.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:45cb06a3b6b3cfaf0cf557a9c234d94dacbb8f3469b0c75d0406ba2ec638b23f
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-architecture.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:cb5672b5c69cbe24a0b18d144f8b2e4507a124ebb0dbc0bc898ceafb27612caa
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-bar.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:6ccd07efe40e2e0ab85eda5aa274c55b03236f17f532625a0235c7d9cce8cc01
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-data-flow.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:9453c838d2ea7fc199659a369475b3141234e51921d4d4282fac8af9765effc7
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-dp-integration.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:d808c354591ec9b751c662efd187ba4920b1861d4a484d8548f4efcb9d897987
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-dp-security-matrix.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:209f4870ec19d90eff1ab80ecfe0062f3a5075c3b666b1a3a900a27260ba8832
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-er.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:61ee3643c9e3a1e2c3a329640132ede2c193bfabaebbbb5fa486be800b6afa29
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-flowchart.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c2af5e2b849255ae4859125db7b101b74bfb9b201204725c1e83fac51a98ebab
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-gantt.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:83a84cdd4b2880debd9e602f1d27ffc54197a6c783eb46228711641956f858ee
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-high-level.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:035a0eac7d4b38452a324d9421457400dfe1a109d43f6acd377ba2c47f873a89
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-it-state.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:ac3ceb94c4e8083130d5373654e150f1c9b3f0a5e3857a00c8e251f1086bf7b1
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-layers.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:393a65464f1189a2244c989a7448a8be5446d5932c907bbdba57d10997729534
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-line.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:31e51069ede341fa9992fcc34c12888651bbcfdb8c10c560c7790d050d138177
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-loop.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:c7e98b8eda1e6d6904920f4d96310745deb0651920e9d531c8f40e54304ab60d
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-medallion.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:a1af03521adb53431766a559e05c984ee07871fd3cf495cf63146999f56f6f42
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-nested.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:e8c61323d96cd085e52750e90a989f9ad321600da6814b8926502b4484aced31
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-org-chart.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:9905c67d6cf884f4537b9f86f893e6a90b4dc4134ff8bf8ce6187d151efbd6ab
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-process.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:46fe29384b5004a7e79c21f093ed2724e58f258e543f45ed64f871bed6d31eda
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-pyramid.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:a07536682478832fbf552aaa066dc827eaa1a072c538766387c8b900ae7add38
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-quadrant.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:2346caba0370beaf8b33efd5d9a3e24f3d555b7160a3d523d9d07a37ce6c353a
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-radar.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8379b0313afbfdbb5a641c98f8ac6668419b4add6cea0749a646365fad02c1d3
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-scatter.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:8c09a935f990ae2455d40962793aade3b9a14f7ec5c12e4f15ad0770cdaf8b38
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-sequence.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:2b08647192d9eb8ab20707de2aea59a9bf47825c05997ce45e3c23495d31d459
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-state.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:7fed5690161e6f75d510cf89d1e989885b2d900fdadca5116e7f5b49ad8529a5
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-swimlane.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:4b689b9dd72078dc76fd2fbb1eb6c0bf0304fee667ae7cd56fab5f19b535f250
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-timeline.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:9102e61347b17b303eafad52d4f8941d507faf889d9316ed0325e5e0f0ba01ca
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-tree.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:cde49c571463bfbb3b91a5ba6abf91a4eb00f1deadc717947a9584fca189e57b
+- kind: project-relative
+  target: codex
+  value: .agents/skills/diagram-design/references/type-venn.md
+  runtime: null
+  scope: project
+  owners:
+  - cathrynlavery/diagram-design/skills/diagram-design
+  active_owner: cathrynlavery/diagram-design/skills/diagram-design
+  content_hash: sha256:f8d5d4f0506160e0502f932140306b12d25adea1d1f6f319fb38c2345b0c6b42
+- kind: project-relative
+  target: codex
+  value: .agents/skills/grill-me
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/productivity/grill-me
+  active_owner: mattpocock/skills/skills/productivity/grill-me
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/grill-me/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/productivity/grill-me
+  active_owner: mattpocock/skills/skills/productivity/grill-me
+  content_hash: sha256:6189dfceb7304a6e5558f75d87e68fa3bc7fcf7ba120e44f21f8a61fe01eba54
+- kind: project-relative
+  target: codex
+  value: .agents/skills/grill-me/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/productivity/grill-me
+  active_owner: mattpocock/skills/skills/productivity/grill-me
+  content_hash: sha256:c061e39c3e0f9d865fb1b97556d485704af2a8a58f4b8221a8917a5c2074a32b
+- kind: project-relative
+  target: codex
+  value: .agents/skills/grilling
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/productivity/grilling
+  active_owner: mattpocock/skills/skills/productivity/grilling
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/grilling/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/productivity/grilling
+  active_owner: mattpocock/skills/skills/productivity/grilling
+  content_hash: sha256:fa5c1e5ee76b1c8f1ae56101f52c9e239de75d5c578adc61227b92d10b7e52ef
+- kind: project-relative
+  target: codex
+  value: .agents/skills/grilling/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/productivity/grilling
+  active_owner: mattpocock/skills/skills/productivity/grilling
+  content_hash: sha256:1411d7df7d99b7e621a1ff8283c8133cc2464be63d064e52d8ce169c6800ee9b
+- kind: project-relative
+  target: codex
   value: .agents/skills/ipa-security-check
   runtime: null
   scope: project
@@ -3099,6 +6595,33 @@ deployments:
   content_hash: sha256:04c48c9c682045264d6c5e7743dbf49768c8ed3daf66e4a82747e3c8b5787479
 - kind: project-relative
   target: codex
+  value: .agents/skills/resolving-merge-conflicts
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/engineering/resolving-merge-conflicts
+  active_owner: mattpocock/skills/skills/engineering/resolving-merge-conflicts
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/resolving-merge-conflicts/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/engineering/resolving-merge-conflicts
+  active_owner: mattpocock/skills/skills/engineering/resolving-merge-conflicts
+  content_hash: sha256:c7c9ba81362a786aac05d2223123bf1bd2f8a99c3243a72882ede9c68bedfb24
+- kind: project-relative
+  target: codex
+  value: .agents/skills/resolving-merge-conflicts/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - mattpocock/skills/skills/engineering/resolving-merge-conflicts
+  active_owner: mattpocock/skills/skills/engineering/resolving-merge-conflicts
+  content_hash: sha256:a1f4f96838f2ed6282eb28abbbf99029cb8fadce552baf53da90a025b8bffddf
+- kind: project-relative
+  target: codex
   value: .agents/skills/terminal-browser
   runtime: null
   scope: project
@@ -3403,3 +6926,282 @@ deployments:
   - classmethod/tsumiki
   active_owner: classmethod/tsumiki
   content_hash: sha256:582becab914324f43f61dec92a6c0cde1180fd8cae40730ed57cb275d715024b
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/auto-debug.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:8cefbd76a7bab0a355f9348fbb2b91716c7c15cf22079a62bd7dd8f9c41f632f
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/build-fix.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:813bf6cdf28748b817d0cbe12e519c9c7aece087691ff87bb47767bff562fa21
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/direct-setup.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:a9857efb5b5944dce742487dfb0436825c39e3dae7386dbe090f0b6c20732f6e
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/direct-verify.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:d70b1e7e488563f28de405b9697b952ad4561b1be46dc67bb64aed91dba02d64
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/env-fix.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:9fb156c69a7b06d0f8b6bade353a45f2e68a0d2f4c9e2e432046d6568a835557
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/flaky-fix.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:84d69d46755ef5b4568cef1646dd6451c85dde5046b19b872d66723a4ed78b16
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/help.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:6f15e7fc9afc82942a7582b19ce88c7d695040c50032e5c11e06612eb3444e15
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/init-tech-stack.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:f86ee21f38136ed316a6b95a6aaaa5ec5ec4322087124866ac761ea92edc2692
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/kairo-design.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:91fef77ddef3508669bf1956032456dfb208c3589830e37385513607dd3a234f
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/kairo-loop.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:699acb01249b469661a82db74ee36f97475a71669a679a6eac64c36bdf38023e
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/kairo-requirements.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:36b71c4a6fe05d7791c839bb92024b29a4b4761f983417cbfbc930c92d8265d9
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/kairo-tasknote.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:27c5f6e9e7e27aeb82e78adfd3feaff79d842c2fa3d78d01e418d3c12faf896c
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/kairo-tasks.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:e19b49714c721129b3c764cde0c56b134ced0bca9e5055edd413917c6055018f
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/orchestrate.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:dfdc205a8ca36a4dfd060b1f7b3fbee5534b7a8a0e03e3923e578e8c44665c2e
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/refine-execute.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:f6bf6206b9acacd5c228c602ab1603d350939b7287e12459325b452db0eb4a28
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/refine-plan.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:82c6c8773e4e43f4f47df7d871adfa3ba3f76fd10c51e719f3f13b7f3a850445
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/rev-design.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:471b31f5d27c2f66e95e6f575343a03a57e351e675f77ce85431f80d88e4198d
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/rev-requirements.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:81a97613747391a54b75fcf2daae363be6d8027a70ad39f993f3d39139ea80c7
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/rev-specs.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:9bf5bb13be95313f1f6fbf615880d0faf2e4f70a1293ad7bc81dfb33956c6816
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/rev-tasks.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:7a39c830821c1d1a819c109f6020b48e599e3e960f5c17d4b01974a9017b275f
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/tdd-green.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:690b189e76aae0f7979125ee8744fcf3a0d428ff4668d8f4f3b3d5aea46e8d3f
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/tdd-red.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:8f87f48114d55990a047325d4cdf5d58c744a712c17f827322a1259b1c5cebf3
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/tdd-refactor.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:9bb5878e8736d1bf7f553503f876ecb747e7c12a1416a47b5437120771446e60
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/tdd-requirements.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:2eaa0f256c82a9f325437c31455e8e5c378fa436fa796b953c25348450498548
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/tdd-tasknote.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:6edf0c0c26f8a43b86c1979efe344543ca2c580fc8fccbdf8f4b6270c880e153
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/tdd-testcases.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:9e20f5c3c498898cef91621d2b9b66fd781c39f62ae613d0b23efbe8314fb859
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/tdd-todo.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:e96543aa31b66764c194dd17ae266338ed480eada11751c51d11a476549f5c67
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/tdd-verify-complete.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:7db3c028bc4148a88f9708a9b8f940c9ded0f18d494976f07a00b11568ad0b74
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/tech-stack.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:a2fee065b3db125d768c09a2659ff20ddbc608c3a63a23621e93748d87422009
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/test-optimization-patterns.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:0846e576d9570f2e3c743bc629b3d0fc701ededd3689b4e2fc77aefd3a416569
+- kind: project-relative
+  target: cursor
+  value: .cursor/commands/timeout-fix.md
+  runtime: null
+  scope: project
+  owners:
+  - classmethod/tsumiki
+  active_owner: classmethod/tsumiki
+  content_hash: sha256:cb40a98d985fdc02524ba40935f0de2cfdd2b1b6b1872921c7fba15cf0a715c2

--- a/dot_apm/apm.lock.yaml
+++ b/dot_apm/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-08-08T11:39:18.985161+00:00'
+generated_at: '2026-08-08T11:46:29.311602+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: cathrynlavery/diagram-design
@@ -1339,7 +1339,7 @@ dependencies:
     .codex/hooks/ponytail/hooks/ponytail-statusline.ps1: sha256:6138f15bc7651ee7e5ced2a2a2280f5c810d58cad3e9f3252c628f4c923e48c9
     .codex/hooks/ponytail/hooks/ponytail-statusline.sh: sha256:f1dbfa5997a5d4b5339619709053eff557ab16d71af75eb3041c3d3e3dca42ec
     .codex/hooks/ponytail/hooks/ponytail-subagent.js: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e
-    .copilot/hooks/ponytail-copilot-hooks.json: sha256:18ee3902e119c2ed993b4be16a09770defcc1cce60707c0dc33d6915d7331e1d
+    .copilot/hooks/ponytail-copilot-hooks.json: sha256:3568a11a7c3a4077622ba53a1d9e63d9a6d6d35f1a94a59abdb9a7d1474f7435
     .copilot/hooks/scripts/ponytail/hooks/package.json: sha256:8005a3491db7d92f36ac66369861589f9c47123d3a7c71e643fc2c06168cd45a
     .copilot/hooks/scripts/ponytail/hooks/ponytail-activate.js: sha256:1c428c4ee9687c2f4321924109ee92e8f8b06fd6600cb6be9ec5b59633cafab1
     .copilot/hooks/scripts/ponytail/hooks/ponytail-config.js: sha256:0a8daf96cf9ac703dc4cb7b5065253567e513c951d60b8eb94a0fe727514aeca
@@ -7208,7 +7208,7 @@ deployments:
   owners:
   - dietrichgebert/ponytail
   active_owner: dietrichgebert/ponytail
-  content_hash: sha256:18ee3902e119c2ed993b4be16a09770defcc1cce60707c0dc33d6915d7331e1d
+  content_hash: sha256:3568a11a7c3a4077622ba53a1d9e63d9a6d6d35f1a94a59abdb9a7d1474f7435
 - kind: project-relative
   target: copilot
   value: .copilot/hooks/scripts/ponytail/hooks/package.json

--- a/dot_apm/apm.yml
+++ b/dot_apm/apm.yml
@@ -49,6 +49,10 @@ dependencies:
       path: skills/diagram-design
       ref: a157f7616473d966d6f433cf0b4d4f1880603504
       alias: diagram-design
+    - git: vercel-labs/skills
+      path: skills/find-skills
+      ref: 941a7bcfeca4bf07913b9fb6f8ed81f20ff5297c
+      alias: find-skills
   mcp: []
 includes: auto
 scripts: {}

--- a/dot_apm/apm.yml
+++ b/dot_apm/apm.yml
@@ -53,6 +53,10 @@ dependencies:
       path: skills/find-skills
       ref: 941a7bcfeca4bf07913b9fb6f8ed81f20ff5297c
       alias: find-skills
+    # Ponytail は repository 全体を plugin package として取り込み、6 skills と hooks を配布する。
+    - git: DietrichGebert/ponytail
+      ref: v4.9.0
+      alias: ponytail
   mcp: []
 includes: auto
 scripts: {}

--- a/dot_apm/apm.yml
+++ b/dot_apm/apm.yml
@@ -32,6 +32,23 @@ dependencies:
       path: skills/ctx-agent-history-search
       ref: v0.25.0
       alias: ctx-agent-history-search
+    - git: mattpocock/skills
+      path: skills/engineering/resolving-merge-conflicts
+      ref: 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+      alias: resolving-merge-conflicts
+    - git: mattpocock/skills
+      path: skills/productivity/grill-me
+      ref: 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+      alias: grill-me
+    # grill-me が呼び出す interview loop。本体と同じ commit に pin する。
+    - git: mattpocock/skills
+      path: skills/productivity/grilling
+      ref: 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+      alias: grilling
+    - git: cathrynlavery/diagram-design
+      path: skills/diagram-design
+      ref: a157f7616473d966d6f433cf0b4d4f1880603504
+      alias: diagram-design
   mcp: []
 includes: auto
 scripts: {}


### PR DESCRIPTION
## Summary
- install the requested MattPocock skills through the APM manifest
- install diagram-design from cathrynlavery/diagram-design through APM
- include the grilling dependency required by grill-me
- document installation and usage for resolving-merge-conflicts, grill-me, and diagram-design

## Testing
- installed the manifest with APM 0.26.0 in an isolated HOME
- verified all four skill directories in both .agents/skills and .claude/skills
- verified diagram-design bundled assets and references
- verified resolved commits in the generated APM lockfile
- ran oxfmt checks for the changed YAML and Markdown
- ran secretlint for the changed YAML and Markdown
- ran git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs APM-managed skills — `resolving-merge-conflicts`, `grill-me` (with `grilling`), `diagram-design`, `find-skills`, and the `ponytail` plugin (6 skills) — and adds a single docs page explaining all external skills (`crit`, `terminal-browser`, Tsumiki, Ponytail, `ctx-agent-history-search`), with clarified SVG/PNG export steps and minor wording/spacing fixes.

- **Dependencies**
  - Added pinned skills from `mattpocock/skills` (`resolving-merge-conflicts`, `grill-me`, `grilling`), `cathrynlavery/diagram-design` (`diagram-design`), `vercel-labs/skills` (`find-skills`), and `DietrichGebert/ponytail` (`ponytail` plugin).
  - Updated `dot_apm/apm.yml` and refreshed `dot_apm/apm.lock.yaml` to resolve and pin all additions.

- **Migration**
  - Install: run `chezmoi apply` then `mise run apm:install`; restart your editor/agent.
  - For diagram PNG export, install Playwright and Chromium: `pip install playwright && playwright install chromium`.
  - Ensure `node` is on PATH for `ponytail` plugin hooks.

<sup>Written for commit bf5b3af6913f1aa26a8199cb4c01f98ef8c4c350. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

- `resolving-merge-conflicts`、`grill-me`、`grilling`、`diagram-design` をAPM管理対象に追加しました。
- APMロックファイル、Renovate設定、ワークフロー、`gh`ヘルパーを追加・更新しました。
- 新しいスキルのインストール方法と利用方法を `docs/skill.md` に追加しました。

## 変更理由

- 複数のエージェント間でスキルを統一して管理するためです。
- スキルのバージョンを固定し、再現性のあるインストールを実現するためです。
- マージ競合の解決、レビュー支援、図の設計を支援するためです。

## 確認した項目

- APM 0.26.0で隔離したHOME環境にインストールしました。
- スキルディレクトリ、同梱アセット、参照ファイルを確認しました。
- ロックファイルのコミット、フォーマット、シークレットスキャン、空白文字を確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->