### PR TITLE
feat(mise): add declarative mise-nix backend

### DIFF
--- a/docs/mise.md
+++ b/docs/mise.md
@@ -7,6 +7,49 @@
 [brew | mise-en-place](https://mise.jdx.dev/bootstrap/packages/brew.html)、
 [macOS defaults | mise-en-place](https://mise.jdx.dev/bootstrap/macos-defaults.html)
 
+## mise-nix による Nix パッケージ管理
+
+[mise-nix](https://github.com/jbadeau/mise-nix) は mise の tool backend なので、Nix
+パッケージも通常の mise tool と同じく `mise.toml` の `[tools]` で宣言的に管理できる。
+このリポジトリでは `dot_config/mise/config.toml` の `[plugins]` に plugin の URL と commit を
+固定しているため、`mise plugin install` を手動実行する必要はない。`nix:` の tool を初めて
+`mise install` したときに mise が plugin を取得する。
+
+```toml
+[plugins]
+nix = "https://github.com/jbadeau/mise-nix.git#<commit>"
+
+[tools]
+# mise の core/aqua/github/cargo/npm 等で取得できない CLI に限って追加する
+"nix:hello" = "2.12.1"
+```
+
+運用上の優先順位は次の通り。
+
+1. mise の core/aqua/github/cargo/npm 等の標準 backend
+2. OS パッケージや GUI アプリ、システム設定は `[bootstrap.*]`
+3. 上記で取得できない **CLI パッケージ**だけ `nix:<nixpkgs attribute>`
+4. sudo、Rosetta、Homebrew の postflight、macOS Login Item などホスト状態の変更が必要なものは
+   mise-nix では表現できないため、既存の idempotent な `bootstrap:*` task
+
+mise-nix 自体が Nix を呼び出すため、**Nix は事前にインストールされている必要がある**。
+また mise-nix が配置するのは mise の install directory と shim であり、macOS の `.app` を
+`/Applications` に登録したり `defaults` を変更したりはしない。このため、現在
+`bootstrap:mac-packages` / `bootstrap:mac-defaults` にある例外を機械的に `nix:` へ移すことは
+しない。Nix 導入済み環境で CLI を追加するときは、例えば以下で候補とバージョンを確認してから
+chezmoi source の `[tools]` に固定する。
+
+```sh
+nix search nixpkgs '^<package>$'
+mise ls-remote nix:<package>
+mise use --global nix:<package>@<version>
+mise install
+```
+
+unfree / insecure / local flake は暗黙に許可せず、必要なホストの `config.private.toml` 等で
+`MISE_NIX_ALLOW_UNFREE=true` / `MISE_NIX_ALLOW_INSECURE=true` /
+`MISE_NIX_ALLOW_LOCAL_FLAKES=true` を明示する。
+
 ## `mise bootstrap` のフェーズ
 
 `mise bootstrap`（フル実行）は以下を順に処理する。

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -5,6 +5,11 @@ min_version = "2026.7.0"
 # https://github.com/acj/asdf-ffmpeg
 ASDF_FFMPEG_ENABLE = "gpl libx264"
 
+# mise の標準 backend で取得できない CLI は、Nix 導入済みの環境で `nix:<attr>` として
+# [tools] に宣言する。plugin の取得元も config で固定し、手動の plugin install を不要にする。
+[plugins]
+nix = "https://github.com/jbadeau/mise-nix.git#e310c4c20e8273ba850298c10fbe97d0c858c300"
+
 [tools]
 # ffmpeg                                                      = "latest"
 # ruby                                                        = "3.3.1"


### PR DESCRIPTION
## Summary
- pin the mise-nix custom backend in the global mise configuration
- document how to declare Nix packages in `[tools]` and the fallback policy
- clarify that Nix is a prerequisite and macOS host-state exceptions remain bootstrap tasks

## Testing
- `mise config ls`
- `mise exec aqua:tamasfe/taplo@0.10.0 -- taplo format --check`
- `mise exec npm:oxfmt@0.59.0 -- oxfmt --check docs/mise.md`
- `mise exec aqua:secretlint/secretlint@13.0.4 -- secretlint docs/mise.md dot_config/mise/config.toml`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a declarative `mise-nix` backend and pins it in global `mise` config so we can manage Nix CLI packages via `[tools]`. Previously Nix packages were not managed through `mise`; now `nix:<attr>` tools install through `mise`, while host-state macOS tasks remain under `bootstrap:*`.

- Pin `mise-nix` in `dot_config/mise/config.toml` so `mise` auto-fetches the plugin on first `nix:` install; no manual `mise plugin install` needed.
- Document how to declare CLI tools as `"nix:<attr>" = "<version>"` and the priority: prefer core/aqua/github/cargo/npm, use `[bootstrap.*]` for OS/GUI/settings, only use `nix:` for missing CLI tools.
- Nix is required on the host. Do not migrate macOS `.app` installs or defaults to `nix:`; keep `bootstrap:mac-packages` and `bootstrap:mac-defaults`.
- Unfree/insecure/local flakes require explicit opt-in via `MISE_NIX_ALLOW_UNFREE`, `MISE_NIX_ALLOW_INSECURE`, `MISE_NIX_ALLOW_LOCAL_FLAKES` in host-private config.

<sup>Written for commit 28dc47db109f5c61549d672c711fb68f7d942c5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR pins a mise-nix custom backend and documents how Nix-backed CLI packages should fit into the repository’s package-management policy.
- Adds a commit-pinned `nix` plugin declaration to the global mise source configuration.
- Documents backend precedence, Nix prerequisites, host-state exceptions, opt-in package allowances, and package-addition commands.
- The package-addition example currently targets the deployed global configuration rather than the chezmoi source of truth.

<h3>Confidence Score: 4/5</h3>

The documentation should be corrected before merging because its package-addition command writes to disposable deployed state rather than the repository source.

Following the new `mise use --global` example can create a tool declaration only in `~/.config/mise/config.toml`; a later `chezmoi apply` can overwrite it, and other machines cannot reproduce it from the repository.

**Files Needing Attention:** docs/mise.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| dot_config/mise/config.toml | Adds a pinned mise-nix plugin declaration; no current `nix:` tool declaration makes the backend active. |
| docs/mise.md | Adds mise-nix operating guidance, but the `mise use --global` example conflicts with the repository’s chezmoi source-of-truth workflow. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ryo246912%2Fdotfiles%20PR%20%231313%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ryo246912%2Fdotfiles&pr=1313&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Adocs%2Fmise.md%3A45%0A**Global%20command%20bypasses%20source%20state**%0A%0AWhen%20a%20user%20follows%20this%20example%2C%20%60--global%60%20writes%20the%20declaration%20to%20the%20deployed%20%60~%2F.config%2Fmise%2Fconfig.toml%60%20instead%20of%20the%20chezmoi%20source%2C%20so%20a%20subsequent%20%60chezmoi%20apply%60%20can%20remove%20the%20tool%20and%20other%20machines%20cannot%20reproduce%20it.%0A%0A%60%60%60suggestion%0Amise%20use%20--path%20dot_config%2Fmise%2Fconfig.toml%20nix%3A%3Cpackage%3E%40%3Cversion%3E%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ryo246912%2Fdotfiles&pr=1313&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ryo246912%2Fdotfiles%22%20on%20the%20existing%20branch%20%22feat%2Fmise-nix-declarative%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmise-nix-declarative%22.%0A%0A%23%23%23%20Issue%201%0Adocs%2Fmise.md%3A45%0A**Global%20command%20bypasses%20source%20state**%0A%0AWhen%20a%20user%20follows%20this%20example%2C%20%60--global%60%20writes%20the%20declaration%20to%20the%20deployed%20%60~%2F.config%2Fmise%2Fconfig.toml%60%20instead%20of%20the%20chezmoi%20source%2C%20so%20a%20subsequent%20%60chezmoi%20apply%60%20can%20remove%20the%20tool%20and%20other%20machines%20cannot%20reproduce%20it.%0A%0A%60%60%60suggestion%0Amise%20use%20--path%20dot_config%2Fmise%2Fconfig.toml%20nix%3A%3Cpackage%3E%40%3Cversion%3E%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ryo246912%2Fdotfiles&pr=1313&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(mise): declare mise-nix backend"](https://github.com/ryo246912/dotfiles/commit/28dc47db109f5c61549d672c711fb68f7d942c5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53698760)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Package and Tool Version Management](https://app.greptile.com/ryo/-/custom-context/knowledge-base/ryo246912/dotfiles/-/docs/package-management.md)

<!-- /greptile_comment -->