### PR TITLE
fix: normalize synced APM lockfile permissions

### DIFF
--- a/docs/apm.md
+++ b/docs/apm.md
@@ -106,6 +106,8 @@ apm install -g
 `mise run apm:install` は続けて tsumiki commands を rulesync source へ同期し、Claude Codeにはcommand、
 Codexにはskillとして配布します。Claude Codeでは `/tsumiki-init-tech-stack`、Codexでは新しいセッションから
 `$tsumiki-init-tech-stack` のように呼び出します。Codexのcustom prompt（`/prompts:...`）には依存しません。
+同期時は source directory 側の `dot_apm/apm.lock.yaml` を `0644` に正規化するため、APM が user scope の
+lockfile を `0600` で生成しても、その後の `chezmoi apply` で mode 差分は表示されません。
 
 > [!NOTE]
 > 導入した skill の `description` は各エージェントの skill 索引に**常時ロード**されます。

--- a/dot_config/mise/config.mac.toml
+++ b/dot_config/mise/config.mac.toml
@@ -1,6 +1,6 @@
 [tools]
 "github:hzqtc/taproom"  = { version = "0.6.2", bin = "taproom" }
-"http:terminal-browser" = { version = "0.3.2", platforms.macos-arm64 = { url = "https://terminal-browser.sh/install/dl/stable/v{{version}}/terminal-browser-darwin-arm64.tar.gz", strip_components = 1, bin_path = "bin" } }
+"http:terminal-browser" = { version = "0.3.2", platforms.macos-arm64 = { url = "https://terminal-browser.sh/install/dl/stable/v{{ version }}/terminal-browser-darwin-arm64.tar.gz", strip_components = 1, bin_path = "bin" } }
 
 [bootstrap.packages]
 # silicon は mac 専用（config.mac.toml の brew:silicon, native arm64。harfbuzz 等の依存も

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -102,12 +102,12 @@ ASDF_FFMPEG_ENABLE = "gpl libx264"
 "go:github.com/atotto/clipboard/cmd/gopaste"                = "0.1.4"
 "go:github.com/go-delve/delve/cmd/dlv"                      = "1.27.0"
 "go:github.com/x-motemen/gore/cmd/gore"                     = "0.7.0"
-"http:tmux-continuum"                                       = { version = "3.1.0", url = "https://github.com/tmux-plugins/tmux-continuum/archive/refs/tags/v{{version}}.tar.gz", strip_components = 1 }
-"http:tmux-cpu"                                             = { version = "bcb110d754ab2417de824c464730c412a3eb2769", url = "https://github.com/tmux-plugins/tmux-cpu/archive/{{version}}.tar.gz", strip_components = 1 }    # renovate: branch=master
-"http:tmux-fingers"                                         = { version = "2.7.1", url = "https://github.com/Morantron/tmux-fingers/archive/refs/tags/{{version}}.tar.gz", strip_components = 1 }
-"http:tmux-fzf"                                             = { version = "4cbbbbde54e1b63712d77483b83075fd712d3bb5", url = "https://github.com/sainnhe/tmux-fzf/archive/{{version}}.tar.gz", strip_components = 1 }         # renovate: branch=master
-"http:tmux-resurrect"                                       = { version = "d05fd6696716bd2434c25155374dc36d21347db4", url = "https://github.com/ryo246912/tmux-resurrect/archive/{{version}}.tar.gz", strip_components = 1 } # renovate: branch=master
-"http:tmux-yank"                                            = { version = "2.3.0", url = "https://github.com/tmux-plugins/tmux-yank/archive/refs/tags/v{{version}}.tar.gz", strip_components = 1 }
+"http:tmux-continuum"                                       = { version = "3.1.0", url = "https://github.com/tmux-plugins/tmux-continuum/archive/refs/tags/v{{ version }}.tar.gz", strip_components = 1 }
+"http:tmux-cpu"                                             = { version = "bcb110d754ab2417de824c464730c412a3eb2769", url = "https://github.com/tmux-plugins/tmux-cpu/archive/{{ version }}.tar.gz", strip_components = 1 }    # renovate: branch=master
+"http:tmux-fingers"                                         = { version = "2.7.1", url = "https://github.com/Morantron/tmux-fingers/archive/refs/tags/{{ version }}.tar.gz", strip_components = 1 }
+"http:tmux-fzf"                                             = { version = "4cbbbbde54e1b63712d77483b83075fd712d3bb5", url = "https://github.com/sainnhe/tmux-fzf/archive/{{ version }}.tar.gz", strip_components = 1 }         # renovate: branch=master
+"http:tmux-resurrect"                                       = { version = "d05fd6696716bd2434c25155374dc36d21347db4", url = "https://github.com/ryo246912/tmux-resurrect/archive/{{ version }}.tar.gz", strip_components = 1 } # renovate: branch=master
+"http:tmux-yank"                                            = { version = "2.3.0", url = "https://github.com/tmux-plugins/tmux-yank/archive/refs/tags/v{{ version }}.tar.gz", strip_components = 1 }
 "npm:@devcontainers/cli"                                    = "0.88.0"
 "npm:@kitlangton/ghui"                                      = "0.9.0"
 "npm:agentlytics"                                           = "0.2.13"

--- a/dot_config/mise/tasks/dev.toml
+++ b/dot_config/mise/tasks/dev.toml
@@ -64,6 +64,7 @@ fi
 
 mkdir -p "$destination_dir"
 cp "$source_lock" "$destination_lock"
+chmod 0644 "$destination_lock"
 '''
 shell = "bash -c"
 

--- a/dot_config/zsh/lazy/function.zsh
+++ b/dot_config/zsh/lazy/function.zsh
@@ -24,7 +24,9 @@ _sync_dotfile_lock() {
   if ! cmp -s "$source_file" "$destination_file"; then
     local temporary_file
     temporary_file="$(mktemp "${destination_file}.XXXXXX")" || return 0
-    if ! cp -p "$source_file" "$temporary_file" || ! mv "$temporary_file" "$destination_file"; then
+    # mktemp と APM の lockfile は 0600 で作られることがある。chezmoi source
+    # では通常ファイルとして管理し、apply のたびに mode 差分が出ないよう正規化する。
+    if ! cp -p "$source_file" "$temporary_file" || ! chmod 0644 "$temporary_file" || ! mv "$temporary_file" "$destination_file"; then
       rm -f "$temporary_file"
       return 0
     fi


### PR DESCRIPTION
### Motivation

`apm install -g` can create `~/.apm/apm.lock.yaml` with mode `0600`. The zsh synchronization helper preserved that mode into the chezmoi source directory, so the next `chezmoi apply` proposed changing the deployed lockfile from `0600` to `0644`.

### Changes

- Normalize temporary synchronized lockfiles to `0644` before atomically moving them into the chezmoi source directory.
- Normalize the explicit `apm:sync-lock` task output to `0644` as well.
- Document why APM lockfile synchronization uses mode `0644`.
- Retain the current mise URL template syntax updates from the preceding commit.

### Testing

- Parsed all modified TOML files with Python `tomllib`.
- Executed the actual `apm:sync-lock` task body against a `0600` fixture and verified the synchronized file is `0644` with unchanged content.
- Confirmed no legacy mise `{{version}}` placeholders remain.
- Ran `git diff --check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize APM lockfile permissions to 0644 during sync so `chezmoi apply` stops proposing mode changes. Also updates docs and keeps `mise` URL template syntax using `{{ version }}` to silence deprecation warnings.

- **Bug Fixes**
  - zsh sync helper now chmods temporary lockfiles to 0644 before the atomic move.
  - `apm:sync-lock` task chmods the copied lockfile to 0644.
  - Added a note explaining why the synced `dot_apm/apm.lock.yaml` is 0644.
  - `mise` HTTP backend URLs updated to `{{ version }}` in `dot_config/mise/config.toml` and `dot_config/mise/config.mac.toml`.

<sup>Written for commit 7e8b4c857285b1501fc96f6152a42dbe8af3e283. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

