### PR TITLE
chore(docker): ローカル設定をdotfiles管理から外す

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -7,7 +7,6 @@
 **/*raycast*
 **/*mac*
 **/*brew*
-.docker/config.json
 {{- end }}
 _*
 plan*

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,7 +1,8 @@
-# git credential の管理
+# git / Docker credential
 
 fnox で管理しているのはアプリ・API用のsecretで、git自身の認証情報はgitのcredential helper
-機構に任せる方が自然なため、fnoxとは別にchezmoiで管理している。
+機構に任せる方が自然なため、fnoxとは別にchezmoiで管理している。Dockerのcredential設定は
+Docker Desktopや利用環境が更新するローカル状態として扱い、dotfilesでは管理しない。
 
 ## git: `credential.helper`
 
@@ -65,3 +66,36 @@ pass show git-credential-manager/<host> # GCM が保存したエントリを pas
 ```
 
 実際に HTTPS 認証が必要なホストへ一度アクセスし、2回目以降パスワードを聞かれなければ有効。
+
+## Docker credential
+
+`docker login`の認証情報は`~/.docker/config.json`から参照される。credential storeが設定されて
+いない場合、認証情報は同ファイルの`auths`へbase64エンコードされるだけで保存されるため、暗号化
+されたsecretとしては扱えない。
+
+`credsStore`を設定すると、認証情報の保存を`docker-credential-<値>`という外部credential helperへ
+委譲できる。たとえば`"credsStore": "desktop"`はDocker Desktop付属の
+`docker-credential-desktop`を使用する。Docker DesktopではOSのkeychainと連携するcredential
+storeがインストール・設定されるため、通常はDocker Desktopが生成した設定をそのまま利用する。
+
+`credHelpers`はレジストリごとに使用するhelperを指定する設定であり、対象レジストリでは
+`credsStore`より優先される。helperバイナリはDocker CLIを実行する環境の`PATH`に必要となる。
+Docker Desktopを使わないLinux環境では、環境に応じて`docker-credential-pass`や
+`docker-credential-secretservice`などを用意する。
+
+### このリポジトリでの扱い
+
+`~/.docker/config.json`にはcredential設定だけでなく、`auths`、`currentContext`、`plugins`、
+`features`などDocker DesktopやCLIが更新するマシン固有の状態も含まれる。そのため、
+`dot_docker/config.json`などのchezmoi sourceは置かず、ファイル全体をdotfiles管理の対象外とする。
+
+設定内容は次のコマンドで確認する。`auths`の各要素に`auth`が直接含まれている場合は、credential
+storeへ移行するため、利用環境に適したhelperを用意してから`docker logout`と`docker login`を
+やり直す。
+
+```sh
+jq '{credsStore, credHelpers, auths}' ~/.docker/config.json
+
+docker logout <registry>
+docker login <registry>
+```

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,9 +1,7 @@
-# git / Docker の credential 管理
+# git credential の管理
 
-`git` と `docker login` はどちらもデフォルトでは認証情報をディスクに平文（または base64
-エンコードしているだけの実質平文）で残す。fnox で管理しているのはアプリ・API 用の secret で、
-git/Docker 自身の認証情報はそれぞれのツールが用意している credential helper 機構に任せる方が
-自然なため、fnox とは別に `chezmoi` 側でこの2つを管理している。
+fnox で管理しているのはアプリ・API用のsecretで、git自身の認証情報はgitのcredential helper
+機構に任せる方が自然なため、fnoxとは別にchezmoiで管理している。
 
 ## git: `credential.helper`
 
@@ -67,60 +65,3 @@ pass show git-credential-manager/<host> # GCM が保存したエントリを pas
 ```
 
 実際に HTTPS 認証が必要なホストへ一度アクセスし、2回目以降パスワードを聞かれなければ有効。
-
-## Docker: `credsStore`
-
-`docker login` のデフォルト動作は `~/.docker/config.json` に認証情報を base64 エンコードして
-書き込むだけで、暗号化はされていない（実質平文）。`credsStore` を設定すると、外部の credential
-helper バイナリに保存を委譲し、OS の keychain 等へ安全に保管できるようになる。
-
-`dot_docker/config.json`（mac のみ）:
-
-```json
-{
-  "credsStore": "desktop"
-}
-```
-
-`desktop` は Docker Desktop に同梱されている `docker-credential-desktop`（macOS Keychain と
-連携する credential helper）を指す。`.chezmoiignore` で mac 以外は `.docker/config.json` を
-デプロイ対象外にしている。`docker-credential-desktop` は Docker Desktop 前提のバイナリで、
-Linux/WSL2 の Docker Engine 環境には存在しないため。
-
-### Linux/WSL2 でも管理したくなったら
-
-Docker Desktop が無い環境では、別途 credential helper を用意して `credsStore` をそれに合わせる
-必要がある:
-
-- [`docker-credential-pass`](https://github.com/docker/docker-credential-helpers)
-  （GPG + `pass` ベース）
-- [`docker-credential-secretservice`](https://github.com/docker/docker-credential-helpers)
-  （GNOME Keyring / KDE Wallet 経由、Secret Service API 使用）
-
-現状このリポジトリでは未対応（必要になったら `.chezmoiignore` の除外を外し、対応する helper を
-`dot_config/mise/config.toml` に pin する形で追加する）。
-
-### 動作確認
-
-```sh
-cat ~/.docker/config.json
-# {"credsStore": "desktop"} になっていること（mac）
-
-docker login ghcr.io
-# ログイン後、ghcr.io の entry が "auths" に追加されていないこと
-# （credsStore 経由で Keychain 側に保存されているため。他レジストリの
-# 既存 auths エントリは対象外なので、ghcr.io だけを見る）
-jq '.auths["ghcr.io"]' ~/.docker/config.json
-# null が返ればOK（credsStore 経由で保存されている証拠）
-```
-
-## まとめ
-
-| 項目   | 何を使うか                                        | どこで管理                   | 対象プラットフォーム                       |
-| ------ | ------------------------------------------------- | ---------------------------- | ------------------------------------------ |
-| git    | `credential.helper`（osxkeychain / manager+pass） | `dot_config/git/config.tmpl` | 全プラットフォーム（内容は OS ごとに分岐） |
-| Docker | `credsStore`（desktop）                           | `dot_docker/config.json`     | mac のみ（`.chezmoiignore` で他は対象外）  |
-
-どちらも設定自体は chezmoi 管理下にあり `chezmoi apply` で自動反映されるが、WSL2/Linux の git は
-上記の `pass init` / `git-credential-manager configure` をマシンごとに一度だけ手動実行する必要が
-ある（age の bootstrap と同様、鍵/ストアの初期化はマシンローカルな一度きりの操作のため自動化していない）。

--- a/dot_docker/config.json
+++ b/dot_docker/config.json
@@ -1,3 +1,0 @@
-{
-  "credsStore": "desktop"
-}


### PR DESCRIPTION
## 概要

- `~/.docker/config.json`をdotfilesの管理対象から削除
- Docker設定を扱うchezmoi modifierも追加せず、Docker Desktopのローカル状態に一任
- 不要になった`.chezmoiignore`のDocker設定を削除
- credentialドキュメントには、dotfiles管理とは切り離してDockerのcredential store、`credsStore`、`credHelpers`、Linux向けhelper、確認・移行方法を記載

## 理由

`auths`、`currentContext`、`plugins`、`features`、`credsStore`を含むDocker設定はDocker Desktopや各マシンの状態として扱い、dotfiles側から変更しません。一方、安全なcredential保存方法を判断できるよう、一般的な仕組みと確認方法はドキュメントに残します。

## テスト

- `mise run lint:md`
- `mise run lint:json`
- `git diff --check`


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes Docker’s machine-local configuration from chezmoi management and updates the credential documentation accordingly.
- Deletes the managed `dot_docker/config.json` source.
- Removes the obsolete platform-specific ignore entry.
- Documents Docker credential configuration as locally owned while retaining managed Git credential guidance.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the previously reported modifier failures are no longer reachable and no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| dot_docker/config.json | Removes the repository-managed Docker credential-store configuration, eliminating both previously reported modifier paths. |
| .chezmoiignore | Removes the now-redundant non-macOS exclusion for the deleted Docker source. |
| docs/credentials.md | Updates credential guidance to distinguish managed Git settings from machine-local Docker configuration. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs(docker): retain credential storage ..."](https://github.com/ryo246912/dotfiles/commit/71ba1db92fb6df2f51bb6c841ba0b8ae0cd1d02d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55823449)</sub>

<!-- /greptile_comment -->