### PR TITLE
feature

### DIFF
--- a/dot_config/mise/config.private.toml
+++ b/dot_config/mise/config.private.toml
@@ -1,5 +1,6 @@
 [tools]
 "aqua:Songmu/laminate"   = "0.0.4"
+"aqua:XcodesOrg/xcodes"  = "2.0.3"
 "aqua:k1LoW/deck"        = "1.24.1"
 "aqua:supabase/cli"      = "2.114.0"
 "github:render-oss/cli"  = { version = "2.15.1", rename_exe = "render" }

--- a/dot_config/mise/config.private.toml
+++ b/dot_config/mise/config.private.toml
@@ -9,6 +9,5 @@
 [bootstrap.packages]
 # 実際に WSL を使い始めたら bootstrap-mac.toml 側への切り出しを検討する
 "brew-cask:android-studio" = "latest" # 2026.1.3.7,quail3,AI-261.26222.65.2613.15948027
-"brew-cask:insomnia"       = "latest" # 13.1.0
 "brew-cask:linear"         = "latest" # 1.32.1
 "brew:ffmpeg"              = "latest" # 8.1.2


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `aqua:XcodesOrg/xcodes` 2.0.3 to the private `mise` config and removes `brew-cask:insomnia` from bootstrap. Previously `xcodes` was not provisioned and Insomnia installed automatically; now `xcodes` is pinned via `aqua` and Insomnia is no longer auto-installed.

- Run `mise install` to install `xcodes` 2.0.3 locally.
- If you need Insomnia, install it manually (e.g., `brew install --cask insomnia`) or re-add it to bootstrap.

<sup>Written for commit 95e955d328ebef56805aecff8a799e442d4c81e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the pinned xcodes CLI to the private mise tool configuration and removes Insomnia from its bootstrap package inventory.
- Provisions `XcodesOrg/xcodes` 2.0.3 through aqua.
- Removes the Homebrew cask declaration for Insomnia.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| dot_config/mise/config.private.toml | Updates the private profile’s aqua-managed tools and Homebrew bootstrap packages. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: insomniaを削除"](https://github.com/ryo246912/dotfiles/commit/95e955d328ebef56805aecff8a799e442d4c81e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53826002)</sub>

**Context used:**

- Knowledge Base — [Package and Tool Version Management](https://app.greptile.com/ryo/-/custom-context/knowledge-base/ryo246912/dotfiles/-/docs/package-management.md)

<!-- /greptile_comment -->