### PR TITLE
fix: support chezmoi versions without shellQuote

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -14,7 +14,7 @@ args = [
 # install マーカー保存用の XDG state を用意（永続化）。
 state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/chezmoi"
 mkdir -p "$state_dir" || exit 1
-source_dir="$(chezmoi source-path)"
+source_dir=$CHEZMOI_SOURCE_DIR
 mise_hash=$(cat "$HOME/.config/mise/config"*.toml 2>/dev/null | (command -v sha1sum >/dev/null && sha1sum || shasum -a 1))
 # post-apply hook は run_once の PATH 変更を引き継がないため、mise 本体と aqua/gh 用の
 # mise shims を PATH に通す。mise 本体は mac/linux とも https://mise.run 経由で ~/.local/bin に導入するため、~/.local/bin を先頭にする。mise shims は

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -14,7 +14,7 @@ args = [
 # install マーカー保存用の XDG state を用意（永続化）。
 state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/chezmoi"
 mkdir -p "$state_dir" || exit 1
-source_dir={{ .chezmoi.sourceDir | shellQuote }}
+source_dir="$(chezmoi source-path)"
 mise_hash=$(cat "$HOME/.config/mise/config"*.toml 2>/dev/null | (command -v sha1sum >/dev/null && sha1sum || shasum -a 1))
 # post-apply hook は run_once の PATH 変更を引き継がないため、mise 本体と aqua/gh 用の
 # mise shims を PATH に通す。mise 本体は mac/linux とも https://mise.run 経由で ~/.local/bin に導入するため、~/.local/bin を先頭にする。mise shims は


### PR DESCRIPTION
## Summary
- resolve the source directory at hook runtime with `chezmoi source-path`
- avoid rendering the config with the unavailable `shellQuote` template function

## Testing
- `git diff --check`
- rendered `.chezmoi.toml.tmpl` with chezmoi v2.72.0 and parsed it with Python `tomllib`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support `chezmoi` versions that lack the `shellQuote` template function by reading the source dir from the hook environment. Previously the template used `{{ .chezmoi.sourceDir | shellQuote }}` (broken on older `chezmoi`); now the hook sets `source_dir=$CHEZMOI_SOURCE_DIR`, which preserves `chezmoi apply --source` overrides and avoids a standalone `chezmoi source-path` call.

- Tested with `chezmoi` v2.72.0; config parses with Python `tomllib`.
- No migration or rollout changes required.

<sup>Written for commit 2c0133b7c36372e14b766295587a7f09649172a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR avoids the unavailable `shellQuote` template function by obtaining the active source directory from the hook environment.
- Assigns the hook’s source directory from `CHEZMOI_SOURCE_DIR`.
- Retains quoted downstream path handling for APM and rulesync operations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge based on the currently established evidence.

No blocking failure remains established.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .chezmoi.toml.tmpl | Replaces template-time source-directory quoting with a hook-environment value while preserving the existing post-apply workflow. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: preserve invocation source in post-..."](https://github.com/ryo246912/dotfiles/commit/2c0133b7c36372e14b766295587a7f09649172a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53517826)</sub>

**Context used:**

- Knowledge Base — [Chezmoi bootstrap and apply flow](https://app.greptile.com/ryo/-/custom-context/knowledge-base/ryo246912/dotfiles/-/docs/chezmoi-setup.md)

<!-- /greptile_comment -->