### PR TITLE
fix(crit): devcontainer起動時のネットワーク確認を省略

### DIFF
--- a/docs/crit.md
+++ b/docs/crit.md
@@ -11,6 +11,7 @@
 | ------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | バイナリ     | `github:tomasz-tomczyk/crit` を mise で導入                               | `dot_config/devcontainer/mise.toml`                                                   |
 | バインド先   | `CRIT_HOST=0.0.0.0` / `CRIT_PORT=7842`（コンテナ内は固定）                | `dot_config/devcontainer/devcontainer.json` (`remoteEnv`)                             |
+| 非認証許可   | `CRIT_ALLOW_UNAUTHENTICATED_NETWORK=1`                                    | `dot_config/devcontainer/devcontainer.json` (`remoteEnv`)                             |
 | ポート公開   | `appPort: 127.0.0.1::7842` でホストへ publish（host port は自動採番）     | `dot_config/devcontainer/devcontainer.json`                                           |
 | 自動起動抑止 | `CRIT_NO_UPDATE_CHECK=1`                                                  | `dot_config/devcontainer/devcontainer.json`                                           |
 | 動作設定     | `~/.crit.config.json` を生成（`no_open` / `agent_cmd`）                   | `dot_config/devcontainer/scripts/post-create.sh`                                      |
@@ -42,6 +43,11 @@ publish されますが、host port は **`127.0.0.1::7842` として Docker に
 devcontainer を複数同時に起動してもポート衝突は起きません。実際に割り当てられた host port は
 `~/.crit-host-port` に記録されるので、ホストのブラウザではその番号で `http://localhost:<port>` を
 開いてレビュー・コメントします。コメントを送るとエージェントへフィードバックされ、修正ループが回ります。
+
+crit は認証機能を持たないため、非 loopback の `CRIT_HOST` を指定すると、明示的な許可がない限り起動を
+拒否します。この構成では `CRIT_ALLOW_UNAUTHENTICATED_NETWORK=1` を設定して確認を省略していますが、
+Docker がコンテナのポートをホストの `127.0.0.1` にだけ publish するため、LAN やインターネットへは
+公開されません。`appPort` を変更する場合は、ホスト側の bind address を `0.0.0.0` にしないでください。
 
 > [!IMPORTANT]
 > ポート公開には **`appPort` を使う**。`forwardPorts` は VS Code 拡張専用で、`multi-worktree` の

--- a/dot_config/devcontainer/devcontainer.json
+++ b/dot_config/devcontainer/devcontainer.json
@@ -23,6 +23,8 @@
     // crit: ホストのブラウザから参照できるよう0.0.0.0にバインドし、固定ポートで待ち受ける
     "CRIT_HOST": "0.0.0.0",
     "CRIT_PORT": "7842",
+    // crit: 非loopback bindを許可する。Docker側は127.0.0.1だけにpublishするため外部公開されない
+    "CRIT_ALLOW_UNAUTHENTICATED_NETWORK": "1",
     // crit: コンテナ内では更新チェック不要のため無効化
     "CRIT_NO_UPDATE_CHECK": "1"
   },


### PR DESCRIPTION
## Summary
- devcontainer内のcritに非loopback bindの明示的な許可を設定
- ホスト側は127.0.0.1限定でpublishされるという安全性の前提を文書化

## Testing
- `mise exec npm:oxfmt -- oxfmt --check dot_config/devcontainer/devcontainer.json docs/crit.md`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
devcontainer 起動時の crit の非 loopback バインド確認を省略し、起動拒否を解消しました。従来は `CRIT_HOST=0.0.0.0` 指定時に明示許可がなく起動が拒否されていましたが、`CRIT_ALLOW_UNAUTHENTICATED_NETWORK=1` を設定して許可し、ホスト側は `appPort: 127.0.0.1::7842` のみで公開される前提を文書化しました。

**レビューポイント**
- `dot_config/devcontainer/devcontainer.json` の `remoteEnv` に `CRIT_ALLOW_UNAUTHENTICATED_NETWORK=1` を追加。`docs/crit.md` に安全性の前提（Docker は `127.0.0.1` のみに publish）と注意点（`appPort` を使用、ホストの bind を `0.0.0.0` にしない）を追記。
- 追加の移行作業は不要。`devcontainer up` 後に crit が即時起動し、ホスト公開が `127.0.0.1` 限定であることを確認してください。

<sup>Written for commit c2178f9f2214cf6213dae3fdd84bd70aa445a05d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR allows crit to start with its existing non-loopback bind and documents host-loopback publishing as the intended security boundary.
- Adds `CRIT_ALLOW_UNAUTHENTICATED_NETWORK=1` to the devcontainer environment.
- Documents the unauthenticated bind and the requirement to keep the published host address on `127.0.0.1`.
- The host publishing rule does not restrict direct traffic to the devcontainer interface, leaving an unauthenticated container-network path.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until the unauthenticated crit listener is isolated from container-network peers or protected by an equivalent access control.

The new override removes crit's non-loopback safety check while the stated mitigation restricts only Docker's host-side published port, leaving direct access through the devcontainer interface.

**Files Needing Attention:** dot_config/devcontainer/devcontainer.json, docs/crit.md

<details open><summary><h3>Security Review</h3></summary>

The new override permits crit to listen without authentication on every devcontainer interface. Host-side `127.0.0.1` publishing does not prevent a peer with container-network reachability from connecting directly to port 7842.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| dot_config/devcontainer/devcontainer.json | Adds the startup override but exposes unauthenticated crit on container interfaces beyond the host-loopback publishing boundary. |
| docs/crit.md | Documents the intended host-loopback protection but omits direct container-network reachability. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Browser["Host browser"] -->|"127.0.0.1:dynamic"| Publish["Docker published port"]
  Publish -->|"container:7842"| Crit["crit on 0.0.0.0:7842"]
  Peer["Reachable container-network peer"] -->|"direct container IP:7842"| Crit
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ryo246912%2Fdotfiles%20PR%20%231316%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ryo246912%2Fdotfiles&pr=1316&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Adot_config%2Fdevcontainer%2Fdevcontainer.json%3A27%0A**Container%20network%20bypasses%20loopback%20isolation**%0A%0AIf%20another%20container%20or%20network%20peer%20can%20route%20to%20the%20devcontainer%20IP%2C%20%60CRIT_HOST%3D0.0.0.0%60%20and%20this%20override%20expose%20crit%20directly%20on%20port%207842%20without%20authentication%3B%20the%20host-side%20%60127.0.0.1%60%20publish%20rule%20does%20not%20restrict%20direct%20container-interface%20traffic%2C%20allowing%20that%20peer%20to%20access%20review%20data%20and%20submit%20interactions.%20**How%20this%20was%20verified%3A**%20The%20configuration%20combines%20an%20all-interface%20listener%20with%20an%20unauthenticated-network%20override%2C%20while%20its%20only%20access%20restriction%20applies%20to%20the%20separately%20published%20host%20port.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ryo246912%2Fdotfiles&pr=1316&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ryo246912%2Fdotfiles%22%20on%20the%20existing%20branch%20%22fix%2Fcrit-network-confirmation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcrit-network-confirmation%22.%0A%0A%23%23%23%20Issue%201%0Adot_config%2Fdevcontainer%2Fdevcontainer.json%3A27%0A**Container%20network%20bypasses%20loopback%20isolation**%0A%0AIf%20another%20container%20or%20network%20peer%20can%20route%20to%20the%20devcontainer%20IP%2C%20%60CRIT_HOST%3D0.0.0.0%60%20and%20this%20override%20expose%20crit%20directly%20on%20port%207842%20without%20authentication%3B%20the%20host-side%20%60127.0.0.1%60%20publish%20rule%20does%20not%20restrict%20direct%20container-interface%20traffic%2C%20allowing%20that%20peer%20to%20access%20review%20data%20and%20submit%20interactions.%20**How%20this%20was%20verified%3A**%20The%20configuration%20combines%20an%20all-interface%20listener%20with%20an%20unauthenticated-network%20override%2C%20while%20its%20only%20access%20restriction%20applies%20to%20the%20separately%20published%20host%20port.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ryo246912%2Fdotfiles&pr=1316&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(crit): allow devcontainer network bi..."](https://github.com/ryo246912/dotfiles/commit/c2178f9f2214cf6213dae3fdd84bd70aa445a05d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53716369)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [AI agent configuration (Claude Code, Codex, APM, rulesync)](https://app.greptile.com/ryo/-/custom-context/knowledge-base/ryo246912/dotfiles/-/docs/ai-agent-config.md)

<!-- /greptile_comment -->