### PR TITLE
feat: add clipboard-free difit agent review loop

### DIFF
--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -3,7 +3,7 @@
 AI エージェントを devcontainer 内で実行するための共通基盤に関する設定をまとめます。
 devcontainer 定義は `dot_config/devcontainer/` を参照してください。
 
-`multi-worktree` や `crit`（docs/crit.md）など、この base template から起動する
+`multi-worktree`、`crit`（docs/crit.md）、`difit`（docs/difit.md）など、この base template から起動する
 devcontainer はいずれもここに書かれた仕組みを共有します。
 
 ## devcontainer 内での docker compose / DB コンテナ（DinD）

--- a/docs/difit.md
+++ b/docs/difit.md
@@ -1,0 +1,68 @@
+# difit
+
+[difit](https://github.com/yoshiko-pg/difit) は、ローカルの Git diff を GitHub 風の browser UI で確認し、
+review comment を AI agent へ直接返せる CLI ツールです。この構成では AI agent を devcontainer 内で
+実行し、`difit` skill から foreground server を起動して human review を待つ使い方を想定しています。
+
+## 結論: clipboard を介さない review loop
+
+現在の difit は、server 終了時に browser で入力された review comment を標準出力へ返します。
+upstream の `difit` skill はその process を foreground で待ち、comment が返った場合は agent に作業を
+継続して指摘へ対応するよう指示します。そのため「Copy Prompt」で clipboard へコピーして agent に
+貼り付ける操作は不要です。
+
+1. agent が変更を終えたら `difit .` を起動する
+2. agent は foreground process の終了を待つ
+3. user が host browser の diff へ comment を追加し、review を終了する
+4. difit が file / line と comment を標準出力へ返す
+5. agent がその出力を読み、修正して次の review round を起動する
+
+browser の「Copy Prompt」は手動連携用として残りますが、この loop では使用しません。crit の
+「Send to agent」のように別 agent process を起動する方式ではなく、**difit を起動した同じ agent turn が
+CLI の出力を受け取って再開する**方式です。
+
+## 構成
+
+| 項目         | 設定                                                       | 場所                                                       |
+| ------------ | ---------------------------------------------------------- | ---------------------------------------------------------- |
+| CLI          | `npm:difit@5.0.11` を mise で導入                          | `dot_config/devcontainer/mise.toml`                        |
+| skills       | upstream の `difit` / `difit-review` を release tag に pin | `dot_apm/apm.yml`                                          |
+| bind / port  | wrapper が `--host 0.0.0.0 --port 4966 --no-open` を追加   | `dot_config/devcontainer/scripts/executable_difit`         |
+| port publish | `127.0.0.1::4966`（host port は Docker が自動採番）        | `dot_config/devcontainer/devcontainer.json`                |
+| host URL     | `~/.difit-host-port` の実 port を wrapper が表示           | `dot_config/devcontainer/scripts/executable_post-start.sh` |
+
+## インストール
+
+```bash
+chezmoi apply
+mise run apm:install
+```
+
+適用後に devcontainer を rebuild してください。skills は Claude Code の `~/.claude/skills/` と、Codex・
+GitHub Copilot・Cursor が利用する `~/.agents/skills/` へ user scope で配置されます。
+
+## 使い方
+
+agent に review を依頼します。
+
+```text
+/difit を使って、現在の未コミット変更をレビューできるようにしてください。
+```
+
+```text
+$difit を使って、現在の未コミット変更をレビューできるようにしてください。
+```
+
+agent が表示する `difit UI (host): http://localhost:<自動採番port>` を browser で開いて comment を
+追加します。review を終了すると comment が agent に返り、agent はそれを基に修正を続けます。
+未追跡ファイルも対象にする場合は `difit . --include-untracked` を使います。
+
+`difit-review` は逆方向の用途で、agent 自身が diff / PR を review し、検出事項を `--comment` で
+あらかじめ UI に載せて user へ提示します。
+
+## 注意点
+
+- `--background` を付けると agent が process の終了と comment 出力を待てないため、この review loop では使いません。
+- browser を閉じるだけで comment がない場合、agent は「指摘なし」として終了します。
+- devcontainer を複数起動しても衝突しないよう、host port は固定していません。
+- comment に秘密情報を含めないでください。CLI 出力は agent の context に入ります。

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -3,6 +3,7 @@
 このページでは、`dot_apm/apm.yml` で導入している次の skill の使い方を説明します。
 
 - `crit` / `crit-cli`
+- `difit` / `difit-review`
 - `terminal-browser`
 - Tsumikiの14 skill
 - Ponytailの6 skill
@@ -51,6 +52,19 @@ $crit を使って、現在のgit diffをreviewできるようにしてくださ
 
 devcontainerでは`crit`を起動した後、表示されたhost側URLをbrowserで開きます。commentを送信するとエージェントが
 修正し、再reviewできます。CLIの構成やhost portの確認方法は[`docs/crit.md`](crit.md)を参照してください。
+
+## `difit` / `difit-review`
+
+`difit`は変更後にhuman reviewを依頼するskillです。browserで入力したcommentはserver終了時に標準出力へ返るため、
+clipboardへのprompt copyなしで、起動元のagentが指摘を受け取り修正を続けます。`difit-review`はagent側のreview結果を
+commentとしてUIへ事前投入し、人間へ提示するskillです。
+
+```text
+$difit を使って、現在の未コミット変更をレビューできるようにしてください。
+```
+
+devcontainerではagentが表示するhost側URLを開き、commentを追加してreviewを終了します。foreground processを待っていた
+agentがcommentを受け取ります。構成とcritとの違いは[`docs/difit.md`](difit.md)を参照してください。
 
 ## `terminal-browser`
 

--- a/dot_apm/apm.lock.yaml
+++ b/dot_apm/apm.lock.yaml
@@ -1502,6 +1502,50 @@ dependencies:
     .claude/skills/terminal-browser/SKILL.md: sha256:7ed3df98ee157d39d488423df2c842b113ad03b04d3a920a49d123fb5d4b6b2c
     .claude/skills/terminal-browser/SKILL.template.md: sha256:1ba1350404b762fe869cdcdf8658b0f0d1dd29d1a90a53d734b6bce77c2e1f47
   content_hash: sha256:ed3bc98ffc87d95320c8ec6064e53e4e27f8737d622cfd76d7645a53b725b396
+- repo_url: yoshiko-pg/difit
+  name: difit
+  host: github.com
+  resolved_commit: e4023997f359375cc48fcea71828a528466ac751
+  resolved_ref: v5.0.11
+  version: unknown
+  virtual_path: skills/difit
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .agents/skills/difit
+  - .agents/skills/difit/SKILL.md
+  - .agents/skills/difit/agents/openai.yaml
+  - .claude/skills/difit
+  - .claude/skills/difit/SKILL.md
+  - .claude/skills/difit/agents/openai.yaml
+  deployed_file_hashes:
+    .agents/skills/difit/SKILL.md: sha256:8171ee2b19d85ba4702e4a0d190e63803ec9d5e91416530c78a63ba86808c97b
+    .agents/skills/difit/agents/openai.yaml: sha256:305d35f2ee4dda20d4c7fbe1eb18fda366f3e84d9ff84b2111d4faa3a608007f
+    .claude/skills/difit/SKILL.md: sha256:8171ee2b19d85ba4702e4a0d190e63803ec9d5e91416530c78a63ba86808c97b
+    .claude/skills/difit/agents/openai.yaml: sha256:305d35f2ee4dda20d4c7fbe1eb18fda366f3e84d9ff84b2111d4faa3a608007f
+  content_hash: sha256:d7183ec34bc1b776e8e54cf34efd1bf8be8b04bdb424e5efcfbb3faa5f095db7
+- repo_url: yoshiko-pg/difit
+  name: difit-review
+  host: github.com
+  resolved_commit: e4023997f359375cc48fcea71828a528466ac751
+  resolved_ref: v5.0.11
+  version: unknown
+  virtual_path: skills/difit-review
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .agents/skills/difit-review
+  - .agents/skills/difit-review/SKILL.md
+  - .agents/skills/difit-review/agents/openai.yaml
+  - .claude/skills/difit-review
+  - .claude/skills/difit-review/SKILL.md
+  - .claude/skills/difit-review/agents/openai.yaml
+  deployed_file_hashes:
+    .agents/skills/difit-review/SKILL.md: sha256:5ff1e4bafafe1c5bc21c686d78a435faa0a33802d175b08ae849f10ccd962902
+    .agents/skills/difit-review/agents/openai.yaml: sha256:8436c3a9d6f88c3c2852856f4a1cf4be19ca2f3f44bc5d629d43612ba57ab70b
+    .claude/skills/difit-review/SKILL.md: sha256:5ff1e4bafafe1c5bc21c686d78a435faa0a33802d175b08ae849f10ccd962902
+    .claude/skills/difit-review/agents/openai.yaml: sha256:8436c3a9d6f88c3c2852856f4a1cf4be19ca2f3f44bc5d629d43612ba57ab70b
+  content_hash: sha256:327e7d90c9e01ad1519e8e12282ffae8ad4eaac5ecd3bfe128f950f35ca9e335
 deployments:
 - kind: project-relative
   target: claude
@@ -7929,3 +7973,111 @@ deployments:
   - dietrichgebert/ponytail
   active_owner: dietrichgebert/ponytail
   content_hash: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e
+- kind: project-relative
+  target: claude
+  value: .claude/skills/difit
+  runtime: null
+  scope: project
+  owners:
+  - yoshiko-pg/difit/skills/difit
+  active_owner: yoshiko-pg/difit/skills/difit
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/difit-review
+  runtime: null
+  scope: project
+  owners:
+  - yoshiko-pg/difit/skills/difit-review
+  active_owner: yoshiko-pg/difit/skills/difit-review
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/difit-review/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - yoshiko-pg/difit/skills/difit-review
+  active_owner: yoshiko-pg/difit/skills/difit-review
+  content_hash: sha256:5ff1e4bafafe1c5bc21c686d78a435faa0a33802d175b08ae849f10ccd962902
+- kind: project-relative
+  target: claude
+  value: .claude/skills/difit-review/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - yoshiko-pg/difit/skills/difit-review
+  active_owner: yoshiko-pg/difit/skills/difit-review
+  content_hash: sha256:8436c3a9d6f88c3c2852856f4a1cf4be19ca2f3f44bc5d629d43612ba57ab70b
+- kind: project-relative
+  target: claude
+  value: .claude/skills/difit/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - yoshiko-pg/difit/skills/difit
+  active_owner: yoshiko-pg/difit/skills/difit
+  content_hash: sha256:8171ee2b19d85ba4702e4a0d190e63803ec9d5e91416530c78a63ba86808c97b
+- kind: project-relative
+  target: claude
+  value: .claude/skills/difit/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - yoshiko-pg/difit/skills/difit
+  active_owner: yoshiko-pg/difit/skills/difit
+  content_hash: sha256:305d35f2ee4dda20d4c7fbe1eb18fda366f3e84d9ff84b2111d4faa3a608007f
+- kind: project-relative
+  target: codex
+  value: .agents/skills/difit
+  runtime: null
+  scope: project
+  owners:
+  - yoshiko-pg/difit/skills/difit
+  active_owner: yoshiko-pg/difit/skills/difit
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/difit-review
+  runtime: null
+  scope: project
+  owners:
+  - yoshiko-pg/difit/skills/difit-review
+  active_owner: yoshiko-pg/difit/skills/difit-review
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/difit-review/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - yoshiko-pg/difit/skills/difit-review
+  active_owner: yoshiko-pg/difit/skills/difit-review
+  content_hash: sha256:5ff1e4bafafe1c5bc21c686d78a435faa0a33802d175b08ae849f10ccd962902
+- kind: project-relative
+  target: codex
+  value: .agents/skills/difit-review/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - yoshiko-pg/difit/skills/difit-review
+  active_owner: yoshiko-pg/difit/skills/difit-review
+  content_hash: sha256:8436c3a9d6f88c3c2852856f4a1cf4be19ca2f3f44bc5d629d43612ba57ab70b
+- kind: project-relative
+  target: codex
+  value: .agents/skills/difit/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - yoshiko-pg/difit/skills/difit
+  active_owner: yoshiko-pg/difit/skills/difit
+  content_hash: sha256:8171ee2b19d85ba4702e4a0d190e63803ec9d5e91416530c78a63ba86808c97b
+- kind: project-relative
+  target: codex
+  value: .agents/skills/difit/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - yoshiko-pg/difit/skills/difit
+  active_owner: yoshiko-pg/difit/skills/difit
+  content_hash: sha256:305d35f2ee4dda20d4c7fbe1eb18fda366f3e84d9ff84b2111d4faa3a608007f

--- a/dot_apm/apm.yml
+++ b/dot_apm/apm.yml
@@ -17,6 +17,15 @@ dependencies:
     # crit（tomasz-tomczyk/crit プラグイン）。devcontainer 固有のグルーは crit ラッパーに分離済み。
     - tomasz-tomczyk/crit/integrations/claude-code/skills/crit#v0.18.2
     - tomasz-tomczyk/crit/integrations/claude-code/skills/crit-cli#v0.18.2
+    # difit: browser review comments are returned directly to the waiting agent process.
+    - git: yoshiko-pg/difit
+      path: skills/difit
+      ref: v5.0.11
+      alias: difit
+    - git: yoshiko-pg/difit
+      path: skills/difit-review
+      ref: v5.0.11
+      alias: difit-review
     # virtual package の既定名 terminal-browser-skill ではなく、skill 名と同じ配置名にする。
     - git: zenbu-labs/terminal-browser
       path: skill

--- a/dot_config/devcontainer/Dockerfile
+++ b/dot_config/devcontainer/Dockerfile
@@ -20,9 +20,9 @@ ENV MISE_STATE_DIR=/mise/state
 ENV MISE_CACHE_DIR=/mise/cache
 # MEMO : postStartCommandではPATHが通らないためこちらで直接PATH(/mise/data/shims)を指定
 ENV PATH=/mise/data/shims:/mise/shims:/mise/installs:$PATH
-# crit ラッパー（~/.config/devcontainer/scripts/crit, bind-mount）を mise shim より
-# 前に置き、pristine な crit skill の `crit` 呼び出しがラッパー経由になるようにする。
-# 詳細は docs/crit.md 参照。
+# review tool ラッパー（crit / difit、bind-mount）を mise shim より前に置き、
+# pristine な upstream skill の CLI 呼び出しへ devcontainer 固有の設定を追加する。
+# 詳細は docs/crit.md と docs/difit.md を参照。
 ENV PATH=/home/vscode/.config/devcontainer/scripts:$PATH
 
 RUN install -d -o vscode -g vscode \

--- a/dot_config/devcontainer/devcontainer.json
+++ b/dot_config/devcontainer/devcontainer.json
@@ -26,14 +26,14 @@
     // crit: コンテナ内では更新チェック不要のため無効化
     "CRIT_NO_UPDATE_CHECK": "1"
   },
-  // crit のレビューUIをホストのブラウザから開けるようにポートを公開する。
+  // crit と difit のレビューUIをホストのブラウザから開けるようにポートを公開する。
   // multi-worktree は devcontainer CLI (`devcontainer up`) で起動するが、CLI は forwardPorts を
   // 解釈しない(VS Code拡張専用)ため、実際に publish される appPort (= docker run -p) を使う。
   // ホストの loopback のみに束縛する。host port は固定せず Docker に自動採番させる
   // (devcontainer を複数同時起動してもポート衝突が起きないようにするため)。
-  // 実際に割り当てられた host port は post-start.sh が ~/.crit-host-port に書き出し、
-  // ホストへ通知する（docs/crit.md 参照）。
-  "appPort": ["127.0.0.1::7842"],
+  // 実際に割り当てられた host port は post-start.sh が各ツールの host-port file に書き出し、
+  // ホストへ通知する（docs/crit.md、docs/difit.md 参照）。
+  "appPort": ["127.0.0.1::7842", "127.0.0.1::4966"],
   // localWorkspaceFolder: ホスト側の作業ディレクトリ(.git/wk/{project}-{branch})を指す
   // "workspaceFolder": "${localWorkspaceFolder}",
   "mounts": [

--- a/dot_config/devcontainer/mise.toml
+++ b/dot_config/devcontainer/mise.toml
@@ -21,6 +21,7 @@ experimental = true
 "github:tomasz-tomczyk/crit"     = "0.18.2"
 "npm:@typescript/native-preview" = "7.0.0-dev.20260519.1"
 "npm:ccusage"                    = "20.0.1"
+"npm:difit"                      = "5.0.11"
 "npm:oxfmt"                      = "0.59.0"
 "npm:oxlint"                     = "1.76.0"
 

--- a/dot_config/devcontainer/scripts/executable_difit
+++ b/dot_config/devcontainer/scripts/executable_difit
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# difit の upstream skill を変更せず、devcontainer 固有の bind / URL 設定を追加する。
+set -uo pipefail
+
+real_difit="$(mise which difit 2>/dev/null || true)"
+if [ -z "${real_difit}" ]; then
+	echo "difit: real binary not found (is difit installed via mise?)" >&2
+	exit 127
+fi
+
+# Docker が自動採番した host port をエージェントとユーザーへ知らせる。
+host_port_file="${HOME}/.difit-host-port"
+if [ -s "${host_port_file}" ]; then
+	printf 'difit UI (host): http://localhost:%s\n' "$(cat "${host_port_file}")"
+fi
+
+# コンテナ内では browser を開かず、appPort が公開する全 interface で待ち受ける。
+# foreground のまま実行することで、終了時に difit が出力する review comments を
+# 呼び出し元の AI agent が直接受け取り、そのまま修正へ進める。
+exec "${real_difit}" "$@" --host 0.0.0.0 --port 4966 --no-open

--- a/dot_config/devcontainer/scripts/executable_post-start.sh
+++ b/dot_config/devcontainer/scripts/executable_post-start.sh
@@ -22,39 +22,35 @@ fi
 mise trust
 echo "✓ mise trust を実行しました"
 
-# crit の appPort (127.0.0.1::7842) は host port を Docker に自動採番させているため、
-# 実際に割り当てられた port を mac-host 経由の `docker port` で調べ、
-# ~/.crit-host-port に記録した上でホストへ通知する（devcontainer を複数同時起動しても
-# ポート衝突が起きないようにするため。詳細は docs/crit.md 参照）。
-# HOSTNAME はコンテナの short ID（Docker のデフォルトのホスト名）と一致する。
-#
-# SSH オプションについて:
-# - BatchMode=yes: 鍵認証が使えない場合にパスワード入力待ちで固まらないようにする
-# - StrictHostKeyChecking は指定しない: ~/.config/ssh/config の mac-host 側で
-#   accept-new を設定済みのため、ここで no を指定すると host key の変更検知が無効化されてしまう
-# - timeout でラップ: ConnectTimeout は接続確立までしかカバーしないため、接続後に
-#   リモートコマンドが固まった場合に備える
-CRIT_HOST_PORT_FILE=~/.crit-host-port
+# review UI の appPort は host port を Docker に自動採番させているため、
+# 実際の port を mac-host 経由で取得してファイルへ記録し、ホストへ通知する。
+# SSH は非対話・timeout 付きにして、devcontainer 外では静かにスキップする。
 SSH_OPTS=(-F ~/.config/ssh/config -o BatchMode=yes -o ConnectTimeout=2)
 
-# docker port の取得はネットワークの一時的な不調で失敗することがあるため数回リトライする。
-# （再起動直後で docker port さえ引ければ port 番号自体は同一コンテナである限り変わらないため、
-# 一時的な失敗で ~/.crit-host-port を消して有効なキャッシュを失わないようにする）
-CRIT_HOST_PORT=""
-for _ in 1 2; do
-	CRIT_HOST_PORT=$(timeout 5 ssh "${SSH_OPTS[@]}" mac-host \
-		"docker port '${HOSTNAME}' 7842/tcp" 2>/dev/null | tail -n1 | sed -E 's/.*://') || true
-	[ -n "$CRIT_HOST_PORT" ] && break
-	sleep 1
-done
+record_review_port() { # $1: tool name, $2: container port
+	local tool="$1" container_port="$2"
+	local host_port_file="${HOME}/.${tool}-host-port"
+	local host_port=""
 
-if [ -n "$CRIT_HOST_PORT" ]; then
-	echo "$CRIT_HOST_PORT" >"$CRIT_HOST_PORT_FILE"
-	timeout 5 ssh "${SSH_OPTS[@]}" mac-host \
-		"macos-notify-cli --title 'crit' --message 'crit UI: http://localhost:${CRIT_HOST_PORT}' --sound Glass" \
-		2>/dev/null || true
-	echo "✓ crit の host port (${CRIT_HOST_PORT}) を ${CRIT_HOST_PORT_FILE} に記録し、ホストへ通知しました"
-else
-	rm -f "$CRIT_HOST_PORT_FILE"
-	echo "ℹ️ crit の host port 取得をスキップしました（devcontainer 外、または mac-host に接続できない環境）"
-fi
+	# 一時的な SSH failure で有効な cache を失わないよう retry する。
+	for _ in 1 2; do
+		host_port=$(timeout 5 ssh "${SSH_OPTS[@]}" mac-host \
+			"docker port '${HOSTNAME}' ${container_port}/tcp" 2>/dev/null | tail -n1 | sed -E 's/.*://') || true
+		[ -n "$host_port" ] && break
+		sleep 1
+	done
+
+	if [ -n "$host_port" ]; then
+		echo "$host_port" >"$host_port_file"
+		timeout 5 ssh "${SSH_OPTS[@]}" mac-host \
+			"macos-notify-cli --title '${tool}' --message '${tool} UI: http://localhost:${host_port}' --sound Glass" \
+			2>/dev/null || true
+		echo "✓ ${tool} の host port (${host_port}) を ${host_port_file} に記録し、ホストへ通知しました"
+	else
+		rm -f "$host_port_file"
+		echo "ℹ️ ${tool} の host port 取得をスキップしました（devcontainer 外、または mac-host に接続できない環境）"
+	fi
+}
+
+record_review_port crit 7842
+record_review_port difit 4966


### PR DESCRIPTION
## Summary
- install difit v5.0.11 and its upstream `difit` / `difit-review` skills
- expose difit's devcontainer UI through a dynamically allocated localhost port
- add a wrapper that keeps difit in the foreground so review comments return directly to the waiting AI agent
- document the clipboard-free human review and revision loop

## Testing
- `mise run lint:toml`
- `mise run lint:json`
- `mise run lint:md`
- `mise x aqua:koalaman/shellcheck -- shellcheck dot_config/devcontainer/scripts/executable_difit dot_config/devcontainer/scripts/executable_post-start.sh`
- wrapper smoke test with fake `mise` / `difit` executables
- APM frozen-install check (difit resolved and integrated; existing terminal-browser upstream package validation warning remains)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a clipboard-free review loop with `difit` in the devcontainer. Browser comments return directly to the waiting agent process, so no prompt copy/paste is needed.

- New Features
  - Install `npm:difit@5.0.11` and add upstream `difit` / `difit-review` skills.
  - Add a `difit` wrapper that runs in the foreground with `--host 0.0.0.0 --port 4966 --no-open` and prints the host URL from `~/.difit-host-port`.
  - Publish `127.0.0.1::4966` and record/notify host ports for both `crit` and `difit` in post-start.
  - Docs: new `docs/difit.md`; updates to `docs/skill.md` and `docs/devcontainer.md`.

- Dependencies
  - Add `npm:difit` 5.0.11 to `mise.toml`.
  - Pin `yoshiko-pg/difit` skills (`difit`, `difit-review`) at `v5.0.11` in `dot_apm/apm.yml` (lockfile updated).

<sup>Written for commit 2e5d3e44f868ac388b545deb2351bd961f21877a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

`difit` v5.0.11 と `difit-review` skill を追加しました。  
devcontainer で `difit` UI を動的なホストポートに公開しました。  
レビューコメントを待機中の AI agent に返す foreground wrapper を追加しました。  
人によるレビューと修正の手順を文書化しました。

## 変更理由

clipboard を使わずに、AI agent と人によるレビューを反復できるようにするためです。  
`crit` と `difit` のポート情報を共通処理し、devcontainer から各 UI に接続できるようにしました。

## 確認した項目

- TOML、JSON、Markdown の検証
- ShellCheck
- `difit` wrapper の smoke test
- APM frozen-install check

<!-- end of auto-generated comment: release notes by coderabbit.ai -->