### PR TITLE
docs: jitpass の導入設定と利用ガイドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@
 # Setup
 
 - [setup](docs/setup.md)
+- [jitpass (`jit`)](docs/jit.md)

--- a/docs/jit.md
+++ b/docs/jit.md
@@ -1,0 +1,214 @@
+# jitpass (`jit`)
+
+[`jitpass/jit`](https://github.com/jitpass/jit) は、開発端末上の平文 credential を
+Touch ID で保護されたローカル vault に移し、許可したプロセスへ必要な時だけ渡すための
+macOS 向け CLI。`.env`、shell export、AWS credential、Docker/Git credential helper、
+各種 CLI token などを対象にできる。
+
+> 現時点の公式 prebuilt binary は **Apple Silicon macOS 専用**。また、vault を開いた後に
+> credential を受け取ったプロセスのメモリまでは保護しない。アカウント侵害への対策や
+> credential の rotation の代わりにはならない。
+
+## このリポジトリでの導入設定
+
+公式が推奨する Homebrew formula を `bootstrap:mac-packages` から導入する。
+
+```sh
+mise run bootstrap:mac-packages
+```
+
+このタスクは Apple Silicon で `brew install jitpass/tap/jitpass` を実行し、導入済みなら
+何もしない。Intel Mac では prebuilt binary がないため skip する。Homebrew 経由では
+download に quarantine attribute が付き、初回実行前に Gatekeeper が署名と notarization
+ticket を検証できる。セキュリティツールなので、mise の GitHub backend や `curl | tar` で
+binary を直接置く方法は採用しない。
+
+単独で手動導入する場合も同じ公式 formula を使う。
+
+```sh
+brew install jitpass/tap/jitpass
+jit doctor
+```
+
+`jit doctor` の `jit` 行で署名の Team ID が `CZC6BH93GJ` と表示されることを確認する。
+Homebrew なら shell completion も同時に導入される。公式の最新要件は
+[Install](https://github.com/jitpass/jit#install) を参照する。
+
+## 初回セットアップ
+
+### 1. 平文 credential を調査する
+
+```sh
+# home directory 全体を調査（read-only）
+jit scan
+
+# まず対象を狭く調べる場合
+jit scan ~/.aws ~/src/my-project
+
+# category ごとの詳細を表示
+jit scan --full
+```
+
+`jit scan` は対象ファイルを書き換えず、実値を完全な形では表示しない。ただし引数なしでは
+home directory 全体を走査するため、初回は時間がかかることがある。
+
+### 2. vault を初期化する
+
+```sh
+jit vault init
+```
+
+master key は macOS login Keychain に保存され、Touch ID（または macOS の認証）が求められる。
+vault の実データは dotfiles に追加しない。
+
+### 3. migration を preview して適用する
+
+最初から home directory 全体を変更せず、まず 1 project で `--dry-run` する。
+
+```sh
+jit migrate ~/src/my-project --dry-run
+jit migrate ~/src/my-project
+```
+
+実行時には変更計画と確認プロンプトが出る。対象ファイルは書き換え前に暗号化 backup される。
+`.env` などは通常ファイルから named pipe (FIFO) を使う live mount に変わる場合があるため、
+**未コミットの変更を先に確認し、migration 後にも `git status` を確認する**。
+
+問題があれば直前の migration を復元できる。
+
+```sh
+jit migrate undo
+```
+
+1 project で挙動を確認した後、`jit scan` の提案に従って個別 path、または端末全体へ広げる。
+
+```sh
+jit migrate --dry-run
+jit migrate
+```
+
+### 4. 状態と診断を確認する
+
+```sh
+jit status
+jit doctor
+```
+
+最初の migration 時に background service が自動設定される。`status` は vault、service、mount、
+profile の概要確認、`doctor` は署名、backup、shim、secret envelope を含む詳細診断に使う。
+
+## 日常の使い方
+
+### project の command に secret を渡す
+
+```sh
+# 通常: profile の値を command の環境変数へ注入
+jit run -- npm run dev
+
+# docker compose の env_file など、command が .env 自体を読む場合
+jit run --live -- docker compose up
+
+# GCP ADC など machine-global credential を明示する場合
+jit run --with gcp -- terraform plan
+
+# project の live mount と global credential の両方が必要な場合
+jit run --live --with gcp -- command
+```
+
+まず通常の `jit run -- <command>` を使い、command が `.env` file を直接読む場合だけ `--live`
+を追加する。詳細は公式の [Run a command with secrets](https://github.com/jitpass/jit/blob/main/docs/run/index.md)
+を参照する。
+
+### CLI token を wrap する
+
+`gh`、`glab`、`stripe` など自身の設定ファイルに token を保存する CLI は、一度 wrap すれば
+以後は通常どおりの command 名で使える。
+
+```sh
+jit wrap gh
+gh pr list
+```
+
+どの tool が `migrate` / `wrap` / credential helper の対象かは
+[Supported tools](https://github.com/jitpass/jit/blob/main/docs/tools.md) で確認する。
+
+### 長時間処理や AI agent に期限付きで許可する
+
+離席中の agent や長時間処理では、対象 process、profile、期限を限定した grant を事前に作る。
+
+```sh
+jit grant --process claude --profile my-project --for 8h
+jit grant list
+jit grant revoke <grant-id>
+```
+
+無期限に consent を無効化するより、期限付き grant を優先する。grant は実行した terminal の
+process tree に限定されるが、許可対象と期限を確認してから Touch ID を承認する。
+
+### session を管理する
+
+```sh
+# 直ちに lock
+jit lock
+
+# idle timeout を変更（例: 15分）
+jit service ttl 15m
+
+# 利用履歴を確認
+jit audit
+```
+
+default では vault の unlock と、各 tool へ credential を渡す最初の consent は別の確認になる。
+vault が開いていても意図しない process に secret を渡さないため、通常は consent を有効のまま
+運用する。
+
+## 更新
+
+Homebrew 管理にそろえ、次で更新する。
+
+```sh
+brew update
+brew upgrade jitpass
+jit doctor
+```
+
+`jit upgrade` にも署名と checksum を検証する self-update があるが、このリポジトリでは
+導入元を Homebrew に一本化するため `brew upgrade jitpass` を使う。更新しても vault は保持される。
+
+## トラブルシューティング
+
+### `jit run` でも設定が空に見える
+
+command が環境変数ではなく `.env` file 自体を開いている可能性がある。
+
+```sh
+jit run --live -- <command>
+```
+
+### Touch ID prompt が多い
+
+service の状態と TTL を確認する。
+
+```sh
+jit status
+jit service ttl
+```
+
+一括処理だけを承認する場合は `jit run --trust -- <command>`、離席を伴う場合は期限付き
+`jit grant` を検討する。利便性だけを理由に `jit service consent off` を常用しない。
+
+### migration を戻したい
+
+```sh
+jit migrate undo
+```
+
+復元後に `git status` と対象 tool の動作を確認する。vault を含めて削除する操作は recovery
+不能になり得るため、`jit uninstall --purge` を安易に実行しない。
+
+## 関連資料
+
+- [jitpass documentation](https://github.com/jitpass/jit/blob/main/docs/index.md)
+- [Quickstart](https://github.com/jitpass/jit/blob/main/docs/getting-started/quickstart.md)
+- [Security architecture](https://github.com/jitpass/jit/blob/main/docs/security/architecture.md)
+- [Command reference](https://github.com/jitpass/jit/blob/main/docs/reference/commands/jit.md)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -31,6 +31,9 @@
   mise run bootstrap:mac
   ```
 
+  - Apple Silicon では jitpass も導入される。vault の初期化と credential の migration は
+    [`jitpass (jit)`](./jit.md) を参照する
+
 - [ ] karabiner-elements
   - [ ] 「Default」というProfile名を作成 or リネーム
   - [ ] `karabiner.ts`を実行

--- a/dot_config/mise/tasks/bootstrap-mac.toml
+++ b/dot_config/mise/tasks/bootstrap-mac.toml
@@ -33,7 +33,8 @@ export PATH="/opt/homebrew/bin:$PATH"
 
 # jitpass: Gatekeeper が notarization ticket を検証できる公式 Homebrew formula を使う。
 # mise の GitHub backend で binary を直接配置せず、公式推奨の導入経路にそろえる。
-if [ "$(uname -m)" = "arm64" ]; then
+# Rosetta shell では `uname -m` が x86_64 になるため、translation 状態も確認する。
+if [ "$(uname -m)" = "arm64" ] || [ "$(sysctl -in sysctl.proc_translated 2>/dev/null || true)" = "1" ]; then
   if ! brew list jitpass &>/dev/null; then
     brew install jitpass/tap/jitpass
   else

--- a/dot_config/mise/tasks/bootstrap-mac.toml
+++ b/dot_config/mise/tasks/bootstrap-mac.toml
@@ -31,6 +31,18 @@ set -euo pipefail
 [ "$(uname)" = "Darwin" ] || { echo "mac 専用タスクです"; exit 1; }
 export PATH="/opt/homebrew/bin:$PATH"
 
+# jitpass: Gatekeeper が notarization ticket を検証できる公式 Homebrew formula を使う。
+# mise の GitHub backend で binary を直接配置せず、公式推奨の導入経路にそろえる。
+if [ "$(uname -m)" = "arm64" ]; then
+  if ! brew list jitpass &>/dev/null; then
+    brew install jitpass/tap/jitpass
+  else
+    echo "jitpass is already installed"
+  fi
+else
+  echo "jitpass prebuilt release is Apple Silicon only; skipping"
+fi
+
 # google-japanese-ime: Rosetta が前提で brew-cask では表現できない。
 # rosetta のインストール失敗（既に導入済み等）で後続の thock 導入を止めないよう || true にする
 if ! brew list --cask google-japanese-ime &>/dev/null; then


### PR DESCRIPTION
## 概要

- macOS bootstrap から jitpass 公式 Homebrew formula を導入
- vault 初期化、migration、日常利用、grant、更新、トラブルシューティングを日本語で文書化
- README とセットアップ手順からガイドへリンク

## 確認

- `git diff --check`
- Python `tomllib` による `bootstrap-mac.toml` の構文確認
- Markdown のローカルリンクおよび外部リンク確認

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Homebrew 経由での `jitpass` 導入を macOS ブートストラップに追加し、日本語ガイドを新規作成。旧: 自動導入なし。新: Apple Silicon で `bootstrap:mac-packages` が公式 formula `jitpass/tap/jitpass` を導入し、Rosetta 上でも誤検出せずにインストール。Intel Mac はスキップし、Gatekeeper 検証を有効化。

**レビュー/ロールアウト**
- ブートストラップ: `dot_config/mise/tasks/bootstrap-mac.toml` が `uname -m` に加え `sysctl.proc_translated` を確認し、Rosetta の `x86_64` でも Apple Silicon として導入。`brew list jitpass` で冪等。Intel は明示的にスキップ。
- ドキュメント: `docs/jit.md` を追加し、`README.md` と `docs/setup.md` からリンク。初期化、migration、日常利用、grant、更新、トラブルシュートを網羅。
- 必要な作業（Apple Silicon 開発者）: `mise run bootstrap:mac-packages` 実行後、`jit vault init` と `jit migrate` を実施。`jit doctor` で Team ID `CZC6BH93GJ` を確認。`jit migrate` は変更が入るため、まず `--dry-run` と `git status` を確認。
- 運用: 更新は `brew upgrade jitpass` に統一。Intel Mac への影響はなし。

<sup>Written for commit a4742dd1c05f392b84d3657aa73814d2f6b68611. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
- macOS の Apple Silicon 環境に `jitpass` の公式 Homebrew formula を導入する設定を追加しました。
- vault の初期化、credential の migration、grant、更新、トラブルシューティングを日本語で文書化しました。
- README とセットアップ手順から `jitpass` ガイドへリンクしました。

## 変更理由
- macOS 環境で `jitpass` を導入しやすくします。
- `jitpass` の日常利用手順と注意事項を一元化します。

## 確認した項目
- `git diff --check`
- Python `tomllib` による `bootstrap-mac.toml` の構文確認
- Markdown のローカルリンク確認
- Markdown の外部リンク確認

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Apple Silicon installation of jitpass through its official Homebrew formula and documents setup, migration, daily usage, updates, and troubleshooting.
- Detects both native and Rosetta-translated Apple Silicon processes before installing jitpass.
- Adds a comprehensive Japanese jitpass guide.
- Links the guide from the README and macOS setup checklist.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the updated architecture check addresses the previously reported Rosetta case.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| dot_config/mise/tasks/bootstrap-mac.toml | Adds an idempotent jitpass installation path with native and Rosetta Apple Silicon detection. |
| docs/jit.md | Documents jitpass installation, vault initialization, migration, grants, updates, and troubleshooting. |
| docs/setup.md | Directs Apple Silicon users to the new jitpass initialization and migration guide. |
| README.md | Adds a top-level link to the jitpass guide. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(jit): Rosetta 上で Apple Silicon を検出"](https://github.com/ryo246912/dotfiles/commit/a4742dd1c05f392b84d3657aa73814d2f6b68611) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53753504)</sub>

<!-- /greptile_comment -->