### PR TITLE
fix(yazi): 最新のTOMLスキーマ指定方式に更新

### DIFF
--- a/dot_config/yazi/keymap.toml
+++ b/dot_config/yazi/keymap.toml
@@ -1,5 +1,5 @@
 # https://github.com/sxyazi/yazi/blob/shipped/yazi-config/preset/keymap-default.toml
-"$schema" = "https://yazi-rs.github.io/schemas/keymap.json"
+#:schema https://yazi-rs.github.io/schemas/keymap.json
 [mgr]
 prepend_keymap = [
     { on = "z", run = "plugin zoxide", desc = "Jump to a directory via zoxide" },


### PR DESCRIPTION
## 概要
- `keymap.toml` の通常のキーとして記述されていた `$schema` を削除
- Yazi 26.5.6 のプリセットに合わせ、TOML Language Server向けの `#:schema` ディレクティブへ変更

## 背景
`$schema` はYaziから未知のトップレベルキーとして扱われ、設定読み込み時にエラーになります。コメント形式のスキーマディレクティブならYaziの設定値として解釈されず、エディタ側のスキーマ検証も維持できます。

## テスト
- `mise run lint:toml`
- pre-push lint（TOML / JSON / YAML / Markdown）

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `keymap.toml` from a top-level `$schema` key to the TOML Language Server `#:schema` directive to match Yazi 26.5.6 presets. This prevents Yazi from erroring on an unknown top-level key while keeping editor schema validation.

- Old vs new: `$schema` caused a config load error; `#:schema` is a comment directive ignored by Yazi but recognized by the language server.
- No changes to key bindings or runtime behavior; verified with `mise run lint:toml` and pre-push linters.

<sup>Written for commit a4e962c8a206f2593743630eac27e76d77865bec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
`keymap.toml` の `$schema` を `#:schema` ディレクティブに変更しました。

## 変更理由
Yazi 26.5.6 のプリセット形式に合わせます。Yaziによる未知のトップレベルキーの扱いを防ぎ、TOML Language Serverのスキーマ検証を維持します。

## 確認した項目
- `mise run lint:toml`
- TOML・JSON・YAML・Markdownのpre-push lint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Yazi’s keymap schema declaration to the comment-based format supported by Yazi 26.5.6 and TOML tooling.
- Removes the unsupported `$schema` top-level configuration key.
- Adds the equivalent `#:schema` directive without changing key mappings.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The new schema declaration matches the configured Yazi version’s convention, remains valid TOML, and preserves schema integration for the repository’s TOML tooling.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| dot_config/yazi/keymap.toml | Replaces the rejected schema key with Yazi’s supported comment directive; no actionable issues identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(yazi): use TOML schema directive"](https://github.com/ryo246912/dotfiles/commit/a4e962c8a206f2593743630eac27e76d77865bec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54978722)</sub>

<!-- /greptile_comment -->