### PR TITLE
fix: restore terminal-browser APM installation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -100,6 +100,11 @@
       "groupName": "terminal-browser"
     },
     {
+      "matchPackageNames": ["https://github.com/zenbu-labs/terminal-browser"],
+      "matchDatasources": ["git-refs"],
+      "enabled": false
+    },
+    {
       "matchPackageNames": ["classmethod/tsumiki", "https://github.com/classmethod/tsumiki"],
       "groupName": "tsumiki"
     }

--- a/dot_apm/apm.lock.yaml
+++ b/dot_apm/apm.lock.yaml
@@ -1484,7 +1484,7 @@ dependencies:
   name: terminal-browser
   host: github.com
   resolved_commit: 1b21e3a76453a53eda7f5bdc93c4aaabf70052f2
-  resolved_ref: v0.3.2
+  resolved_ref: 1b21e3a76453a53eda7f5bdc93c4aaabf70052f2
   version: unknown
   virtual_path: skill
   is_virtual: true

--- a/dot_apm/apm.yml
+++ b/dot_apm/apm.yml
@@ -17,10 +17,11 @@ dependencies:
     # crit（tomasz-tomczyk/crit プラグイン）。
     - tomasz-tomczyk/crit/integrations/claude-code/skills/crit#v0.18.2
     - tomasz-tomczyk/crit/integrations/claude-code/skills/crit-cli#v0.18.2
-    # virtual package の既定名 terminal-browser-skill ではなく、skill 名と同じ配置名にする。
+    # v0.4.0 以降の skill/ は生成前の SKILL.template.md のみで APM package として無効なため、
+    # SKILL.md を含む最後の release commit に固定する。配置名は skill 名と揃える。
     - git: zenbu-labs/terminal-browser
       path: skill
-      ref: v0.4.9
+      ref: 1b21e3a76453a53eda7f5bdc93c4aaabf70052f2
       alias: terminal-browser
     # tsumiki はリポジトリ全体を plugin package として取り込み、skills 14種と commands を配布する。
     - git: classmethod/tsumiki


### PR DESCRIPTION
## Summary
- pin the terminal-browser APM dependency to the last release commit whose `skill/` directory contains a valid `SKILL.md`
- synchronize the lockfile reference with the immutable commit
- prevent Renovate from moving this compatibility pin to the repository default branch while continuing to update the terminal-browser CLI independently

## Testing
- `apm install -g` with APM 0.26.0 in an isolated HOME
- `apm install -g --frozen` with APM 0.26.0 in an isolated HOME
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores APM installation of the `terminal-browser` skill by pinning `zenbu-labs/terminal-browser` to an immutable commit with a valid SKILL.md and aligning the lockfile. Previously we tracked release tags (e.g., v0.4.x) that shipped only SKILL.template.md and broke installation; now installs succeed and Renovate will not overwrite the pin.

- Pin `dot_apm/apm.yml` to commit 1b21e3a76453a53eda7f5bdc93c4aaabf70052f2 and update `apm.lock.yaml` to match.
- Disable Renovate `git-refs` updates for `https://github.com/zenbu-labs/terminal-browser`; CLI updates for `terminal-browser` remain unaffected.
- Verified `apm install -g` and `apm install -g --frozen` work with APM 0.26.0 in a clean HOME.

<sup>Written for commit fa4417155dbfd7f4384744231ddd09a32074d0ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores terminal-browser skill installation by pinning the APM dependency and lockfile to the last compatible immutable commit while excluding that pin from Renovate updates.

- Pins the terminal-browser APM skill to commit `1b21e3a76453a53eda7f5bdc93c4aaabf70052f2`.
- Synchronizes the lockfile’s resolved reference with the manifest.
- Disables Renovate only for the APM `git-refs` dependency, leaving CLI release updates enabled.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the compatibility pin, lockfile entry, and Renovate exception consistently scoped.

The manifest and lockfile use the established representation for commit-pinned APM dependencies, while the Renovate rule matches only the APM git-ref dependency and leaves terminal-browser CLI updates enabled.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/renovate.json | Adds a narrowly scoped disabled rule for the terminal-browser APM git-ref dependency without disabling the separately managed CLI. |
| dot_apm/apm.yml | Replaces the incompatible release tag with the immutable last-compatible commit and documents why the pin is required. |
| dot_apm/apm.lock.yaml | Aligns the terminal-browser lock reference with the commit pin using the repository’s established SHA-pinned dependency shape. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[terminal-browser CLI] -->|github-releases| B[Renovate updates enabled]
    C[terminal-browser APM skill] -->|git-refs| D[Immutable compatible commit]
    D --> E[Renovate updates disabled]
    D --> F[APM lock resolved_ref and resolved_commit]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: pin terminal-browser APM skill pack..."](https://github.com/ryo246912/dotfiles/commit/fa4417155dbfd7f4384744231ddd09a32074d0ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53520831)</sub>

<!-- /greptile_comment -->