### PR TITLE
Update apm.yml

### DIFF
--- a/dot_apm/apm.yml
+++ b/dot_apm/apm.yml
@@ -14,7 +14,7 @@ dependencies:
   # 再現性のため各依存をコミット SHA または release tag に pin する。
   # CLI も配布するリポジトリは release tag を使い、Renovate で同一PRにまとめる。
   apm:
-    # crit（tomasz-tomczyk/crit プラグイン）。devcontainer 固有のグルーは crit ラッパーに分離済み。
+    # crit（tomasz-tomczyk/crit プラグイン）。
     - tomasz-tomczyk/crit/integrations/claude-code/skills/crit#v0.18.2
     - tomasz-tomczyk/crit/integrations/claude-code/skills/crit-cli#v0.18.2
     # virtual package の既定名 terminal-browser-skill ではなく、skill 名と同じ配置名にする。
@@ -26,8 +26,6 @@ dependencies:
     - git: classmethod/tsumiki
       ref: 9a0a2348ebf1cb83b7cf91adfe2ffff28be02525
       alias: tsumiki
-
-    # ctx CLI と同じ release tag に pin して、Renovate では同一PRで更新する。
     - git: ctxrs/ctx
       path: skills/ctx-agent-history-search
       ref: v0.25.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up comments in `dot_apm/apm.yml` to clarify the `tomasz-tomczyk/crit` plugin reference and remove outdated guidance; no changes to dependencies or versions.

<sup>Written for commit 119e204714ba1f8247930240c1efc8a1d76f4918. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
`apm.yml` 内の依存関係に関するコメントを整理しました。依存関係の設定は変更していません。

## 変更理由
不要になった補足コメントを削除し、設定内容を簡潔にしました。

## 確認した項目
- `crit` と `ctx` の依存関係設定に変更がないこと
- 公開エンティティに変更がないこと

<!-- end of auto-generated comment: release notes by coderabbit.ai -->