### PR TITLE
feat(mac): install Tinycast and document launcher configs

### DIFF
--- a/docs/raycast-tinycast.md
+++ b/docs/raycast-tinycast.md
@@ -1,0 +1,77 @@
+# Raycast と Tinycast
+
+## インストール
+
+macOS のパッケージ bootstrap で Raycast と Tinycast を導入する。
+
+```sh
+mise run bootstrap:mac-packages
+```
+
+Tinycast は公式 tap の cask を利用する。サードパーティ tap の Homebrew API メタデータが
+公開されていないため、`[bootstrap.packages]` の `brew-cask:` には入れず、mise task から
+実 Homebrew の `brew trust --tap abue-ammar/tinycast` と
+`brew install --cask abue-ammar/tinycast/tinycast` を実行する。
+
+## Raycast の設定を Git で管理する
+
+Raycast の **Settings → Advanced → Export** で設定を書き出し、出力されたファイルで
+`dot_config/raycast/Raycast.rayconfig` を置き換えてコミットする。新しい Mac では
+**Settings → Advanced → Import** から、chezmoi が配置した
+`~/.config/raycast/Raycast.rayconfig` を読み込む。
+
+```sh
+cp ~/Downloads/Raycast.rayconfig \
+  "$(chezmoi source-path)/dot_config/raycast/Raycast.rayconfig"
+git -C "$(chezmoi source-path)" add dot_config/raycast/Raycast.rayconfig
+git -C "$(chezmoi source-path)" commit -m "chore(raycast): update exported settings"
+```
+
+`.rayconfig` はバイナリのスナップショットであり、通常のテキスト diff や手編集には向かない。
+設定変更後に再 export し、秘密情報を含めないことを確認して更新する。履歴・キャッシュなどの
+Raycast の内部データディレクトリを丸ごと追跡するのではなく、公式の export/import を使う。
+
+### export で管理できるもの
+
+Raycast の export 画面で選択した次の項目を、この 1 ファイルとして管理できる。
+
+- General、Appearance、Advanced などの環境設定
+- グローバルおよび各コマンドのショートカット
+- Extensions と各 Extension の設定
+- Quicklinks、Snippets、Script Commands
+- Floating Notes
+
+アカウント認証、macOS の Accessibility などの権限、Raycast AI の履歴、クリップボード履歴、
+キャッシュは、端末固有または機密性の高いデータであり、このバックアップの管理対象にしない。
+export 時に表示される対象項目を確認し、API key、token、個人情報を含む Extension 設定は選択から
+外す。Raycast のバージョンにより export 対象は変わりうるため、画面の一覧を正とする。
+
+## 比較表
+
+| 観点               | Raycast                                                                           | Tinycast                                                                                                     |
+| ------------------ | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| 位置づけ           | 多機能な生産性ランチャー                                                          | 必要機能に絞った軽量な macOS ランチャー                                                                      |
+| 実装・サイズ       | 独自アプリ。多数の組み込み機能とサービスを統合                                    | SwiftUI + AppKit、依存なし。公式 README では約 3 MB、RAM 100 MB 未満                                         |
+| 基本機能           | アプリ検索、計算、Clipboard History、Snippets、Quicklinks、Window Management など | アプリ検索、計算・単位/通貨変換、Clipboard History、Snippets、カスタム shell command、Window Management など |
+| 拡張               | Raycast Store の豊富な Extensions                                                 | Raycast Extensions を JavaScriptCore で実行し、SwiftUI で描画（互換性は Extension ごとに確認が必要）         |
+| AI                 | Raycast AI（プランや設定に依存）                                                  | 組み込み AI 機能は公式 README に記載なし                                                                     |
+| 同期・バックアップ | Raycast アカウントの Sync と `.rayconfig` の export/import                        | 読みやすい JSON の settings backup/import。Raycast の `.rayconfig` import にも対応                           |
+| 設定を Git 管理    | `.rayconfig` は一括管理しやすいがバイナリで差分確認しにくい                       | JSON backup は差分確認しやすい。ただし権限同意、端末固有パス、Extension 実行許可などは意図的に対象外         |
+| ライセンス         | プロプライエタリ                                                                  | AGPL-3.0 のオープンソース                                                                                    |
+| macOS              | Raycast の現行要件に従う                                                          | macOS 15 Sequoia 用 cask と通常版を提供                                                                      |
+| 向いている用途     | 完成度の高いエコシステム、AI、チーム/クラウド機能を重視                           | 小容量、低オーバーヘッド、オープンソース、ローカル中心を重視                                                 |
+
+## Tinycast 側で Git 管理できる設定
+
+Tinycast の **Settings → Backup** が出力する JSON は、設定、hotkey、custom command、
+quicklink、お気に入りアプリ、非表示 launcher item、alias を保持する。clipboard の内容、notes、
+snippets の本文、Extension 本体/設定は含まれない。また、安全上の理由から keystroke listening を
+有効にする設定、第三者 JavaScript の実行許可、Extension registry、端末固有パス、画面上の位置、
+入力ソースなども除外される。将来 Tinycast の backup も管理する場合は、この JSON を別途 export
+して追跡し、コミット前に custom command や quicklink に秘密情報がないか確認する。
+
+## 参考資料
+
+- [Tinycast repository](https://github.com/abue-ammar/tinycast)
+- [Tinycast settings backup implementation](https://github.com/abue-ammar/tinycast/blob/main/Tinycast/Features/Backup/Model/SettingsBackup.swift)
+- [Raycast: Import & Export](https://manual.raycast.com/preferences/advanced#import-and-export)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -45,6 +45,7 @@
 
 - [ ] Raycast
   - [ ] `Raycast.rayconfig`をインポート
+  - [ ] 設定の管理方法と Tinycast との比較は [Raycast と Tinycast](raycast-tinycast.md) を参照
 
 - [ ] Google日本語入力
   - [ ] 「システム設定」で「キーボード」→「入力ソース」左下の「+」ボタンをクリックして、「日本語」を追加

--- a/dot_config/mise/tasks/bootstrap-mac.toml
+++ b/dot_config/mise/tasks/bootstrap-mac.toml
@@ -117,6 +117,16 @@ else
   echo "raycast is already installed"
 fi
 
+# tinycast: 公式のサードパーティ tap は Homebrew API メタデータを公開していないため、
+# mise の brew-cask バックエンドではなく、この mise task から実 Homebrew を呼び出す。
+# third-party tap の利用には明示的な trust が必要。
+if ! brew list --cask tinycast &>/dev/null; then
+  brew trust --tap abue-ammar/tinycast
+  brew install --cask abue-ammar/tinycast/tinycast
+else
+  echo "tinycast is already installed"
+fi
+
 # opencode-bar: 独自 tap（opgginc/tap）が Homebrew API メタデータ（api/cask/opencode-bar.json）
 # を公開しておらず、brew-cask 経由だと `mise bootstrap packages apply` が 404 で中断する
 if ! brew list --cask opencode-bar &>/dev/null; then


### PR DESCRIPTION
## Summary
- install Tinycast from its official Homebrew tap through the macOS mise bootstrap task
- document how to keep the exported Raycast configuration in Git
- add a Raycast/Tinycast comparison and document which settings can be backed up

## Testing
- `python3` TOML parse check
- `npx --yes oxfmt@0.59.0 --check 'docs/**/*.md'`\n- `git diff --check`\n\n## Notes\n- Full `mise run lint:all` cannot run in this container because repository-managed lint binaries are not installed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs `Tinycast` on macOS during bootstrap and adds guidance on backing up launcher configs. Previously we installed only `Raycast`; now the bootstrap task also installs `Tinycast` from its official tap, and docs explain export/import and what to commit.

- Installs `Tinycast` via `brew trust --tap abue-ammar/tinycast` and `brew install --cask abue-ammar/tinycast/tinycast` in `bootstrap-mac` because third‑party taps without Homebrew API metadata cannot be installed through `mise`’s `brew-cask` backend.
- Adds `docs/raycast-tinycast.md` with: how to export/import `Raycast` settings, what the `.rayconfig` includes/excludes, a `Raycast` vs `Tinycast` comparison, and what `Tinycast` backs up to JSON. Links this from `docs/setup.md`.

**Review and rollout**
- Confirm `brew trust` exists in your Homebrew and that the cask path `abue-ammar/tinycast/tinycast` resolves; the script is idempotent via `brew list --cask tinycast`.
- To install locally: run `mise run bootstrap:mac-packages`.
- To track `Raycast` settings: export and commit to `dot_config/raycast/Raycast.rayconfig`; avoid secrets in exports.

<sup>Written for commit ca6871209193640bb82c95771f207b7ac236a836. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要
- macOS の mise ブートストラップに Tinycast の公式 Homebrew tap 経由のインストール処理を追加しました。
- Raycast の設定を `.rayconfig` として chezmoi/Git で管理する手順を追加しました。
- Raycast と Tinycast の機能、同期、ライセンス、対応 macOS を比較しました。
- Tinycast のバックアップ対象と対象外の設定を文書化しました。

## 変更理由
- macOS の初期セットアップで Tinycast を自動導入できるようにするためです。
- Raycast の設定を Git で管理し、再利用とバックアップを可能にするためです。
- Raycast と Tinycast の選択に必要な情報を整理するためです。

## 確認した項目
- Python による TOML の解析を確認しました。
- `oxfmt` による Markdown のフォーマットを確認しました。
- `git diff --check` を実行しました。
- リポジトリ管理の lint バイナリがコンテナにないため、`mise run lint:all` は実行していません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Tinycast to the macOS bootstrap and documents launcher installation, Raycast export management, and Raycast/Tinycast backup differences.
- Installs Tinycast through its official third-party Homebrew tap.
- Adds a launcher comparison and backup/configuration guidance.
- Links the new guide from the macOS setup checklist.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, although the unnecessary whole-tap trust should be narrowed to reduce supply-chain exposure.

The documented paths and restore workflow match the repository’s chezmoi layout, while the only accepted concern is the non-blocking breadth and compatibility cost of the redundant `brew trust --tap` command.

**Files Needing Attention:** dot_config/mise/tasks/bootstrap-mac.toml

<details open><summary><h3>Security Review</h3></summary>

The explicit whole-tap trust is broader than necessary because the following fully qualified cask installation already limits implicit trust to Tinycast.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| dot_config/mise/tasks/bootstrap-mac.toml | Adds an idempotent Tinycast cask installation, but grants unnecessary trust to the entire third-party tap. |
| docs/raycast-tinycast.md | Adds consistent installation, Raycast export, backup-scope, and launcher-comparison documentation. |
| docs/setup.md | Adds a valid relative link from the Raycast setup checklist to the new guide. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[macOS bootstrap] --> B{Tinycast installed?}
  B -->|No| C[Trust Tinycast tap]
  C --> D[Install fully qualified Tinycast cask]
  B -->|Yes| E[Skip installation]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ryo246912%2Fdotfiles%20PR%20%231335%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ryo246912%2Fdotfiles&pr=1335&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Adot_config%2Fmise%2Ftasks%2Fbootstrap-mac.toml%3A124%0A**Avoid%20whole-tap%20trust**%0A%0AThe%20fully%20qualified%20%60brew%20install%60%20already%20limits%20implicit%20trust%20to%20the%20Tinycast%20cask%2C%20while%20this%20preceding%20command%20trusts%20every%20package%20in%20the%20third-party%20tap%20and%20unnecessarily%20broadens%20the%20supply-chain%20exposure.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ryo246912%2Fdotfiles&pr=1335&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ryo246912%2Fdotfiles%22%20on%20the%20existing%20branch%20%22feat%2Ftinycast-raycast-config%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ftinycast-raycast-config%22.%0A%0A%23%23%23%20Issue%201%0Adot_config%2Fmise%2Ftasks%2Fbootstrap-mac.toml%3A124%0A**Avoid%20whole-tap%20trust**%0A%0AThe%20fully%20qualified%20%60brew%20install%60%20already%20limits%20implicit%20trust%20to%20the%20Tinycast%20cask%2C%20while%20this%20preceding%20command%20trusts%20every%20package%20in%20the%20third-party%20tap%20and%20unnecessarily%20broadens%20the%20supply-chain%20exposure.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ryo246912%2Fdotfiles&pr=1335&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(mac): install tinycast and document..."](https://github.com/ryo246912/dotfiles/commit/ca6871209193640bb82c95771f207b7ac236a836) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55405339)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Package and Tool Version Management](https://app.greptile.com/ryo/-/custom-context/knowledge-base/ryo246912/dotfiles/-/docs/package-management.md)
- Knowledge Base — [Platform-Specific Tooling](https://app.greptile.com/ryo/-/custom-context/knowledge-base/ryo246912/dotfiles/-/docs/platform-specific-tooling.md)

<!-- /greptile_comment -->