### PR TITLE
fix(gh): select skills once for all agents

### DIFF
--- a/docs/gh.md
+++ b/docs/gh.md
@@ -6,7 +6,8 @@
 `gh skill`、常時使う外部 skill は APM で管理する方針にします。
 
 `gh:skill-install-all` は GitHub Copilot / Cursor / Codex / Claude Code に user scope でまとめて install する
-mise task です。複数の `--agent` を 1 回の `gh skill install` に渡すため、skill の対話選択も 1 回だけで済みます。
+mise task です。skill を省略した場合は一時 directory への install で対話選択を 1 回だけ行い、選択結果を各 agent
+へ配布します（`gh skill install` の `--agent` は単一値のため、実際の配布処理は agent ごとに実行します）。
 
 ```bash
 mise run gh:skill-install-all github/awesome-copilot git-commit

--- a/docs/gh.md
+++ b/docs/gh.md
@@ -6,7 +6,7 @@
 `gh skill`、常時使う外部 skill は APM で管理する方針にします。
 
 `gh:skill-install-all` は GitHub Copilot / Cursor / Codex / Claude Code に user scope でまとめて install する
-mise task です。
+mise task です。複数の `--agent` を 1 回の `gh skill install` に渡すため、skill の対話選択も 1 回だけで済みます。
 
 ```bash
 mise run gh:skill-install-all github/awesome-copilot git-commit

--- a/tasks/gh.toml
+++ b/tasks/gh.toml
@@ -63,10 +63,10 @@ if not has_pin:
 
     pin_args = ["--pin", resolved_ref]
 
-for agent in AGENTS:
-    subprocess.run(
-        ["gh", "skill", "install", repo, *install_args, "--agent", agent, "--scope", "user", *pin_args],
-        check=True,
-    )
+agent_args = [arg for agent in AGENTS for arg in ("--agent", agent)]
+subprocess.run(
+    ["gh", "skill", "install", repo, *install_args, *agent_args, "--scope", "user", *pin_args],
+    check=True,
+)
 ' "$@"
 '''

--- a/tasks/gh.toml
+++ b/tasks/gh.toml
@@ -5,7 +5,9 @@ python3 -c '
 import shutil
 import subprocess
 import sys
+import tempfile
 import urllib.parse
+from pathlib import Path
 
 AGENTS = ["github-copilot", "cursor", "codex", "claude-code"]
 
@@ -63,10 +65,38 @@ if not has_pin:
 
     pin_args = ["--pin", resolved_ref]
 
-agent_args = [arg for agent in AGENTS for arg in ("--agent", agent)]
-subprocess.run(
-    ["gh", "skill", "install", repo, *install_args, *agent_args, "--scope", "user", *pin_args],
-    check=True,
-)
+skill_is_explicit = bool(install_args and not install_args[0].startswith("-"))
+all_skills = "--all" in install_args
+
+if not skill_is_explicit and not all_skills:
+    with tempfile.TemporaryDirectory(prefix="gh-skill-install-") as staging_dir:
+        subprocess.run(
+            ["gh", "skill", "install", repo, *install_args, "--dir", staging_dir, *pin_args],
+            check=True,
+        )
+
+        selected_paths = []
+        for skill_file in sorted(Path(staging_dir).glob("*/SKILL.md")):
+            for line in skill_file.read_text(encoding="utf-8").splitlines():
+                if line.lstrip().startswith("github-path:"):
+                    selected_paths.append(line.split(":", 1)[1].strip().strip("\\\"\x27"))
+                    break
+
+        if not selected_paths:
+            print("Error: could not determine the selected skill path(s).", file=sys.stderr)
+            sys.exit(1)
+
+        for skill_path in selected_paths:
+            for agent in AGENTS:
+                subprocess.run(
+                    ["gh", "skill", "install", repo, skill_path, *install_args, "--agent", agent, "--scope", "user", *pin_args],
+                    check=True,
+                )
+else:
+    for agent in AGENTS:
+        subprocess.run(
+            ["gh", "skill", "install", repo, *install_args, "--agent", agent, "--scope", "user", *pin_args],
+            check=True,
+        )
 ' "$@"
 '''


### PR DESCRIPTION
## Summary
- invoke `gh skill install` once with all supported `--agent` flags
- document that interactive skill selection now occurs only once

## Testing
- parsed `tasks/gh.toml` with Python `tomllib`
- exercised the task script with a mock `gh` and verified all four agents are passed in one invocation
- ran `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs interactive skill selection once in `gh:skill-install-all` and distributes the chosen skills to all agents. Previously each agent prompted separately; now we stage the selection in a temp directory and re-install the selected skills per agent. User scope, pinning, and task inputs are unchanged.

- `tasks/gh.toml`: when no explicit skill and not `--all`, call `gh skill install --dir <tmp>` once, parse selected `github-path` from `SKILL.md`, then install those skills for each agent with `--agent <agent> --scope user` and existing pin args. Fall back to the per‑agent loop when skills are provided or `--all` is set. Exit with an error if no selected paths are found.
- `docs/gh.md`: document the single interactive selection and per‑agent distribution because `--agent` accepts a single value.

<sup>Written for commit d5f9cf7a93e5c7126ee1400caad41441f0cd004e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
`gh:skill-install-all` が全エージェント向けの `--agent` フラグをまとめて指定し、`gh skill install` を1回だけ実行するように変更しました。ユーザースコープ、追加引数、ピン指定は維持します。ドキュメントも更新しました。

## 変更理由
対話形式のスキル選択を1回だけ実行し、複数エージェントへのインストールを効率化するためです。

## 確認した項目
- `tomllib` による設定検証
- `gh` コマンドをモックした動作検証
- `git diff --check` による差分検証

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes `gh:skill-install-all` so an omitted skill is selected once in a temporary directory and then installed for each supported agent.
- Extracts selected skill paths from staged `SKILL.md` metadata.
- Retains per-agent installation, user scope, and pin resolution.
- Documents the single interactive-selection workflow.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tasks/gh.toml | Adds temporary staging and selected-path replay so interactive selection occurs once before installation for all four agents. |
| docs/gh.md | Documents the staging-based single-selection behavior and continued per-agent distribution. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(gh): distribute selected skills to e..."](https://github.com/ryo246912/dotfiles/commit/d5f9cf7a93e5c7126ee1400caad41441f0cd004e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52459572)</sub>

**Context used:**

- Knowledge Base — [Package and Tool Version Management](https://app.greptile.com/ryo/-/custom-context/knowledge-base/ryo246912/dotfiles/-/docs/package-management.md)

<!-- /greptile_comment -->