### PR TITLE
feat: session-migrate の導入と利用ガイドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@
 # Setup
 
 - [setup](docs/setup.md)
+- [session-migrate（Claude Code / Codex のセッション引き継ぎ）](docs/session-migrate.md)

--- a/docs/session-migrate.md
+++ b/docs/session-migrate.md
@@ -1,0 +1,118 @@
+# session-migrate で Claude Code / Codex のセッションを引き継ぐ
+
+[session-migrate](https://github.com/xhluca/session-migrate) は、コーディングエージェントの
+ネイティブなセッション履歴を別のエージェントで再開できる形式へ変換する CLI です。
+この dotfiles では upstream が現在サポートする Linux（WSL2 を含む）に、mise の `pipx` backend で
+`session-migrate` 0.7.1 を導入します。`session-migrate` と短縮名 `smigrate` は同じコマンドです。
+
+> [!IMPORTANT]
+> セッション移行は同期ではなく、移行先に新しい独立セッションを作る操作です。移行元は変更されません。
+> 認証情報、hooks、MCP、権限・sandbox 設定などの実行環境設定は移行されないため、移行先 CLI は通常の方法で
+> あらかじめログイン・設定してください。
+
+## インストール
+
+chezmoi の反映後に Linux 用 mise 設定からインストールします。
+
+```bash
+chezmoi apply
+mise install
+smigrate --version
+```
+
+個別に導入し直す場合は次を実行します。
+
+```bash
+mise install pipx:session-migrate@0.7.1
+```
+
+upstream は Python 3.11 以上および Linux をサポート対象としています。macOS では現時点でこの dotfiles の
+自動インストール対象にしていません。
+
+## Claude Code から Codex へ引き継ぐ
+
+移行元セッションへの書き込みが止まってから、そのプロジェクトのディレクトリで実行します。
+
+```bash
+cd /path/to/project
+
+# セッションを検索する（UUID が分かっていればこの2行は不要）
+smigrate catalog refresh
+smigrate catalog search "セッション名のキーワード" --format claude
+
+# まず dry-run。UUID は検索結果の移行元 Claude セッション ID
+smigrate transfer CLAUDE_SESSION_UUID --from claude --to codex --cwd "$PWD" --dry-run
+
+# warnings と dropped_events を確認してから移行する
+smigrate transfer CLAUDE_SESSION_UUID --from claude --to codex --cwd "$PWD"
+```
+
+成功時の JSON に表示された新しい `session_id` を使い、**同じプロジェクトディレクトリ**で再開します。
+
+```bash
+codex resume NEW_CODEX_SESSION_UUID
+```
+
+## Codex から Claude Code へ引き継ぐ
+
+逆方向も同じ流れです。
+
+```bash
+cd /path/to/project
+
+smigrate catalog refresh
+smigrate catalog search "セッション名のキーワード" --format codex
+
+smigrate transfer CODEX_SESSION_UUID --from codex --to claude --cwd "$PWD" --dry-run
+smigrate transfer CODEX_SESSION_UUID --from codex --to claude --cwd "$PWD"
+```
+
+成功時の JSON に表示された新しい `session_id` で Claude Code を再開します。
+
+```bash
+claude --resume NEW_CLAUDE_SESSION_UUID
+```
+
+## タイトル検索が曖昧な場合
+
+同名セッションや active/archive の重複がある場合は、catalog の不透明な `CATALOG_ID` を指定すると
+物理的なセッションを一意に選べます。パスを出力するときは機密情報として扱ってください。
+
+```bash
+smigrate catalog refresh
+smigrate catalog search "キーワード" --format codex --include-paths
+smigrate transfer --catalog-id CATALOG_ID --to claude --cwd "$PWD" --dry-run
+smigrate transfer --catalog-id CATALOG_ID --to claude --cwd "$PWD"
+```
+
+Claude のプロジェクトパス表現が衝突する場合は、移行元の作業ディレクトリも明示します。
+
+```bash
+smigrate transfer CLAUDE_SESSION_UUID --from claude --source-cwd "$PWD" \
+  --to codex --cwd "$PWD" --dry-run
+```
+
+## 安全に移行するための確認事項
+
+- 最初に必ず `--dry-run` を実行し、出力の `warnings` と `dropped_events` を確認する。
+- tool call、画像、compaction summary などは両形式が対応する範囲だけ移行される。private/signed thinking は
+  移行されず、モデルや provider のメタデータも移行先の既定値になる。
+- `--dry-run` と本実行の間は移行元セッションを更新しない。厳密に同じ移行先 UUID を使いたい場合は、先に
+  UUID を生成し、両方のコマンドへ同じ `--session-id NEW_UUID` を渡す。
+- 上書き用の `--force` はない。衝突時は新しい UUID を使い、移行先に作成済みの可能性があるというエラーでは
+  先に対象 CLI のセッション一覧を確認する。
+- manifest や catalog に会話本文は保存されないが、タイトル、パス、作業ディレクトリ、UUID、時刻、hash は
+  機密になり得る。会話内の秘密情報は redaction されず、対応するメッセージ等と一緒にコピーされる。
+- Codex の paginated/history-base セッションと Claude の sidechain/subagent セッションは移行対象外。
+  Claude の sidechain の場合は親セッションを移行する。
+
+構造だけを確認するときは `inspect` が利用できます（会話本文は表示しません）。
+
+```bash
+smigrate inspect /path/to/session.jsonl --json
+```
+
+全オプションと対応状況は upstream の
+[CLI reference](https://github.com/xhluca/session-migrate/blob/main/docs/cli-reference.md)、
+[format compatibility](https://github.com/xhluca/session-migrate/blob/main/docs/format-compatibility.md)、
+[troubleshooting](https://github.com/xhluca/session-migrate/blob/main/docs/troubleshooting.md) を参照してください。

--- a/dot_config/mise/config.linux.toml
+++ b/dot_config/mise/config.linux.toml
@@ -2,7 +2,7 @@
 "github:vorojar/md-preview" = { version = "1.4.0", bin = "md-preview" }
 # git credential.helper (dot_config/git/config.tmpl) 用。WSL2/Linux 専用（macOS は osxkeychain）。
 "github:git-ecosystem/git-credential-manager" = "2.9.1"
-"pipx:session-migrate" = "0.7.1"
+"pipx:session-migrate"                        = "0.7.1"
 
 [bootstrap.packages]
 "apt:colordiff" = "latest"

--- a/dot_config/mise/config.linux.toml
+++ b/dot_config/mise/config.linux.toml
@@ -2,6 +2,7 @@
 "github:vorojar/md-preview" = { version = "1.4.0", bin = "md-preview" }
 # git credential.helper (dot_config/git/config.tmpl) 用。WSL2/Linux 専用（macOS は osxkeychain）。
 "github:git-ecosystem/git-credential-manager" = "2.9.1"
+"pipx:session-migrate" = "0.7.1"
 
 [bootstrap.packages]
 "apt:colordiff" = "latest"


### PR DESCRIPTION
## Summary
- Linux/WSL2 の mise 設定に session-migrate 0.7.1 を追加
- Claude Code と Codex 間の双方向セッション引き継ぎ手順を追加
- dry-run、catalog 検索、制約・セキュリティ上の注意点を文書化
- README からガイドへのリンクを追加

## Testing
- `git diff --check`
- Python `tomllib` で mise TOML 設定を検証
- `mise exec npm:oxfmt@0.59.0 -- oxfmt --check README.md docs/session-migrate.md`
- `mise exec pipx:session-migrate@0.7.1 -- smigrate --version`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Linux/WSL2 の mise 環境に `session-migrate` 0.7.1 を追加し、Claude Code ↔ Codex のセッション引き継ぎガイドを新規追加。これにより、dry-run と catalog 検索付きで安全に双方向移行できるようにした。Linux の mise 設定を整形（機能差なし）も含む。

- 必要な対応
  - Linux/WSL2 で `chezmoi apply` 後に `mise install` を実行し、`smigrate --version` で導入確認（macOS は対象外）。
  - セッション移行時は必ず `smigrate transfer ... --dry-run` を先に実行し、warnings と dropped_events を確認してから本実行。

<sup>Written for commit 89b0a99a7e78c276bf0edd83535a70053db3877c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更内容概要

`session-migrate` 0.7.1 を Linux／WSL2 向けの mise 設定に追加しました。  
Claude Code と Codex のセッション移行手順を新規ガイドに追加しました。  
README にガイドへのリンクを追加しました。

## 変更理由

Claude Code と Codex の間でセッションを双方向に移行できるようにするためです。  
ガイドでは、ドライラン、カタログ検索、`CATALOG_ID` の指定、制約、安全確認、`inspect` コマンドを説明しています。

## 確認した項目

- `git diff --check`
- Python `tomllib` による mise TOML の検証
- `oxfmt` による README とガイドのフォーマット確認
- インストール済み `session-migrate` のバージョン確認

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds session-migrate 0.7.1 to the Linux/WSL2 mise toolset and documents safe session transfer workflows between Claude Code and Codex.
- Adds the version-pinned pipx package to the Linux mise configuration.
- Documents installation, dry runs, catalog lookup, bidirectional transfer, constraints, and security considerations.
- Links the new guide from the README.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified.

The Linux mise integration follows existing pipx conventions, and the documentation consistently describes the newly introduced installation and session-transfer workflow without an established incorrect command or broken repository contract.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| dot_config/mise/config.linux.toml | Adds a version-pinned session-migrate package using the repository’s established mise pipx backend pattern. |
| docs/session-migrate.md | Adds a comprehensive usage guide covering installation, transfer commands, validation, limitations, and sensitive-data handling. |
| README.md | Adds a working documentation link to the new session migration guide. |

</details>

<sub>Reviews (1): Last reviewed commit: ["style: format Linux mise config"](https://github.com/ryo246912/dotfiles/commit/89b0a99a7e78c276bf0edd83535a70053db3877c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56428585)</sub>

<!-- /greptile_comment -->