### PR TITLE
fix(devcontainer): コンテナ固有の生成物を再帰的に分離

### DIFF
--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -6,6 +6,26 @@ devcontainer 定義は `dot_config/devcontainer/` を参照してください。
 `multi-worktree` や `crit`（docs/crit.md）など、この base template から起動する
 devcontainer はいずれもここに書かれた仕組みを共有します。
 
+## ホストと共有しないプロジェクト生成物
+
+ワークスペース自体はホストから bind mount しますが、次のルートディレクトリには devcontainer ごとの
+named volume を重ねてマウントします。macOS ホストと Linux コンテナでネイティブバイナリや実行環境を
+共有することによる衝突を防ぎます。
+
+- `node_modules`: Node.js の依存パッケージ（native addon やパッケージマネージャーが生成するリンクを含む）
+- `.venv`: Python 仮想環境（OS 固有の実行ファイルやパスを含む）
+- `target`: Rust / Maven などのビルド成果物
+- `.gradle`: Gradle のプロジェクトキャッシュ
+- `.terraform`: Terraform provider の実行ファイルと初期化データ
+
+volume 名には `${devcontainerId}` を含めるため、ホストとは共有せず、同時に起動した別の devcontainer
+とも共有しません。同じ devcontainer のリビルド時には volume が再利用されます。ホスト側に同名の
+ディレクトリが存在してもコンテナ内からは見えず、コンテナ内で作成した内容もホスト側には書き込まれません。
+
+対象はワークスペース直下のディレクトリです。monorepo でサブディレクトリごとに `node_modules` などを
+作る構成では、依存関係をルートへ集約するか、プロジェクト固有の devcontainer 設定に追加の volume mount
+を定義してください。
+
 ## devcontainer 内での docker compose / DB コンテナ（DinD）
 
 base template で `docker-in-docker`（DinD）feature を有効化しているため、devcontainer 内から

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -8,60 +8,31 @@ devcontainer はいずれもここに書かれた仕組みを共有します。
 
 ## ホストと共有しないプロジェクト生成物
 
-ワークスペース自体はホストから bind mount しますが、次のルートディレクトリには devcontainer ごとの
-named volume を重ねてマウントします。macOS ホストと Linux コンテナでネイティブバイナリや実行環境を
-共有することによる衝突を防ぎます。
+ワークスペース自体はホストから bind mount しますが、次のディレクトリは起動時に検出し、コンテナの
+writable layer (`/var/lib/devcontainer-project-artifacts`) を bind mount してホスト側の内容を隠します。
+macOS ホストと Linux コンテナでネイティブバイナリや実行環境を共有することによる衝突を防ぎます。
 
-- `node_modules`: Node.js の依存パッケージ（native addon やパッケージマネージャーが生成するリンクを含む）
-- `.venv`: Python 仮想環境（OS 固有の実行ファイルやパスを含む）
+- `node_modules`: Node.js の依存パッケージ
+- `.venv`: Python 仮想環境
 - `target`: Rust / Maven などのビルド成果物
 - `.gradle`: Gradle のプロジェクトキャッシュ
 - `.terraform`: Terraform provider の実行ファイルと初期化データ
 
-volume 名には `${devcontainerId}` を含めるため、ホストとは共有せず、同時に起動した別の devcontainer
-とも共有しません。同じ devcontainer のリビルド時には volume が再利用されます。ホスト側に同名の
-ディレクトリが存在してもコンテナ内からは見えず、コンテナ内で作成した内容もホスト側には書き込まれません。
+ワークスペース直下だけでなく、既存の対象ディレクトリを任意の深さから検出します。また、まだ対象が
+作られていなくても `package.json`、`pyproject.toml`、`Cargo.toml`、`pom.xml`、Gradle 設定、Terraform
+ファイルなどの場所から mount point を作るため、monorepo の `apps/*` や `packages/*` も分離されます。
+`.git` と検出済みの生成物以下は走査しません。
 
-対象はワークスペース直下のディレクトリです。monorepo でサブディレクトリごとに `node_modules` などを
-作る構成では、依存関係をルートへ集約するか、プロジェクト固有の devcontainer 設定に追加の volume mount
-を定義してください。devcontainer の `mounts` はコンテナ作成前に確定し、target に glob を指定できないため、
-共通設定だけで任意の深さにある同名ディレクトリを安全に自動マウントすることはできません。
+格納先は Docker named volume ではなくコンテナ自身の writable layer です。ホストや別のコンテナとは共有されず、
+コンテナを削除すれば生成物も一緒に削除されるため、volume の手動削除は不要です。コンテナの停止・再起動時には
+`postStartCommand` が bind mount を張り直すので、同じコンテナ内の生成物は引き続き利用できます。
 
-例えば `apps/web` と `packages/ui` に依存関係を置く monorepo では、プロジェクト側の
-`.devcontainer/devcontainer.json` に次のような mount を追加します。
-
-```jsonc
-{
-  "mounts": [
-    "source=web-node-modules-${devcontainerId},target=${localWorkspaceFolder}/apps/web/node_modules,type=volume",
-    "source=ui-node-modules-${devcontainerId},target=${localWorkspaceFolder}/packages/ui/node_modules,type=volume",
-  ],
-}
-```
-
-追加した mount が初回作成時に `root` 所有となる環境では、プロジェクトの `postCreateCommand` でも各 target に
-`sudo chown "$(id -u):$(id -g)" <target>` を実行してください。任意階層の検出・マウントと lifecycle command の
-安全な合成を共通設定だけで行うと複雑になるため、自動化はワークスペース直下に限定しています。
-
-### 不要になった volume の削除
-
-named volume は devcontainer を削除しても自動削除されません。使わなくなった worktree / devcontainer の
-volume がディスクを占有し続けないよう、関連するコンテナを停止・削除した後、ホスト側で定期的に次を実行します。
+プロジェクト定義ファイルを追加した直後など、コンテナ起動後に新しい対象パスが生じた場合は、次を実行するか
+コンテナを再起動してください。
 
 ```bash
-# 対象を確認
-docker volume ls --filter 'name=^devcontainer-(node-modules|python-venv|rust-target|gradle-project-cache|terraform-data)-'
-
-# この設定が作成した未使用 volume だけを削除
-docker volume ls --quiet \
-  --filter 'name=^devcontainer-(node-modules|python-venv|rust-target|gradle-project-cache|terraform-data)-' \
-  | while IFS= read -r volume; do
-      [ -z "$volume" ] || docker volume rm "$volume"
-    done
+bash ~/.config/devcontainer/scripts/mount-container-only-dirs.sh "$PWD"
 ```
-
-使用中の volume は Docker が削除を拒否します。`devcontainer-dind-var-lib-docker-*` は Docker image などの
-永続化用途なので、上記の削除対象には含めていません。
 
 ## devcontainer 内での docker compose / DB コンテナ（DinD）
 

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -18,14 +18,48 @@ macOS ホストと Linux コンテナでネイティブバイナリや実行環�
 - `.gradle`: Gradle のプロジェクトキャッシュ
 - `.terraform`: Terraform provider の実行ファイルと初期化データ
 
+### writable layer と bind mount を使う理由
+
+通常、`${localWorkspaceFolder}/node_modules` はワークスペースの bind mount に含まれるため、コンテナから
+書いた内容がそのまま macOS 側にも現れます。この設定では、同じパスへコンテナ内の別ディレクトリを
+bind mount して、次のように見える場所と実際の保存先を差し替えます。
+
+| コンテナから見えるパス              | 実際の保存先（コンテナ内）                       | ホストから見える内容          |
+| ----------------------------------- | ------------------------------------------------ | ----------------------------- |
+| `<workspace>/apps/web/node_modules` | `/var/lib/devcontainer-project-artifacts/<hash>` | mount point用の空ディレクトリ |
+| `<workspace>/packages/api/.venv`    | `/var/lib/devcontainer-project-artifacts/<hash>` | mount point用の空ディレクトリ |
+
+Dockerコンテナのwritable layerは、そのコンテナだけが持つ書き込み領域です。ここを保存先にすることで、
+
+- Linux用native addonや実行ファイルがmacOS側へ書き込まれない
+- ホストに既にあるmacOS用生成物はmountの下に隠れ、コンテナから誤って利用されない
+- 別のdevcontainerとも生成物を共有しない
+- named volumeと違い、コンテナ削除時にDockerがwritable layerも削除するため手動掃除が不要
+
+という状態になります。ソースコードなど他のファイルは従来のworkspace bind mount上にあるため、コンテナでの
+編集は引き続きホストへ反映されます。生成物ディレクトリだけを局所的に差し替えるのがこの方式のポイントです。
+
 ワークスペース直下だけでなく、既存の対象ディレクトリを任意の深さから検出します。また、まだ対象が
 作られていなくても `package.json`、`pyproject.toml`、`Cargo.toml`、`pom.xml`、Gradle 設定、Terraform
 ファイルなどの場所から mount point を作るため、monorepo の `apps/*` や `packages/*` も分離されます。
 `.git` と検出済みの生成物以下は走査しません。
 
+`target` は一般的なディレクトリ名でもあるため、名前だけでは検出しません。同じ階層に`Cargo.toml`または
+`pom.xml`がある場合に限り、Rust/Mavenの生成物として分離します。
+
 格納先は Docker named volume ではなくコンテナ自身の writable layer です。ホストや別のコンテナとは共有されず、
 コンテナを削除すれば生成物も一緒に削除されるため、volume の手動削除は不要です。コンテナの停止・再起動時には
 `postStartCommand` が bind mount を張り直すので、同じコンテナ内の生成物は引き続き利用できます。
+
+bind mountのtargetにはLinuxの仕様上ディレクトリが必要です。対象が未作成の場合はworkspace（ホスト）側にも
+空のmount pointが作られますが、依存パッケージやビルド成果物の実体はそこへ書かれません。この空ディレクトリは
+通常それぞれのツール向け`.gitignore`の対象です。
+
+検出は`postCreateCommand` / `postStartCommand`を実行した時点のスナップショットです。manifestのない場所で
+起動中に`python -m venv .venv`などを新規実行すると、その回はホスト側へ作成されます。また、後からスクリプトを
+実行しても既存内容はコンテナ側へコピーせず、mountの下に隠します。これはmacOS用生成物をLinux環境へコピーして
+再利用しないための意図的な動作です。その場合はホスト側の生成物を削除し、下記コマンドでmountした後にコンテナ内で
+依存関係を作り直してください。
 
 プロジェクト定義ファイルを追加した直後など、コンテナ起動後に新しい対象パスが生じた場合は、次を実行するか
 コンテナを再起動してください。

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -24,7 +24,44 @@ volume 名には `${devcontainerId}` を含めるため、ホストとは共有�
 
 対象はワークスペース直下のディレクトリです。monorepo でサブディレクトリごとに `node_modules` などを
 作る構成では、依存関係をルートへ集約するか、プロジェクト固有の devcontainer 設定に追加の volume mount
-を定義してください。
+を定義してください。devcontainer の `mounts` はコンテナ作成前に確定し、target に glob を指定できないため、
+共通設定だけで任意の深さにある同名ディレクトリを安全に自動マウントすることはできません。
+
+例えば `apps/web` と `packages/ui` に依存関係を置く monorepo では、プロジェクト側の
+`.devcontainer/devcontainer.json` に次のような mount を追加します。
+
+```jsonc
+{
+  "mounts": [
+    "source=web-node-modules-${devcontainerId},target=${localWorkspaceFolder}/apps/web/node_modules,type=volume",
+    "source=ui-node-modules-${devcontainerId},target=${localWorkspaceFolder}/packages/ui/node_modules,type=volume",
+  ],
+}
+```
+
+追加した mount が初回作成時に `root` 所有となる環境では、プロジェクトの `postCreateCommand` でも各 target に
+`sudo chown "$(id -u):$(id -g)" <target>` を実行してください。任意階層の検出・マウントと lifecycle command の
+安全な合成を共通設定だけで行うと複雑になるため、自動化はワークスペース直下に限定しています。
+
+### 不要になった volume の削除
+
+named volume は devcontainer を削除しても自動削除されません。使わなくなった worktree / devcontainer の
+volume がディスクを占有し続けないよう、関連するコンテナを停止・削除した後、ホスト側で定期的に次を実行します。
+
+```bash
+# 対象を確認
+docker volume ls --filter 'name=^devcontainer-(node-modules|python-venv|rust-target|gradle-project-cache|terraform-data)-'
+
+# この設定が作成した未使用 volume だけを削除
+docker volume ls --quiet \
+  --filter 'name=^devcontainer-(node-modules|python-venv|rust-target|gradle-project-cache|terraform-data)-' \
+  | while IFS= read -r volume; do
+      [ -z "$volume" ] || docker volume rm "$volume"
+    done
+```
+
+使用中の volume は Docker が削除を拒否します。`devcontainer-dind-var-lib-docker-*` は Docker image などの
+永続化用途なので、上記の削除対象には含めていません。
 
 ## devcontainer 内での docker compose / DB コンテナ（DinD）
 

--- a/dot_config/devcontainer/devcontainer.json
+++ b/dot_config/devcontainer/devcontainer.json
@@ -54,13 +54,6 @@
     // 本体の .git (2つ上の階層) を、ホストと同じ絶対パスにマウント
     "source=${localWorkspaceFolder}/../..,target=${localWorkspaceFolder}/../..,type=bind",
     "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
-    // OS / CPU 依存の生成物をホスト(macOS)と共有しない。
-    // devcontainer ごとの named volume でホスト側の同名ディレクトリを隠しつつ、リビルド後も再利用する。
-    "source=devcontainer-node-modules-${devcontainerId},target=${localWorkspaceFolder}/node_modules,type=volume",
-    "source=devcontainer-python-venv-${devcontainerId},target=${localWorkspaceFolder}/.venv,type=volume",
-    "source=devcontainer-rust-target-${devcontainerId},target=${localWorkspaceFolder}/target,type=volume",
-    "source=devcontainer-gradle-project-cache-${devcontainerId},target=${localWorkspaceFolder}/.gradle,type=volume",
-    "source=devcontainer-terraform-data-${devcontainerId},target=${localWorkspaceFolder}/.terraform,type=volume",
     // AI agent configs
     "type=bind,source=${localEnv:HOME}/.claude,target=/home/vscode/.claude",
     "type=bind,source=${localEnv:HOME}/.claude/settings.json,target=/home/vscode/.claude/settings.json,readonly",

--- a/dot_config/devcontainer/devcontainer.json
+++ b/dot_config/devcontainer/devcontainer.json
@@ -54,6 +54,13 @@
     // 本体の .git (2つ上の階層) を、ホストと同じ絶対パスにマウント
     "source=${localWorkspaceFolder}/../..,target=${localWorkspaceFolder}/../..,type=bind",
     "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
+    // OS / CPU 依存の生成物をホスト(macOS)と共有しない。
+    // devcontainer ごとの named volume でホスト側の同名ディレクトリを隠しつつ、リビルド後も再利用する。
+    "source=devcontainer-node-modules-${devcontainerId},target=${localWorkspaceFolder}/node_modules,type=volume",
+    "source=devcontainer-python-venv-${devcontainerId},target=${localWorkspaceFolder}/.venv,type=volume",
+    "source=devcontainer-rust-target-${devcontainerId},target=${localWorkspaceFolder}/target,type=volume",
+    "source=devcontainer-gradle-project-cache-${devcontainerId},target=${localWorkspaceFolder}/.gradle,type=volume",
+    "source=devcontainer-terraform-data-${devcontainerId},target=${localWorkspaceFolder}/.terraform,type=volume",
     // AI agent configs
     "type=bind,source=${localEnv:HOME}/.claude,target=/home/vscode/.claude",
     "type=bind,source=${localEnv:HOME}/.claude/settings.json,target=/home/vscode/.claude/settings.json,readonly",

--- a/dot_config/devcontainer/scripts/executable_mount-container-only-dirs.sh
+++ b/dot_config/devcontainer/scripts/executable_mount-container-only-dirs.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+workspace=${1:?workspace path is required}
+storage_root=/var/lib/devcontainer-project-artifacts
+declare -A targets=()
+
+add_target() {
+	local target=$1
+	case "${target}" in
+	"${workspace}"/*) targets["${target}"]=1 ;;
+	*) echo "error: mount target is outside workspace: ${target}" >&2; exit 1 ;;
+	esac
+}
+
+# 既に存在する対象ディレクトリは、深さを問わず検出する。
+while IFS= read -r -d '' directory; do
+	add_target "${directory}"
+done < <(
+	find "${workspace}" -xdev \
+		\( -name .git -type d -prune \) -o \
+		\( -type d \( -name node_modules -o -name .venv -o -name target -o -name .gradle -o -name .terraform \) -print0 -prune \)
+)
+
+# まだ生成物ディレクトリがない場合も、プロジェクト定義から mount point を先に作る。
+while IFS= read -r -d '' manifest; do
+	directory=$(dirname "${manifest}")
+	case "$(basename "${manifest}")" in
+	package.json) add_target "${directory}/node_modules" ;;
+	pyproject.toml | setup.py | setup.cfg | requirements.txt) add_target "${directory}/.venv" ;;
+	Cargo.toml | pom.xml) add_target "${directory}/target" ;;
+	build.gradle | build.gradle.kts | settings.gradle | settings.gradle.kts) add_target "${directory}/.gradle" ;;
+	*.tf) add_target "${directory}/.terraform" ;;
+	esac
+done < <(
+	find "${workspace}" -xdev \
+		\( -name .git -o -name node_modules -o -name .venv -o -name target -o -name .gradle -o -name .terraform \) -type d -prune -o \
+		-type f \( -name package.json -o -name pyproject.toml -o -name setup.py -o -name setup.cfg \
+		-o -name requirements.txt -o -name Cargo.toml -o -name pom.xml -o -name build.gradle \
+		-o -name build.gradle.kts -o -name settings.gradle -o -name settings.gradle.kts -o -name '*.tf' \) -print0
+)
+
+sudo install -d -o "$(id -u)" -g "$(id -g)" "${storage_root}"
+for target in "${!targets[@]}"; do
+	mountpoint -q "${target}" && continue
+	key=$(printf '%s' "${target}" | sha256sum | cut -d ' ' -f 1)
+	backing_dir="${storage_root}/${key}"
+	sudo install -d -o "$(id -u)" -g "$(id -g)" "${target}" "${backing_dir}"
+	sudo mount --bind "${backing_dir}" "${target}"
+done
+
+echo "✓ ${#targets[@]} 個のプロジェクト生成物をコンテナ内に分離しました"

--- a/dot_config/devcontainer/scripts/executable_mount-container-only-dirs.sh
+++ b/dot_config/devcontainer/scripts/executable_mount-container-only-dirs.sh
@@ -19,7 +19,7 @@ while IFS= read -r -d '' directory; do
 done < <(
 	find "${workspace}" -xdev \
 		\( -name .git -type d -prune \) -o \
-		\( -type d \( -name node_modules -o -name .venv -o -name target -o -name .gradle -o -name .terraform \) -print0 -prune \)
+		\( -type d \( -name node_modules -o -name .venv -o -name .gradle -o -name .terraform \) -print0 -prune \)
 )
 
 # まだ生成物ディレクトリがない場合も、プロジェクト定義から mount point を先に作る。
@@ -45,6 +45,9 @@ for target in "${!targets[@]}"; do
 	mountpoint -q "${target}" && continue
 	key=$(printf '%s' "${target}" | sha256sum | cut -d ' ' -f 1)
 	backing_dir="${storage_root}/${key}"
+	if [ -d "${target}" ] && [ -n "$(find "${target}" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+		echo "ℹ️ ホスト側の既存内容を移行せず隠します: ${target}" >&2
+	fi
 	sudo install -d -o "$(id -u)" -g "$(id -g)" "${target}" "${backing_dir}"
 	sudo mount --bind "${backing_dir}" "${target}"
 done

--- a/dot_config/devcontainer/scripts/executable_post-create.sh
+++ b/dot_config/devcontainer/scripts/executable_post-create.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# named volume は初回マウント時に root 所有で作られることがあるため、
+# コンテナユーザーが依存関係やビルド成果物を書き込めるようにする。
+for container_only_dir in node_modules .venv target .gradle .terraform; do
+	sudo chown "$(id -u):$(id -g)" "${PWD}/${container_only_dir}"
+done
+
 # .claude.json のコピー（既存の処理）
 if [ ! -f ~/.claude.json ] && [ -f /tmp/claude-config-host.json ]; then
 	cp /tmp/claude-config-host.json ~/.claude.json

--- a/dot_config/devcontainer/scripts/executable_post-create.sh
+++ b/dot_config/devcontainer/scripts/executable_post-create.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 set -e
 
-# named volume は初回マウント時に root 所有で作られることがあるため、
-# コンテナユーザーが依存関係やビルド成果物を書き込めるようにする。
-for container_only_dir in node_modules .venv target .gradle .terraform; do
-	sudo chown "$(id -u):$(id -g)" "${PWD}/${container_only_dir}"
-done
+# OS 依存の生成物を、ホストへ書き込まないコンテナローカル領域へ切り替える。
+bash /home/vscode/.config/devcontainer/scripts/mount-container-only-dirs.sh "${PWD}"
 
 # .claude.json のコピー（既存の処理）
 if [ ! -f ~/.claude.json ] && [ -f /tmp/claude-config-host.json ]; then

--- a/dot_config/devcontainer/scripts/executable_post-start.sh
+++ b/dot_config/devcontainer/scripts/executable_post-start.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# コンテナ再起動時には bind mount を張り直す必要がある。
+bash /home/vscode/.config/devcontainer/scripts/mount-container-only-dirs.sh "${PWD}"
+
 # SSH configを生成（~/.config/ssh/configに配置）
 mkdir -p ~/.config/ssh
 SSH_CONFIG=~/.config/ssh/config

--- a/dot_config/devcontainer/scripts/executable_post-start.sh
+++ b/dot_config/devcontainer/scripts/executable_post-start.sh
@@ -2,7 +2,9 @@
 set -e
 
 # コンテナ再起動時には bind mount を張り直す必要がある。
-bash /home/vscode/.config/devcontainer/scripts/mount-container-only-dirs.sh "${PWD}"
+if ! bash /home/vscode/.config/devcontainer/scripts/mount-container-only-dirs.sh "${PWD}"; then
+	echo "⚠️ プロジェクト生成物の分離に失敗しましたが、残りの起動処理を続行します" >&2
+fi
 
 # SSH configを生成（~/.config/ssh/configに配置）
 mkdir -p ~/.config/ssh


### PR DESCRIPTION
## 概要

- named volume を廃止し、生成物をコンテナ writable layer へ bind mount
- `node_modules`、`.venv`、`target`、`.gradle`、`.terraform` を任意階層から検出
- manifest から未作成の mount point も検出し、monorepo のサブプロジェクトに対応
- post-create / post-start で自動設定し、コンテナ削除時は成果物も自動削除

## 確認

- `mise run lint:json`
- `mise run lint:md`
- `mise run lint:secret`
- `bash -n dot_config/devcontainer/scripts/executable_mount-container-only-dirs.sh`
- mock workspace による monorepo target 検出テスト
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces named-volume-backed project artifacts with recursive discovery and container-local bind mounts that are restored during devcontainer lifecycle hooks.
- Detects existing and manifest-implied `node_modules`, `.venv`, `target`, `.gradle`, and `.terraform` directories throughout the workspace.
- Stores generated content in the container writable layer and mounts it over workspace artifact paths.
- Runs the setup during post-create and post-start, with expanded operational documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| dot_config/devcontainer/scripts/executable_mount-container-only-dirs.sh | Adds recursive artifact discovery, manifest-derived mount points, hashed container-local storage, and bind-mount setup; no follow-up-eligible finding was established. |
| dot_config/devcontainer/scripts/executable_post-create.sh | Configures artifact isolation before the existing post-create initialization. |
| dot_config/devcontainer/scripts/executable_post-start.sh | Restores artifact bind mounts on startup while allowing unrelated startup work to continue if restoration fails. |
| docs/devcontainer.md | Documents the writable-layer architecture, recursive detection behavior, lifecycle, limitations, and manual refresh procedure. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Start["postCreate / postStart"] --> Scan["Scan workspace manifests and artifact directories"]
    Scan --> Targets["Deduplicate mount targets"]
    Targets --> Storage["Create hashed backing directories under /var/lib/devcontainer-project-artifacts"]
    Storage --> Mount["Bind mount backing directories over workspace artifact paths"]
    Mount --> Tools["Build and package tools write container-local artifacts"]
    Tools --> Restart["Container restart"]
    Restart --> Start
    Tools --> Remove["Container removal"]
    Remove --> Cleanup["Writable-layer artifacts are deleted"]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(devcontainer): address artifact moun..."](https://github.com/ryo246912/dotfiles/commit/698abed2b54a5ab3e454570f2db22633e08bbcbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53731930)</sub>

**Context used:**

- Knowledge Base — [AI agent configuration (Claude Code, Codex, APM, rulesync)](https://app.greptile.com/ryo/-/custom-context/knowledge-base/ryo246912/dotfiles/-/docs/ai-agent-config.md)

<!-- /greptile_comment -->