### PR TITLE
docs: Atat のインストール方法を追記

### DIFF
--- a/docs/mise.md
+++ b/docs/mise.md
@@ -351,3 +351,36 @@ Homebrew API メタデータ（`api/formula/<name>.json` / `api/cask/<token>.jso
 fatal 扱いする**ため、未確認の tap を安易に `[bootstrap.packages]` に入れると、hook 全体を
 壊すリスクがある。追加する場合は先に `mise bootstrap packages apply --dry-run` で個別に
 検証してから。
+
+## Atat のインストール
+
+Atat（<https://atatapp.com/features>）は、現時点では Homebrew Cask に登録されておらず、
+公開された固定バージョンの配布 URL や公式 Homebrew tap も確認できないため、
+`brew install --cask atat` や mise の `brew-cask:atat` では導入できない。
+配布元サイトからダウンロードして手動でインストールする。
+
+```bash
+open https://atatapp.com/features
+```
+
+Homebrew Cask への登録後は、次のコマンドで利用可否を確認できる。
+
+```bash
+brew search --cask atat
+brew info --cask atat
+```
+
+公式 cask が利用可能になった場合は、`dot_config/mise/config.mac.toml` の
+`[bootstrap.packages]` に以下を追加し、通常の macOS パッケージ適用手順で管理する。
+
+```toml
+"brew-cask:atat" = "latest"
+```
+
+```bash
+chezmoi apply
+MISE_ENV=mac mise bootstrap packages apply
+```
+
+配布元が固定 URL とチェックサムを公開していない状態で、HTML から最新のダウンロード URL を
+スクレイピングする独自 task は作らない。サイト変更で壊れやすく、取得物の検証もできないためである。


### PR DESCRIPTION
## 概要

- Atat は現時点で Homebrew Cask / mise 経由では導入できないことを明記
- 現在の手動ダウンロード方法と、将来公式 cask が追加された際の確認・設定手順を追加
- 安定した配布 URL とチェックサムなしで独自ダウンロード task を作らない理由を記載

## テスト

- `mise run lint:md`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Atat installation guidance to `docs/mise.md`, clarifying it is not installable via Homebrew Cask or `mise` today and must be installed manually. This avoids brittle bootstrap steps and checksum-less downloads.

- Current state: `brew install --cask atat` and `brew-cask:atat` do not work; download from the vendor site and install manually. Check future availability with `brew search --cask atat` and `brew info --cask atat`.
- Policy: Do not add a scraping/download task; there is no stable URL or checksum.
- Migration: Do not add Atat to `[bootstrap.packages]`. When an official cask exists, add `"brew-cask:atat" = "latest"` to `dot_config/mise/config.mac.toml`, then run `chezmoi apply` and `MISE_ENV=mac mise bootstrap packages apply`.

<sup>Written for commit 54c92046422780e2c7419a76b2fa4101319df9cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
Atat のインストール手順を追加しました。現時点で利用できる手動インストール方法と、将来公式 cask が提供された場合の設定方法を記載しました。

## 変更理由
Atat は現在、Homebrew Cask と mise からインストールできません。固定 URL とチェックサムがないため、独自のダウンロード task は作成しない方針を明記しました。

## 確認した項目
- `mise run lint:md`
- `git diff --check`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Atat が現在 Homebrew Cask や mise から導入できないことを説明し、手動インストール方法と将来公式 cask が利用可能になった場合の設定手順を追記します。
- 現在利用できない配布経路と手動導入方針を明記
- 将来の cask 確認コマンドと mise 設定例を追加
- 検証可能な固定 URL とチェックサムがない状態で独自 task を作成しない理由を説明

<h3>Confidence Score: 5/5</h3>

確認可能な不具合やリポジトリ規約違反はなく、このドキュメント変更はマージして問題ないと考えられます。

変更は Atat の導入可否、手動インストール、および将来の cask 設定を説明する範囲に限定され、既存の mise パッケージ管理フローを破壊する挙動はありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/mise.md | Atat の現在および将来のインストール手順を追加したドキュメント変更で、確認可能なブロッキング問題はありません。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: document Atat installation options"](https://github.com/ryo246912/dotfiles/commit/54c92046422780e2c7419a76b2fa4101319df9cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55168388)</sub>

<!-- /greptile_comment -->