### PR TITLE
feat: rulesync feedback hooksの運用を整備

### DIFF
--- a/docs/rulesync.md
+++ b/docs/rulesync.md
@@ -102,6 +102,46 @@ mise run rulesync:generate
 
 どちらかのスコープが未初期化でも、もう片方の生成を止めないように warning を出して skip します。
 
+## 会話のフィードバックからルール候補を作る hook
+
+[Claude Code の Hooks でフィードバックを残す仕組み](https://zenn.dev/nozomi720/articles/claude_code_hooks_feedback)
+を参考に、会話履歴から再利用可能なルール追記候補・スキル化候補を作る hook をグローバル設定に含めています。
+既存ルールを直接増やし続ける方式ではなく、候補を一度確認してから rulesync の正本へ反映する方式です。
+
+### 配布と devcontainer 内での実行
+
+1. `dot_config/rulesync/exact_dot_rulesync/hooks.json` を rulesync の hook source とする。
+2. `chezmoi apply` と `mise run rulesync:generate` により Claude Code の user scope へ hook を生成する。
+3. devcontainer はホストの `~/.claude` と `~/.config/devcontainer/scripts` を bind mount するため、コンテナ内で
+   起動した Claude Code も同じ hook 設定と runner を使用する。
+4. `SessionEnd` / `PreCompact` で runner が transcript の末尾を読み、別の非対話 Claude プロセスで候補を生成する。
+   再帰実行は `AI_RULE_HOOK_RUNNING` で防止する。
+
+候補は自動でルールへ追記しません。セッション別の結果は
+`${XDG_STATE_HOME:-$HOME/.local/state}/ai-rule-hook/claude/<session>/`、最新の結果は
+`${XDG_STATE_HOME:-$HOME/.local/state}/ai-rule-hook/claude/latest.md` で確認できます。採用する場合は、グローバル
+ルールなら `dot_config/rulesync/exact_dot_rulesync/rules/COMMON.md`、定型作業なら同ディレクトリ配下の
+`skills/<name>/SKILL.md` に反映し、再度 `chezmoi apply` と `mise run rulesync:generate` を実行してください。
+
+hook runner は transcript とルールの読み込み量に上限を設け、秘密情報・個人情報・一時的な事情を候補から除外する
+prompt を使用します。それでも transcript を外部の AI CLI へ渡す処理であるため、無効化したい場合は
+rulesync source の `sessionEnd` / `preCompact` を削除して再生成してください。
+
+### 動作確認
+
+AI を呼び出さず payload の解釈と生成対象を確認できます。
+
+```bash
+transcript=$(mktemp)
+printf '%s\n' '{"type":"user","message":{"role":"user","content":"test"}}' >"$transcript"
+jq -nc --arg transcript "$transcript" \
+  '{hook_event_name:"SessionEnd",session_id:"smoke-test",transcript_path:$transcript}' \
+  | AI_RULE_HOOK_DRY_RUN=1 ~/.config/devcontainer/scripts/ai-rule-hook.sh --tool claude
+rm -f "$transcript"
+```
+
+`should_run` が `true` になり、`canonical_event` が `session_end` なら hook payload は認識されています。
+
 ## トラブルシューティング
 
 ### `.rulesync directory not found. Run 'rulesync init' first.`

--- a/dot_config/devcontainer/scripts/executable_ai-rule-hook.sh
+++ b/dot_config/devcontainer/scripts/executable_ai-rule-hook.sh
@@ -22,6 +22,7 @@
 #
 # 注意:
 #   - ルール・スキルを自動で書き換えることはしない。suggestion.md を確認して手動転記する。
+#   - 最新の候補は ${STATE_ROOT}/<tool>/latest.md から確認できる。
 #   - ドライラン: AI_RULE_HOOK_DRY_RUN=1 でデバッグ用 JSON を出力（AI は呼ばない）
 #   - ステート保存先: ${XDG_STATE_HOME:-~/.local/state}/ai-rule-hook/<tool>/<session>/
 #
@@ -143,6 +144,17 @@ write_json() {
 	local payload="$2"
 
 	printf '%s\n' "$payload" >"$path"
+}
+
+publish_latest_suggestion() {
+	local suggestion_path="$1"
+	local tool_state_dir="${STATE_ROOT}/${TOOL}"
+	local latest_tmp="${tool_state_dir}/.latest.md.tmp.$$"
+
+	# 同じ tool の別 session が同時に終了しても、読み手に途中までのファイルを見せない。
+	mkdir -p "$tool_state_dir"
+	cp "$suggestion_path" "$latest_tmp"
+	mv -f "$latest_tmp" "${tool_state_dir}/latest.md"
 }
 
 tool_paths() {
@@ -517,7 +529,8 @@ if ((DRY_RUN == 1)); then
 fi
 
 if run_analysis "$PROMPT_OUTPUT_PATH" "$ANALYSIS_OUTPUT_PATH" "$ANALYSIS_STDERR_PATH"; then
-	log "wrote suggestion: $ANALYSIS_OUTPUT_PATH"
+	publish_latest_suggestion "$ANALYSIS_OUTPUT_PATH"
+	log "wrote suggestion: $ANALYSIS_OUTPUT_PATH (latest: ${STATE_ROOT}/${TOOL}/latest.md)"
 	if [[ "$TOOL" == "codex" ]] && [[ "$CANONICAL_EVENT" == "stop" ]]; then
 		jq -n --argjson last_lines "$CODEX_STOP_CURRENT_LINES" '{last_lines: $last_lines}' \
 			>"${SESSION_STATE_DIR}/codex-stop-state.json"


### PR DESCRIPTION
## 概要

- rulesyncで配布する会話フィードバックhookの構成とdevcontainer内での動作を文書化
- セッションごとの候補に加え、最新候補を安定した `latest.md` から確認できるように変更
- AIを起動しないdry-run確認手順を追加

## テスト

- `bash -n dot_config/devcontainer/scripts/executable_ai-rule-hook.sh`
- `shellcheck dot_config/devcontainer/scripts/executable_ai-rule-hook.sh`
- fake Claude CLIを使ったSessionEnd hookの動作確認と`latest.md`の内容比較
- `mise run lint:md`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
会話フィードバック用の `rulesync` hook の運用を整理し、最新候補を安定の `latest.md` で参照できるようにしました。従来はセッション別パスのみでしたが、これからは `SessionEnd`/`PreCompact` 時に最新候補も公開します。

**レビューと展開の要点**
- 仕様変更: セッション別候補に加え、`${XDG_STATE_HOME:-~/.local/state}/ai-rule-hook/<tool>/latest.md` を発行。原子的な置換で部分書き込みを防止し、同一ツールでの並行終了にも耐性あり。ルール/スキルは自動更新しない。
- 実装: `executable_ai-rule-hook.sh` に `publish_latest_suggestion` を追加し、分析成功時に呼び出し。ログへ `latest.md` のパスを出力。再帰防止は `AI_RULE_HOOK_RUNNING` を継続使用。
- ドキュメント: `docs/rulesync.md` に hook 構成、`devcontainer` での実行、出力場所、乾式確認（`AI_RULE_HOOK_DRY_RUN=1`）を追記。配布元 `hooks.json` と生成手順（`chezmoi apply` → `mise run rulesync:generate`）を明記。
- 運用/無効化: 採用は手動で `dot_config/rulesync/exact_dot_rulesync/rules/COMMON.md` または `skills/<name>/SKILL.md` へ転記後、`chezmoi apply` と `mise run rulesync:generate` を実行。無効化は `hooks.json` source の `sessionEnd`/`preCompact` を削除して再生成。

<sup>Written for commit 1fff4902e0cf9181068bd5b4ac8b21a8df6b86ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

- rulesyncの会話フィードバックhookの構成と運用手順を文書化しました。
- 最新の提案をツール単位の`latest.md`で確認できるようにしました。
- AIを起動しない`SessionEnd` payloadのdry-run手順を追加しました。
- hookの配布経路、再帰防止、候補の保存・反映方法、transcriptの制限と無効化方法を記載しました。

## 変更理由

- rulesyncで配布するフィードバックhookの運用方法を明確にするためです。
- セッション単位の候補に加えて、最新候補を安定したパスから確認できるようにするためです。
- devcontainer内で安全にhookの動作を確認できるようにするためです。

## 確認した項目

- `bash -n`
- `shellcheck`
- fake Claude CLIによる`SessionEnd` hookの動作確認
- `mise run lint:md`
- `git diff --check`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->