### PR TITLE
feat(devcontainer): ホストのtmux pane読み取りを追加

### DIFF
--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -6,6 +6,31 @@ devcontainer 定義は `dot_config/devcontainer/` を参照してください。
 `multi-worktree` や `crit`（docs/crit.md）など、この base template から起動する
 devcontainer はいずれもここに書かれた仕組みを共有します。
 
+## devcontainer からホスト側 tmux pane を読む
+
+ホスト側の開発サーバーログを、devcontainer 内の AI エージェントから確認する場合は
+`host-tmux` を使います。コンテナへ bind mount される devcontainer scripts に同コマンドを置き、
+既存の `mac-host` SSH 接続上でホストの tmux client を実行します。tmux socket 自体をコンテナへ
+mount しないため、ホストとコンテナの UID や socket path の差に依存しません。
+
+```bash
+# pane ID（%3 など）、実行中コマンド、作業ディレクトリを一覧表示
+host-tmux list
+
+# 指定した pane の直近 200 行を取得（行数は省略可能、既定値は 200）
+host-tmux capture %3 200
+```
+
+AI エージェントには、例えば「`host-tmux list` で server の pane を探し、
+`host-tmux capture <pane-id> 300` の出力をもとにエラーを修正して」と指示します。継続的なログ監視が
+必要なら、同じ capture コマンドを一定間隔で再実行させます。pane ID は tmux の session/window 構成を
+変えると変わり得るため、固定値を設定へ埋め込まず、その都度 `list` で確認してください。
+
+この経路は読み取り専用のラッパーですが、利用する SSH 鍵自体は通常のホストログイン権限を持ちます。
+鍵をより厳密に制限したい場合は、ホスト側 `authorized_keys` の `command=` で許可コマンドを制限する
+専用鍵・専用 dispatcher を別途用意してください。また、後述のリモートログイン、公開鍵登録、
+`mac-host` 設定が完了している必要があります。
+
 ## devcontainer 内での docker compose / DB コンテナ（DinD）
 
 base template で `docker-in-docker`（DinD）feature を有効化しているため、devcontainer 内から

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -21,8 +21,8 @@ host-tmux list
 host-tmux capture %3 200
 ```
 
-AI エージェントには、例えば「`host-tmux list` で server の pane を探し、
-`host-tmux capture <pane-id> 300` の出力をもとにエラーを修正して」と指示します。継続的なログ監視が
+AI エージェントには `/tmux %3`（Codex では `$tmux %3`）と指示すると、追加した tmux skill が
+`host-tmux capture` を呼び出してログを分析します。継続的なログ監視が
 必要なら、同じ capture コマンドを一定間隔で再実行させます。pane ID は tmux の session/window 構成を
 変えると変わり得るため、固定値を設定へ埋め込まず、その都度 `list` で確認してください。
 

--- a/dot_config/devcontainer/scripts/executable_host-tmux
+++ b/dot_config/devcontainer/scripts/executable_host-tmux
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# devcontainer から SSH 経由でホスト側 tmux の pane を参照する。
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage:
+  host-tmux list
+  host-tmux capture <pane> [lines]
+
+Examples:
+  host-tmux list
+  host-tmux capture %3 200
+EOF
+}
+
+case "${1-}" in
+list)
+	[ "$#" -eq 1 ] || { usage >&2; exit 2; }
+	;;
+capture)
+	[ "$#" -ge 2 ] && [ "$#" -le 3 ] || { usage >&2; exit 2; }
+	case "$2" in
+	%[0-9]*) ;;
+	*) echo "host-tmux: pane must be an ID such as %3 (run: host-tmux list)" >&2; exit 2 ;;
+	esac
+	case "${2#%}" in
+	'' | *[!0-9]*) echo "host-tmux: pane must be an ID such as %3 (run: host-tmux list)" >&2; exit 2 ;;
+	esac
+	lines="${3:-200}"
+	case "${lines}" in
+	'' | *[!0-9]*) echo "host-tmux: lines must be a positive integer" >&2; exit 2 ;;
+	esac
+	[ "${lines}" -gt 0 ] || { echo "host-tmux: lines must be a positive integer" >&2; exit 2; }
+	set -- "$1" "$2" "$lines"
+	;;
+-h | --help)
+	usage
+	exit 0
+	;;
+*)
+	usage >&2
+	exit 2
+	;;
+esac
+
+ssh_config="${HOME}/.config/ssh/config"
+[ -f "${ssh_config}" ] || {
+	echo "host-tmux: SSH config not found: ${ssh_config}" >&2
+	exit 1
+}
+
+# リモートへ渡す pane ID と行数は上で安全な文字だけに制限する。
+# 非対話 SSH では Homebrew/mise の PATH が通らない場合があるため、代表的な配置も探索する。
+ssh -F "${ssh_config}" -o BatchMode=yes -o ConnectTimeout=5 mac-host \
+	bash -s -- "$@" <<'REMOTE_SCRIPT'
+set -euo pipefail
+
+if command -v tmux >/dev/null 2>&1; then
+	tmux_bin="$(command -v tmux)"
+elif [ -x "${HOME}/.local/share/mise/shims/tmux" ]; then
+	tmux_bin="${HOME}/.local/share/mise/shims/tmux"
+elif [ -x /opt/homebrew/bin/tmux ]; then
+	tmux_bin=/opt/homebrew/bin/tmux
+else
+	echo "host-tmux: tmux was not found on the host" >&2
+	exit 127
+fi
+
+case "$1" in
+list)
+	"${tmux_bin}" list-panes -a \
+		-F '#{pane_id}\t#{session_name}:#{window_index}.#{pane_index}\t#{pane_current_command}\t#{pane_current_path}\t#{pane_width}x#{pane_height}'
+	;;
+capture)
+	"${tmux_bin}" capture-pane -p -J -S "-$3" -t "$2"
+	;;
+esac
+REMOTE_SCRIPT

--- a/dot_config/devcontainer/scripts/executable_host-tmux
+++ b/dot_config/devcontainer/scripts/executable_host-tmux
@@ -52,7 +52,7 @@ ssh_config="${HOME}/.config/ssh/config"
 
 # リモートへ渡す pane ID と行数は上で安全な文字だけに制限する。
 # 非対話 SSH では Homebrew/mise の PATH が通らない場合があるため、代表的な配置も探索する。
-ssh -F "${ssh_config}" -o BatchMode=yes -o ConnectTimeout=5 mac-host \
+timeout 15 ssh -F "${ssh_config}" -o BatchMode=yes -o ConnectTimeout=5 mac-host \
 	bash -s -- "$@" <<'REMOTE_SCRIPT'
 set -euo pipefail
 
@@ -62,6 +62,8 @@ elif [ -x "${HOME}/.local/share/mise/shims/tmux" ]; then
 	tmux_bin="${HOME}/.local/share/mise/shims/tmux"
 elif [ -x /opt/homebrew/bin/tmux ]; then
 	tmux_bin=/opt/homebrew/bin/tmux
+elif [ -x /usr/local/bin/tmux ]; then
+	tmux_bin=/usr/local/bin/tmux
 else
 	echo "host-tmux: tmux was not found on the host" >&2
 	exit 127
@@ -69,11 +71,12 @@ fi
 
 case "$1" in
 list)
+	separator="$(printf '\t')"
 	"${tmux_bin}" list-panes -a \
-		-F '#{pane_id}\t#{session_name}:#{window_index}.#{pane_index}\t#{pane_current_command}\t#{pane_current_path}\t#{pane_width}x#{pane_height}'
+		-F "#{pane_id}${separator}#{session_name}:#{window_index}.#{pane_index}${separator}#{pane_current_command}${separator}#{pane_current_path}${separator}#{pane_width}x#{pane_height}"
 	;;
 capture)
-	"${tmux_bin}" capture-pane -p -J -S "-$3" -t "$2"
+	"${tmux_bin}" capture-pane -p -J -S "-$3" -t "$2" | tail -n "$3"
 	;;
 esac
 REMOTE_SCRIPT

--- a/dot_config/rulesync/exact_dot_rulesync/skills/tmux/SKILL.md
+++ b/dot_config/rulesync/exact_dot_rulesync/skills/tmux/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: tmux
+description: devcontainer からホスト側 tmux pane のログを読み取り、その内容を調査・対応するスキル。`/tmux <pane-id>` または `$tmux <pane-id>` で、別 pane の開発サーバーログやエラーを確認するときに使う。
+targets:
+  - claudecode
+  - codexcli
+  - copilot
+---
+
+# ホスト側 tmux pane の確認
+
+呼び出し時に指定された pane ID（例: `%3`）を使い、次を実行する。
+
+```bash
+host-tmux capture <pane-id>
+```
+
+出力を開発サーバーなどの最新ログとして読み取り、エラーの原因、影響、必要な対応を判断する。
+ユーザーが修正も求めている場合は、ログに基づいて対象コードを調査・修正し、適切なテストを実行する。
+
+## 手順
+
+1. pane ID が `%` と数字からなることを確認する。
+2. pane ID がない、または形式が不正な場合は `host-tmux list` を実行し、候補を示して確認する。
+3. `host-tmux capture <pane-id>` を実行する。既定で直近 200 行まで取得される。
+4. ログの末尾を優先して分析する。過去に出た解消済みエラーと、現在のエラーを混同しない。
+5. 情報が不足する場合だけ、必要な行数を指定して再取得する。
+
+```bash
+host-tmux capture <pane-id> 500
+```
+
+## 制約
+
+- pane 内容の取得には必ず読み取り専用の `host-tmux` を使う。SSH やホスト側 `tmux` を直接実行しない。
+- `send-keys`、`kill-pane`、`respawn-pane` など、ホスト側 tmux の状態を変更する操作は行わない。
+- ログに認証情報や秘密情報が含まれる可能性があるため、必要な箇所だけを回答に要約する。


### PR DESCRIPTION
## 概要
- devcontainer からホストの tmux pane 一覧を取得する `host-tmux list` を追加
- 指定 pane の scrollback を取得する `host-tmux capture` を追加
- AI エージェントへの指示例、SSH 経路、セキュリティ上の注意を文書化

## テスト
- `bash -n dot_config/devcontainer/scripts/executable_host-tmux`
- mock SSH/tmux を使った list/capture/不正引数の確認
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
devcontainer からホストの tmux pane を安全に読み取る `host-tmux` と、エージェント経由で呼び出す `tmux` スキルを追加。従来の「tmux ソケットをコンテナへマウント」から、SSH 経由の読み取り専用フローに変更し、UID/パス差異を回避してログ取得の安定性を上げる。

- `dot_config/devcontainer/scripts/executable_host-tmux` を追加。`host-tmux list` は pane ID/ターゲット/コマンド/CWD/サイズをタブ区切りで出力、`host-tmux capture <pane-id> [lines=200]` は末尾 N 行のみを返す。ホスト上の `tmux` は PATH に加え Homebrew/mise 既定パスも探索。
- `docs/devcontainer.md` に使い方とセキュリティ注意を追記。`dot_config/rulesync/exact_dot_rulesync/skills/tmux/SKILL.md` を追加し、`/tmux <pane-id>`（Codex は `$tmux <pane-id>`）で `host-tmux capture` を実行可能にした。

**レビュー/ロールアウト**
- 必須: `~/.config/ssh/config` に `mac-host` を設定し、devcontainer から鍵認証で接続可能にする。ホストに `tmux` をインストール（`/opt/homebrew/bin/tmux` や `~/.local/share/mise/shims/tmux` を許容）。
- 運用: pane ID は変動するため固定せず、その都度 `host-tmux list` で確認してから `capture` を実行。ラッパーは読み取り専用だが、鍵は通常権限を持つため、必要なら `authorized_keys` の `command=` で専用鍵に許可コマンドを制限。

<sup>Written for commit fc35f73eb17a7f03d3059c54680479c3121d404a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a read-only `host-tmux` wrapper for inspecting host tmux panes from a devcontainer over SSH.
- Adds commands to list host panes and capture a bounded amount of recent pane output.
- Adds a rulesync-managed tmux skill for AI agents.
- Documents setup, usage, and SSH-key security considerations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the current capture pipeline bounds output to the requested line count, and the list format emits actual tab delimiters.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| dot_config/devcontainer/scripts/executable_host-tmux | Adds validated list and capture operations over SSH; both previously reported output-formatting issues are resolved at the current head. |
| dot_config/rulesync/exact_dot_rulesync/skills/tmux/SKILL.md | Adds agent instructions that consistently use the read-only wrapper and avoid state-changing tmux operations. |
| docs/devcontainer.md | Documents host pane access, invocation examples, configuration prerequisites, and SSH credential implications. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(tmux): paneログ確認スキルを追加"](https://github.com/ryo246912/dotfiles/commit/fc35f73eb17a7f03d3059c54680479c3121d404a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53754000)</sub>

**Context used:**

- Knowledge Base — [AI agent configuration (Claude Code, Codex, APM, rulesync)](https://app.greptile.com/ryo/-/custom-context/knowledge-base/ryo246912/dotfiles/-/docs/ai-agent-config.md)

<!-- /greptile_comment -->