### PR TITLE
feat(navi): add grip browser preview cheat

### DIFF
--- a/dot_config/navi/cheats/other.cheat.md
+++ b/dot_config/navi/cheats/other.cheat.md
@@ -47,7 +47,7 @@ ffmpeg -i <input_file> -vf "fps=10" <input_file>.gif
 gh-md-toc <markdown_file> --insert --no-backup
 
 # grip : preview a Markdown file in the browser [-b:open in browser]
-grip -b <file>
+grip -b <markdown_file>
 
 # inkscape : convert from svg file to png file
 inkscape --export-filename="<output_file>.png" --export-width=<width> --export-height=<width> <input_file>

--- a/dot_config/navi/cheats/other.cheat.md
+++ b/dot_config/navi/cheats/other.cheat.md
@@ -46,6 +46,9 @@ ffmpeg -i <input_file> -vf "fps=10" <input_file>.gif
 # gh-md-toc : generate table of contents
 gh-md-toc <markdown_file> --insert --no-backup
 
+# grip : preview a Markdown file in the browser [-b:open in browser]
+grip -b <file>
+
 # inkscape : convert from svg file to png file
 inkscape --export-filename="<output_file>.png" --export-width=<width> --export-height=<width> <input_file>
 


### PR DESCRIPTION
## Summary
- add a navi cheat for previewing a Markdown file in the browser with `grip -b <file>`

## Testing
- `git diff --check`
- `navi 2.23.0 --version`

## Notes
- `dot_config/navi/**` is intentionally excluded from oxfmt by `.oxfmtrc.json`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `navi` cheat to preview Markdown in the browser with `grip -b <markdown_file>`, speeding up local doc review. Previously no Markdown preview cheat existed; now one is available with no side effects.

- Change is limited to `dot_config/navi/cheats/other.cheat.md` and remains excluded from formatting by `.oxfmtrc.json`.
- Reuses the existing Markdown file picker for consistency; no new picker definitions.
- Usage: `grip -b <markdown_file>`; requires `grip` to be installed.

<sup>Written for commit 6dcd5fc9d9c429daa705c3a9ed8bd56aa3c385fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 変更内容概要
既存のMarkdownファイル選択機能を使用するNaviチートを追加しました。`grip -b <markdown_file>`でMarkdownファイルをブラウザ表示します。

## 変更理由
Markdownファイルのブラウザプレビューを簡単に実行するためです。

## 確認した項目
- `git diff --check`
- `navi 2.23.0 --version`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a Navi cheat for opening a selected Markdown file in the browser with Grip.

- Adds `grip -b <markdown_file>` to the existing `other` cheat sheet.
- Reuses the cheat sheet’s existing Markdown-file placeholder.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| dot_config/navi/cheats/other.cheat.md | Adds a Grip browser-preview command using the file’s established Navi cheat syntax and existing Markdown placeholder. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(navi): reuse markdown file picker fo..."](https://github.com/ryo246912/dotfiles/commit/6dcd5fc9d9c429daa705c3a9ed8bd56aa3c385fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55828891)</sub>

<!-- /greptile_comment -->