### PR TITLE
docs(tsumiki): 現行Dev Skillsのガイドに更新

### DIFF
--- a/docs/skill.md
+++ b/docs/skill.md
@@ -4,7 +4,7 @@
 
 - `crit` / `crit-cli`
 - `terminal-browser`
-- Tsumikiの14 skill
+- Tsumiki skills
 - Ponytailの6 skill
 - `ctx-agent-history-search`
 - `resolving-merge-conflicts`
@@ -91,7 +91,8 @@ Tsumikiは、project初期化、context生成、plan作成、TDD実装、検証�
 | `dev-webtest`        | Playwrightで画面動作、visual、accessibility、responsive、formをtestする                      |
 | `ipa-security-check` | IPAの公開資料に基づいてsource codeを静的検査し、出典付きで脆弱性候補を報告する               |
 | `ipa-security-guide` | security診断reportを読み、優先順位付きの`dev-debug`依頼リストへ変換する                      |
-| `kairo-implement`    | 分割済みtaskを指定順に実装し、TDD commandを使って完了まで検証する                            |
+| `task-breakdown`     | 開発に限らない依頼を、依存関係と完了条件を持つ実行可能なtaskへ構造分解する                   |
+| `uat-test-design`    | repositoryを分析し、業務・system・非機能の受入test項目を階層化して生成する                   |
 
 最初にどのskillを使うべきか分からない場合は、次のように`dev-navigate`へ相談します。
 
@@ -108,167 +109,149 @@ $dev-plan checkout "決済providerを追加し、失敗時に安全にretryで�
 `dev-verify`の順で使用します。Web UIを含む場合は`dev-webtest-plan`と`dev-webtest`、security確認が必要な場合は
 `ipa-security-check`と`ipa-security-guide`を組み合わせます。
 
-## tsumiki 入門ガイド
+## Tsumiki 入門ガイド
 
-### 1. tsumikiとは何か
+### 現行の中心は Dev Skills
 
-tsumikiは「**要件定義 → 設計 → タスク分割 → 実装（TDD）**」という開発プロセスを、Claude Codeのスラッシュコマンド／スキルとして一気通貫でサポートするフレームワークです。
+Tsumikiの現行workflowはDev Skillsです。従来このページで中心としていたKairo・個別TDD・DIRECT commandは、upstreamで
+`tsumiki-legacy` pluginへ分離されたlegacy機能です。新しい開発ではDev Skillsを使用し、Kairoを前提とした
+`kairo-requirements` → `kairo-design` → `kairo-tasks`という手順は採用しません。
 
-大きく分けて以下のコマンド群があります。
-
-| カテゴリ                     | 何をするか                                              | 本プロジェクトで使うか               |
-| ---------------------------- | ------------------------------------------------------- | ------------------------------------ |
-| **Kairo**                    | 要件定義〜実装までの包括的フロー                        | ◎ メインで使用                       |
-| **TDD**                      | Red/Green/Refactorの個別実行（Kairoの内部でも使われる） | △ 必要に応じて個別実行               |
-| **Dev Skills**               | コンテキスト分析・計画・実装・検証の統合ワークフロー    | △ 代替案として利用可                 |
-| **DCS**                      | 既存コードの分析・調査・PRD作成支援                     | △ 途中の調査で利用可                 |
-| **ユーティリティ**           | ヘルプ・自動デバッグ・小規模修正など                    | ○ 困ったときに利用                   |
-| **リバースエンジニアリング** | 既存コードから設計書・要件定義書を逆生成                | – 今回はゼロからの開発なので基本不要 |
-
-ポイントは、**各ステップの成果物がすべて `docs/` 配下にMarkdown等のドキュメントとして残る**ことです。これは今回の課題が必須としている「Design Doc」や「判断理由の記録」とも相性が良い仕組みです。
-
----
-
-### 2. 全体のワークフロー（Kairo）
-
-tsumikiのメインフローは次の5ステップです。
+Dev Skillsは、新規projectの初期化または既存projectの分析から、計画、test-first実装、検証、debug、Web testまでを
+次のようにつなぎます。
 
 ```mermaid
 flowchart TD
-    A[要件概要を伝える] --> B["/tsumiki:kairo-requirements"]
-    B --> C{要件を確認}
-    C -->|修正必要| B
-    C -->|OK| D["/tsumiki:kairo-design"]
-    D --> E{設計を確認}
-    E -->|修正必要| D
-    E -->|OK| F["/tsumiki:kairo-tasks"]
-    F --> G{タスクを確認}
-    G -->|OK| H["/tsumiki:kairo-implement もしくは kairo-loop"]
-    H --> I{全タスク完了?}
-    I -->|No| H
-    I -->|Yes| J[完了]
+    A[新規project] --> B[dev-init]
+    C[既存project] --> D[dev-context]
+    B --> E[docs/dev/context.md]
+    D --> E
+    E --> F[dev-plan]
+    F --> G[dev-impl]
+    F --> H[dev-run]
+    G --> I[dev-verify]
+    H --> I
+    G -->|失敗| J[dev-debug]
+    H -->|失敗| J
+    F --> K[dev-screen-spec]
+    K --> L[dev-webtest-plan]
+    L --> M[dev-webtest]
+    M -->|問題を検出| J
 ```
 
-**重要な考え方**: 各ステップの後には必ず人間（自分）が生成物をレビューし、必要なら修正を指示してから次のステップに進みます。生成AIに丸投げするのではなく、「AIの提案を検証・レビューする過程」自体が今回の課題で評価されるポイントでもあります。
+どこから始めるか判断できない場合は、`dev-navigate`へ目的を伝えます。
 
----
-
-### 3. 各コマンドの詳細
-
-#### 3-1. `/tsumiki:init-tech-stack` — 技術スタックの決定
-
-プロジェクトで使うフレームワーク・ライブラリを対話的に決めます。
-
-- 生成物: `docs/tech-stack.md`
-- 今回は非機能要件で「フロントエンド: TypeScript + React」「バックエンド: Go」と指定されているため、その制約を踏まえた選定を行うことになります（React内でのラッパーフレームワークやUIライブラリ、Goでのフレームワーク・APIスキーマ形式など、指定がない部分をここで決定していきます）。
-
-#### 3-2. `/tsumiki:kairo-requirements` — 要件定義
-
-要件の概要を渡すと、EARS記法（Easy Approach to Requirements Syntax）で詳細な要件定義書を作ってくれます。
-
-```
-/tsumiki:kairo-requirements 要件概要
+```text
+/dev-navigate
+既存Web applicationへ決済機能を追加したいです。どのskillから始めるべきですか。
 ```
 
-- 生成物: `docs/spec/{要件名}-requirements.md`
-- 含まれる内容: ユーザーストーリー、EARS記法の詳細要件、エッジケース、受け入れ基準
-- 課題側の「Design Doc に要件の整理（自分で補った要件を含む）を書く」という要求と直結する部分です。README.mdの機能要件（ツイート・フォロー・タイムライン）や非機能要件をここでインプットします。
+### 基本workflow
 
-#### 3-3. `/tsumiki:kairo-design` — 設計
+#### 1. Contextを準備する
 
-要件を承認した後に実行します（省略しても直前の要件定義を引き継いで実行可能）。
+新規projectでは`dev-init`が技術stackを対話で決定し、承認後にscaffoldします。既存projectでは`dev-context`が技術stack、
+test framework、規約、architectureを分析します。どちらも後続skillが共有する`docs/dev/context.md`を生成します。
 
-- 生成物: `docs/design/{要件名}/` 配下
-  - アーキテクチャ設計書
-  - データフロー図（Mermaid）
-  - TypeScriptインターフェース定義
-  - データベーススキーマ
-  - APIエンドポイント仕様
-- **注意点**: 課題が求める「Design Doc」には「検討した選択肢とトレードオフ」「最終的に選んだ方針とその理由」という比較検討のセクションが必須です。`kairo-design` はそのまま「決定した設計」を出力する傾向があるため、この比較検討部分は生成後に自分で加筆するか、設計を依頼する際のプロンプトで「複数の選択肢とトレードオフも明記してほしい」と明示的に指示するのがおすすめです。
-
-#### 3-4. `/tsumiki:kairo-tasks` — タスク分割
-
-設計を確認した後に実行します。
-
-- 生成物: `docs/tasks/{要件名}/overview.md`、`docs/tasks/{要件名}/TASK-XXXX.md`
-- 依存関係を考慮した実装順序、各タスクのテスト要件・UI/UX要件まで含めて分割してくれます。
-- `/tsumiki:kairo-task-verify`（タスク内容の確認用コマンド）を実行してから実装に進むと安全です。
-
-#### 3-5. 実装コマンド
-
-タスクができたら実装に入ります。2つのやり方があります。
-
-```bash
-# 全タスクを順番に実装
-/tsumiki:kairo-implement
-
-# 特定タスクだけ実装（タスクファイル名 TASK番号 を指定）
-/tsumiki:kairo-implement タスクファイル名 TASK番号
-
-# タスク範囲を指定して自動連続実装（長時間実行・compact対応）
-/tsumiki:kairo-loop
+```text
+/dev-init
 ```
 
-内部的には各タスクごとに以下のTDDサイクルが自動で回ります。
-
-1. `tdd-requirements`（TDD要件定義）
-2. `tdd-testcases`（テストケース作成）
-3. `tdd-red`（失敗するテストを書く）
-4. `tdd-green`（テストを通す最小実装）
-5. `tdd-refactor`（リファクタリング）
-6. `tdd-verify-complete`（完了確認）
-
-このサイクルを個別に手動で回したい場合は `/tsumiki:tdd-requirements` 〜 `/tsumiki:tdd-verify-complete` を1つずつ呼び出すこともできます。
-
----
-
-### 4. 生成物が置かれるディレクトリ構成
-
-```
-./
-├── docs/
-│   ├── tech-stack.md        # 技術スタック選定
-│   ├── spec/{要件名}/        # 要件定義書（requirements.md 等）
-│   ├── design/{要件名}/      # 設計書（architecture.md, api-endpoints.md, database-schema.sql 等）
-│   ├── tasks/{要件名}/       # タスク一覧（overview.md, TASK-XXXX.md）
-│   └── implements/{要件名}/{タスクID}/  # 実装に関する記録
-├── frontend/                # フロントエンド（TypeScript + React）
-├── backend/                 # バックエンド（Go）
-└── database/                # DB関連
+```text
+/dev-context
 ```
 
-プロジェクト固有のルールを追加したい場合は `docs/rule/{種類1}/{種類2}/*.md` にMarkdownを置くと、対応するコマンド実行時に自動で読み込まれます（例: `docs/rule/kairo/requirements/` は `kairo-requirements` 実行時のみ読み込まれる）。
+#### 2. Planを作る
 
----
+`dev-plan`はinterface-firstの設計とtest可能なtaskを`docs/dev/plans/<plan-name>/`へ出力します。素早く計画する
+Lightweight modeと、EARS要件、user story、受け入れ条件まで作るFull-spec modeがあり、実行中に選択します。
 
-### 5. 困ったときは
-
-```bash
-# コマンド一覧・使い方を表示
-/tsumiki:help
-
-# 特定コマンドの詳細ヘルプ
-/tsumiki:help kairo-requirements
-
-# 「〜が分からない」で検索
-/tsumiki:help テストが失敗して原因がわからない
+```text
+/dev-plan auth "ユーザー認証機能を実装"
 ```
 
-その他、テストやビルドで詰まった場合は `/tsumiki:auto-debug`（テストエラー自動デバッグ）、`/tsumiki:build-fix`（ビルドエラー修正）なども用意されています。
+既存のPRDを入力にすることもできます。
 
----
+```text
+/dev-plan auth ./docs/prd.md
+```
 
-### 6. 本プロジェクト（ENG-1100課題）での想定進行イメージ
+#### 3. 実装する
 
-`ENG-1100/README.md` の要件（ツイート・フォロー・タイムライン、TypeScript+React／Go、Design Doc必須）を踏まえると、次の順序で進めるのが自然です。
+taskを1件ずつ実装する場合は`dev-impl`へplan名とtask IDを渡します。Planを作るほどではない軽微な変更には、修正指示を
+直接渡すquick modeを使用できます。どちらもRed → Green → Refactorをguardrailとするtest-first実装です。
 
-1. `/tsumiki:init-tech-stack` — React側のフレームワークやUIライブラリ、Go側のWebフレームワークやAPIスキーマ形式（OpenAPI等）を決定
-2. `/tsumiki:kairo-requirements` — 機能要件・非機能要件・自分で補った要件をEARS記法で整理
-3. `/tsumiki:kairo-design` — アーキテクチャ、データフロー、API仕様、DBスキーマを設計。**比較検討したトレードオフと決定理由は別途加筆**して課題の「Design Doc」要件を満たす
-4. `/tsumiki:kairo-tasks` → `/tsumiki:kairo-task-verify` — 実装タスクへ分割・確認
-5. `/tsumiki:kairo-implement` または `/tsumiki:kairo-loop` — TDDサイクルで実装を進行
+```text
+/dev-impl auth 001
+```
 
-各ステップの成果物は必ず内容を読んでレビューし、必要な修正指示を出してから次に進むことをおすすめします（AIに任せた部分と自分で判断した部分を分けて記録する、という課題の評価観点にも合致します）。
+```text
+/dev-impl "validation messageを日本語へ変更"
+```
+
+複数taskを連続実行する場合は`dev-run`へ対象範囲を渡します。各taskについて`dev-impl`、`dev-verify`、失敗時の
+`dev-debug`を組み合わせて実行します。
+
+```text
+/dev-run auth 001 005
+```
+
+#### 4. 検証・debugする
+
+`dev-verify`はplanのtask完了状態、test、build、lint、file sizeを確認し、
+`docs/dev/plans/<plan-name>/reports/`へreportを出力します。
+
+```text
+/dev-verify auth
+```
+
+失敗の原因を調べて修正する場合は`dev-debug`を使用します。errorの自動検出、error messageの直接指定、Web testで
+検出した問題を扱う`webtest` modeに対応します。
+
+```text
+/dev-debug "TypeError: Cannot read properties of undefined"
+```
+
+### Web UIをtestする
+
+Web UIを含む変更では、画面仕様、Playwright test計画、実行を分離します。
+
+1. `dev-screen-spec`でsource codeまたはplanから`docs/dev/screen-specs/`へ画面仕様を生成・差分更新する。
+2. `dev-webtest-plan`でplanと画面仕様からPlaywright用test計画を生成・差分更新する。
+3. `dev-webtest`で計画test、monkey test、visual、accessibility、responsive、formを確認する。
+4. 問題が見つかった場合は`dev-debug webtest`で修正する。
+
+```text
+/dev-screen-spec from-plan auth
+/dev-webtest-plan auth
+/dev-webtest auth
+/dev-debug webtest
+```
+
+### その他の現行command
+
+Dev Skills以外にも、目的別のcommandを使用できます。
+
+| カテゴリ            | 主なcommand                                                              | 用途                                                     |
+| ------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------- |
+| DCS                 | `dcs:feature-rubber-duck`、`dcs:impact-analysis`、`dcs:bug-analysis`など | PRD作成、影響範囲・bug・performance・edge caseなどの分析 |
+| utility             | `help`、`orchestrate`、`refine-plan`、`refine-execute`                   | command案内、複雑な依頼の編成、小規模変更の計画と実行    |
+| error対応           | `auto-debug`、`build-fix`、`env-fix`、`flaky-fix`、`timeout-fix`         | test、build、環境、flaky test、timeoutの修正             |
+| reverse engineering | `rev-tasks`、`rev-design`、`rev-specs`、`rev-requirements`               | 既存codeからtask、設計、test仕様、要件を逆生成           |
+
+このdotfilesではTsumiki commandをRulesync経由でも配布します。Claude Codeでは`/tsumiki-<name>`、Codexでは
+`$tsumiki-<name>`として呼び出します。たとえばhelpは`/tsumiki-help`または`$tsumiki-help`です。詳細は
+[`docs/rulesync.md`](rulesync.md)を参照してください。
+
+### Legacy commandについて
+
+Kairo、個別TDD、DIRECTが必要な既存workflowでは、upstreamの`tsumiki-legacy` pluginを明示的に導入し、Claude Codeで
+`/tsumiki-legacy:<command>`として実行します。たとえばKairoの要件定義は
+`/tsumiki-legacy:kairo-requirements`です。現行の`tsumiki` pluginだけを導入した環境では利用できません。
+
+新規作業でKairoの成果物や手順をそのままDev Skillsへ読み替えないでください。Dev Skillsではcontextを
+`docs/dev/context.md`、planを`docs/dev/plans/<plan-name>/`で管理し、個別のTDD commandではなく`dev-impl`が
+test-first実装を担当します。
 
 ## Ponytail skills
 


### PR DESCRIPTION
## 概要

- Kairo・個別TDDを中心としたレガシー手順を、現行のDev Skills workflowへ更新
- context作成、plan、実装、検証、Web testの利用例を追加
- DCS・utility・reverse engineering commandとlegacy pluginの位置付けを明記
- 現行skill一覧からlegacyのkairo-implementを除き、task-breakdownとuat-test-designを追加

## 確認

- `mise run lint:md`
- `mise run lint:secret`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Tsumiki guide to center on the current Dev Skills workflow and demotes Kairo/TDD/DIRECT to legacy. This matters because new projects should follow Dev Skills, while Kairo requires the separate `tsumiki-legacy` plugin.

- Rewrites the intro and workflow to use `dev-init`/`dev-context` → `dev-plan` → `dev-impl`/`dev-run` → `dev-verify` → `dev-debug`, plus `dev-screen-spec`/`dev-webtest-plan`/`dev-webtest`.
- Adds concrete examples for context creation, planning, test-first implementation, verification/debug, and web UI testing.
- Clarifies the roles of DCS, utility, and reverse engineering commands, and documents Rulesync aliases.
- Updates the skills list: removes `kairo-implement`; adds `task-breakdown` and `uat-test-design`; normalizes headings and terminology.
- Documents how to run legacy Kairo/TDD via `tsumiki-legacy` (for example, `/tsumiki-legacy:kairo-requirements`) and warns against mapping Kairo artifacts directly to Dev Skills.

**Review notes**
- Verify command names and sequences match the `tsumiki` plugin and that legacy paths explicitly use `tsumiki-legacy`.
- Check that paths for generated artifacts (`docs/dev/context.md`, `docs/dev/plans/...`, `docs/dev/screen-specs/...`) are consistent.
- Confirm examples execute as written and that cross-references (for example, `rulesync.md`) resolve.
- Ensure the updated skills table and Web test flow reflect current capabilities. 

**Rollout/Migration**
- For teams still on Kairo/TDD, install `tsumiki-legacy` and call legacy commands via `/tsumiki-legacy:<command>`.
- For new work, switch to Dev Skills: start with `dev-init`/`dev-context`, plan with `dev-plan`, implement with `dev-impl`/`dev-run`, verify with `dev-verify`, and test UI with `dev-webtest`.
- Do not repurpose Kairo artifacts; adopt the new doc locations under `docs/dev/`.
- Remove references to `kairo-implement`; consider `task-breakdown` and `uat-test-design` where applicable.

<sup>Written for commit 38c48455aa55f17a31de4224c73171de67953caa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the legacy Kairo-focused Tsumiki guide with the Dev Skills workflow, including context creation, planning, implementation, verification, debugging, and Web testing. It also revises the skill inventory and explains Rulesync and legacy-command invocation.

- Adds a Dev Skills workflow diagram and command examples.
- Documents generated context, plan, report, and screen-spec artifacts.
- Reclassifies Kairo, individual TDD, and DIRECT commands as legacy functionality.
- Updates the listed Tsumiki skills, although the new inventory does not match the repository's pinned package.

<h3>Confidence Score: 4/5</h3>

The documentation should not be merged until its skill inventory and legacy-plugin guidance are aligned with the Tsumiki version this repository actually installs.

The updated guide advertises two undeployed skills and describes bundled Kairo, TDD, and DIRECT commands as requiring a separate plugin, causing users of the pinned installation to follow unavailable or incorrect invocation paths.

**Files Needing Attention:** docs/skill.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/skill.md | Rewrites the Tsumiki guide around Dev Skills, but documents skills and legacy-plugin boundaries that do not match the repository's pinned Tsumiki v1.4.2 installation. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Repository APM manifest] --> B[Pinned Tsumiki v1.4.2]
  B --> C[Installed skills and commands]
  D[Updated docs/skill.md] --> E[Documented current upstream workflow]
  E -. inventory mismatch .-> C
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ryo246912%2Fdotfiles%20PR%20%231317%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ryo246912%2Fdotfiles&pr=1317&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Adocs%2Fskill.md%3A94-95%0A**Pinned%20skill%20inventory%20mismatch**%0A%0AWhen%20users%20install%20this%20repository's%20pinned%20Tsumiki%20v1.4.2%20package%2C%20%60task-breakdown%60%20and%20%60uat-test-design%60%20are%20not%20deployed%2C%20while%20Kairo%2C%20individual%20TDD%2C%20and%20DIRECT%20commands%20remain%20bundled%20in%20the%20main%20plugin.%20The%20updated%20inventory%20and%20legacy-plugin%20guidance%20therefore%20direct%20users%20to%20unavailable%20skills%20and%20unnecessary%20legacy-plugin%20setup.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ryo246912%2Fdotfiles&pr=1317&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ryo246912%2Fdotfiles%22%20on%20the%20existing%20branch%20%22docs%2Fupdate-tsumiki-guide%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fupdate-tsumiki-guide%22.%0A%0A%23%23%23%20Issue%201%0Adocs%2Fskill.md%3A94-95%0A**Pinned%20skill%20inventory%20mismatch**%0A%0AWhen%20users%20install%20this%20repository's%20pinned%20Tsumiki%20v1.4.2%20package%2C%20%60task-breakdown%60%20and%20%60uat-test-design%60%20are%20not%20deployed%2C%20while%20Kairo%2C%20individual%20TDD%2C%20and%20DIRECT%20commands%20remain%20bundled%20in%20the%20main%20plugin.%20The%20updated%20inventory%20and%20legacy-plugin%20guidance%20therefore%20direct%20users%20to%20unavailable%20skills%20and%20unnecessary%20legacy-plugin%20setup.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ryo246912%2Fdotfiles&pr=1317&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(tsumiki): 現行Dev Skillsのガイドに更新"](https://github.com/ryo246912/dotfiles/commit/38c48455aa55f17a31de4224c73171de67953caa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53726472)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [AI agent configuration (Claude Code, Codex, APM, rulesync)](https://app.greptile.com/ryo/-/custom-context/knowledge-base/ryo246912/dotfiles/-/docs/ai-agent-config.md)

<!-- /greptile_comment -->