### PR TITLE
feat(fnox): add Bitwarden age-encrypted local sync

### DIFF
--- a/docs/fnox.md
+++ b/docs/fnox.md
@@ -220,41 +220,42 @@ age の秘密鍵は PC ごとに別々に生成するのが基本です（同じ
   DATABASE_URL = { provider = "bws", value = "DATABASE_URL" }
   ```
 
-## 1Password の値を age でローカルキャッシュする
+## Bitwarden の値を age でローカルキャッシュする
 
-これは `.env.local` を生成する仕組みではありません。commit する `fnox.toml` には 1Password の
+これは `.env.local` を生成する仕組みではありません。commit する `fnox.toml` には Bitwarden の
 参照先だけを書き、`fnox sync` が取得した値を age で暗号化して、個人用の
-`fnox.local.toml` に保存します。`fnox.local.toml` は暗号化済みですが、端末ごとの cache であり
+`fnox.local.toml`（`.fnox.toml` を使う場合は `.fnox.local.toml`）に保存します。つまり、値は
+local override の `sync` フィールドに暗号文として書き出され、以後は Bitwarden へ接続せずに
+ローカルで復号できます。local override は暗号化済みですが、端末ごとの cache であり
 source of truth ではないため **gitignore したまま運用**します。GitHub に同期したい暗号文は、team/CI
 全員を recipient に含めた別の age provider で `fnox.toml` に保存してください。
 
-この dotfiles では 1Password CLI (`op`) と個人用の `sync-age` provider をセットアップし、次の
-global mise task を用意しています。初回実行時は `fnox.local.toml` を project の `.gitignore` に
-自動追加します。
+この dotfiles では既存の Bitwarden Secrets Manager (`bws`) provider と個人用の `sync-age` providerを
+使う global mise task を用意しています。初回実行時は両方の local override 名を project の
+`.gitignore` に自動追加します。既に git 管理されている場合は、安全のため同期前に停止します。
 
 ```toml
 # project の fnox.toml（commit する）
-[providers.op]
-type  = "1password"
-vault = "Development" # project ごとに別 vault を指定できる
+[providers.bws]
+type       = "bitwarden-sm"
+project_id = "xxx" # repository/environment ごとに Secrets Manager project を分けられる
 
 [secrets]
-DATABASE_URL = { provider = "op", value = "Database/url" }
+DATABASE_URL = { provider = "bws", value = "DATABASE_URL" }
 ```
 
 ```sh
-# 1Password app 連携または service account で op を認証してから実行
-eval "$(op signin)"
+# BWS_ACCESS_TOKEN は global fnox config の age 暗号文から shell 起動時に設定される
 mise run fnox:sync
 
-# 1Password 側で値をローテーションした後は cache を強制更新
+# Bitwarden 側で値をローテーションした後は cache を強制更新
 mise run fnox:sync -- --force
 
 # cache された値を環境変数として対象 process だけに渡す
 fnox exec -- your-command
 ```
 
-新しい secret は、まず 1Password app / `op item create` で対象 vault に保存し、その参照を
-`fnox.toml` の `[secrets]` に追加してから task を実行します。secret をコマンド引数へ直書きすると
-shell history や process list に残るため、`op item create` の対話入力または JSON template を使って
-ください。
+新しい secret は、まず Bitwarden Secrets Manager の対象 project に保存し、その secret 名または ID の
+参照を `fnox.toml` の `[secrets]` に追加してから task を実行します。Password Manager の vault を使う
+`bitwarden` (`bw`) provider ではなく、セッション切れのない machine account 向けの
+`bitwarden-sm` (`bws`) provider をこの task の対象にしています。

--- a/docs/fnox.md
+++ b/docs/fnox.md
@@ -219,3 +219,42 @@ age の秘密鍵は PC ごとに別々に生成するのが基本です（同じ
   [secrets]
   DATABASE_URL = { provider = "bws", value = "DATABASE_URL" }
   ```
+
+## 1Password の値を age でローカルキャッシュする
+
+これは `.env.local` を生成する仕組みではありません。commit する `fnox.toml` には 1Password の
+参照先だけを書き、`fnox sync` が取得した値を age で暗号化して、個人用の
+`fnox.local.toml` に保存します。`fnox.local.toml` は暗号化済みですが、端末ごとの cache であり
+source of truth ではないため **gitignore したまま運用**します。GitHub に同期したい暗号文は、team/CI
+全員を recipient に含めた別の age provider で `fnox.toml` に保存してください。
+
+この dotfiles では 1Password CLI (`op`) と個人用の `sync-age` provider をセットアップし、次の
+global mise task を用意しています。初回実行時は `fnox.local.toml` を project の `.gitignore` に
+自動追加します。
+
+```toml
+# project の fnox.toml（commit する）
+[providers.op]
+type  = "1password"
+vault = "Development" # project ごとに別 vault を指定できる
+
+[secrets]
+DATABASE_URL = { provider = "op", value = "Database/url" }
+```
+
+```sh
+# 1Password app 連携または service account で op を認証してから実行
+eval "$(op signin)"
+mise run fnox:sync
+
+# 1Password 側で値をローテーションした後は cache を強制更新
+mise run fnox:sync -- --force
+
+# cache された値を環境変数として対象 process だけに渡す
+fnox exec -- your-command
+```
+
+新しい secret は、まず 1Password app / `op item create` で対象 vault に保存し、その参照を
+`fnox.toml` の `[secrets]` に追加してから task を実行します。secret をコマンド引数へ直書きすると
+shell history や process list に残るため、`op item create` の対話入力または JSON template を使って
+ください。

--- a/docs/fnox.md
+++ b/docs/fnox.md
@@ -230,7 +230,7 @@ local override の `sync` フィールドに暗号文として書き出され、
 source of truth ではないため **gitignore したまま運用**します。GitHub に同期したい暗号文は、team/CI
 全員を recipient に含めた別の age provider で `fnox.toml` に保存してください。
 
-この dotfiles では既存の Bitwarden Secrets Manager (`bws`) provider と個人用の `sync-age` providerを
+この dotfiles では既存の Bitwarden Secrets Manager (`bws`) provider と個人用の `sync-age` provider を
 使う global mise task を用意しています。初回実行時は両方の local override 名を project の
 `.gitignore` に自動追加します。既に git 管理されている場合は、安全のため同期前に停止します。
 

--- a/dot_config/fnox/config.toml
+++ b/dot_config/fnox/config.toml
@@ -19,6 +19,7 @@ type = "age"
 
 # リモート provider の値を fnox.local.toml へキャッシュするための個人用 provider。
 # project が定義する age provider と名前を分け、設定 merge 時の上書きを避ける。
+# age provider と同じ端末一覧を意図しているため、端末追加時は両方の recipients を更新する。
 [providers.sync-age]
 key_file = "~/.config/fnox/age.txt"
 recipients = [

--- a/dot_config/fnox/config.toml
+++ b/dot_config/fnox/config.toml
@@ -17,6 +17,16 @@ recipients = [
 ]
 type = "age"
 
+# リモート provider の値を fnox.local.toml へキャッシュするための個人用 provider。
+# project が定義する age provider と名前を分け、設定 merge 時の上書きを避ける。
+[providers.sync-age]
+key_file = "~/.config/fnox/age.txt"
+recipients = [
+    "age1k9zxqxufy599csnlkfwq2efxnscju4ek3ftqpvx55r9re38akers6zrq2z", # mac-private
+    "age184vvj44q3x0jn8j5xlrzlecnd4ae8nw68e0mj3eq8uu0z22t5dvs3g4enu", # mac-work2
+]
+type = "age"
+
 [secrets]
 BWS_ACCESS_TOKEN  = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXSTBOT3U1bm4vWExyVTFYWEVxa3VvOWphdDFFR29JUnFIeitjU3owMVVNCjlyV3haZFQ5Z20vRUo3b0lyai9hcklXcG5ScmhzdlVkY1N1TlMxT3RCMlUKLT4gWDI1NTE5IFJBcGpVWTJFQjg1T1l0TXBTNUg0NloxcU1LS0hVcUZ3c2VIRFhCbE5wQzAKVHJLVENPU0hSbzlSU3AvYzFHVXVFOXB2QTVYcGRHQmc3U0d5L1dSYTBNSQotPiBtP0YtZ3JlYXNlIGIkMXUrdUVnIFs7XyAwCmI0K0x5WWtTVFRNCi0tLSAzSlNDTUxoVWdSM241aTA5R3RTL2ltNVJFL3crVWFNd2c2bkVRdmFKQlYwCuUS6hKg5oHiz2GwsDRHTc/2mFXhqnJr1vXTqklhqe5NQv6RE6VQdItzkuJK1gEOn2ROULemR54g4daNeyb4roUONkqQ+PffaUsMYQFrIH63qdliK6Hpy1TrSIEooYRlr9QiRQ439rrSEsJC9sdSZc0klSgyhDnFzrE16RpuBA==" }
 CZ_OPENAI_API_KEY = { provider = "bws", value = "GitHub PAT(cz-git)" }

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -9,7 +9,6 @@ ASDF_FFMPEG_ENABLE = "gpl libx264"
 # ffmpeg                                                      = "latest"
 # ruby                                                        = "3.3.1"
 
-"aqua:1password/cli"                                        = "2.32.0"
 "aqua:BurntSushi/ripgrep"                                   = "15.2.0"
 "aqua:FiloSottile/age"                                      = "1.3.1"
 "aqua:Wilfred/difftastic"                                   = "0.70.0"

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -9,6 +9,7 @@ ASDF_FFMPEG_ENABLE = "gpl libx264"
 # ffmpeg                                                      = "latest"
 # ruby                                                        = "3.3.1"
 
+"aqua:1password/cli"                                        = "2.32.0"
 "aqua:BurntSushi/ripgrep"                                   = "15.2.0"
 "aqua:FiloSottile/age"                                      = "1.3.1"
 "aqua:Wilfred/difftastic"                                   = "0.70.0"

--- a/dot_config/mise/tasks/fnox.toml
+++ b/dot_config/mise/tasks/fnox.toml
@@ -1,5 +1,7 @@
 ["fnox:sync"]
-description = "Cache remote project secrets locally with age encryption"
+description = "Cache Bitwarden project secrets locally with age encryption"
+dir = "{{cwd}}"
+interactive = true
 run = '''
 set -eu
 
@@ -8,27 +10,26 @@ if [ ! -f fnox.toml ] && [ ! -f .fnox.toml ]; then
   exit 1
 fi
 
-# fnox.local.toml は暗号化済みでも個人用 cache なので、誤って commit しない。
-if git rev-parse --is-inside-work-tree >/dev/null 2>&1 && ! git check-ignore -q fnox.local.toml; then
-  printf '\n# fnox personal encrypted cache\nfnox.local.toml\n' >> .gitignore
-  echo ".gitignore に fnox.local.toml を追加しました。"
-fi
-
-if ! command -v op >/dev/null 2>&1; then
-  echo "1Password CLI (op) がありません。mise install を実行してください。" >&2
-  exit 1
-fi
-
 if ! command -v fnox >/dev/null 2>&1; then
   echo "fnox がありません。mise install を実行してください。" >&2
   exit 1
 fi
 
-if ! op whoami >/dev/null 2>&1; then
-  echo "1Password CLI にサインインしてください（例: eval \"$(op signin)\"）。" >&2
-  exit 1
+# local override は暗号化済みでも個人用 cache なので、誤って commit しない。
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  for cache_file in fnox.local.toml .fnox.local.toml; do
+    if git ls-files --error-unmatch -- "$cache_file" >/dev/null 2>&1; then
+      echo "$cache_file は既に git 管理されています。git rm --cached -- $cache_file を実行してから再実行してください。" >&2
+      exit 1
+    fi
+    if ! git check-ignore -q -- "$cache_file"; then
+      printf '%s\n' "$cache_file" >> .gitignore
+      echo ".gitignore に $cache_file を追加しました。"
+    fi
+  done
 fi
 
-fnox sync --provider sync-age --local-file "$@"
+# bws provider から取得した値だけを個人用 age provider で暗号化する。
+fnox sync --source bws --provider sync-age --local-file "$@"
 '''
 shell = "bash -c"

--- a/dot_config/mise/tasks/fnox.toml
+++ b/dot_config/mise/tasks/fnox.toml
@@ -1,0 +1,34 @@
+["fnox:sync"]
+description = "Cache remote project secrets locally with age encryption"
+run = '''
+set -eu
+
+if [ ! -f fnox.toml ] && [ ! -f .fnox.toml ]; then
+  echo "fnox.toml または .fnox.toml がありません。先に remote provider と secrets を定義してください。" >&2
+  exit 1
+fi
+
+# fnox.local.toml は暗号化済みでも個人用 cache なので、誤って commit しない。
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1 && ! git check-ignore -q fnox.local.toml; then
+  printf '\n# fnox personal encrypted cache\nfnox.local.toml\n' >> .gitignore
+  echo ".gitignore に fnox.local.toml を追加しました。"
+fi
+
+if ! command -v op >/dev/null 2>&1; then
+  echo "1Password CLI (op) がありません。mise install を実行してください。" >&2
+  exit 1
+fi
+
+if ! command -v fnox >/dev/null 2>&1; then
+  echo "fnox がありません。mise install を実行してください。" >&2
+  exit 1
+fi
+
+if ! op whoami >/dev/null 2>&1; then
+  echo "1Password CLI にサインインしてください（例: eval \"$(op signin)\"）。" >&2
+  exit 1
+fi
+
+fnox sync --provider sync-age --local-file "$@"
+'''
+shell = "bash -c"


### PR DESCRIPTION
## Summary
- add a dedicated `sync-age` provider for machine-local encrypted caches
- add a global `fnox:sync` mise task that syncs Bitwarden Secrets Manager values into `fnox.local.toml`/`.fnox.local.toml`
- prevent either local override from being committed, including aborting if already tracked
- document that the result is an age-encrypted local override cache, not `.env.local`

## Testing
- `git diff --check`
- parsed changed TOML files with Python `tomllib`
- `bash -n` on the task script
- exercised the task in a temporary Git repository with a stub `fnox` executable

## Notes
- Full local mise validation is limited because the environment mise version is older than this repository minimum.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an age-backed provider and a global mise task for caching Bitwarden Secrets Manager values in fnox local overrides.

- Defines the dedicated `sync-age` provider.
- Adds synchronization, tracked-file checks, and Git ignore management for both supported local override names.
- Documents cache creation, rotation, and usage.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until synchronization performed before Git initialization also leaves the generated local cache excluded from future commits.

The task skips all ignore protection outside an existing Git worktree but still generates the machine-local override, allowing that cache to become committable after the directory is subsequently initialized as a repository.

**Files Needing Attention:** dot_config/mise/tasks/fnox.toml

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| dot_config/mise/tasks/fnox.toml | Adds the synchronization task and Git safeguards, but skips cache exclusion when synchronization occurs before repository initialization. |
| dot_config/fnox/config.toml | Adds a distinct age provider for encrypting machine-local synchronized values. |
| docs/fnox.md | Documents the Bitwarden-to-age local-cache workflow and both supported override filenames. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ryo246912%2Fdotfiles%20PR%20%231350%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ryo246912%2Fdotfiles&pr=1350&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Adot_config%2Fmise%2Ftasks%2Ffnox.toml%3A19%0A**Pre-Git%20cache%20remains%20unignored**%0A%0AWhen%20this%20task%20runs%20before%20the%20project%20directory%20is%20initialized%20as%20a%20Git%20repository%2C%20%60git%20rev-parse%60%20fails%20and%20skips%20all%20ignore%20protection%2C%20but%20%60fnox%20sync%20--local-file%60%20still%20generates%20the%20machine-local%20override.%20A%20later%20%60git%20init%60%20therefore%20leaves%20%60fnox.local.toml%60%20or%20%60.fnox.local.toml%60%20available%20to%20add%20and%20commit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ryo246912%2Fdotfiles&pr=1350&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ryo246912%2Fdotfiles%22%20on%20the%20existing%20branch%20%22feat%2Ffnox-1password-sync%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ffnox-1password-sync%22.%0A%0A%23%23%23%20Issue%201%0Adot_config%2Fmise%2Ftasks%2Ffnox.toml%3A19%0A**Pre-Git%20cache%20remains%20unignored**%0A%0AWhen%20this%20task%20runs%20before%20the%20project%20directory%20is%20initialized%20as%20a%20Git%20repository%2C%20%60git%20rev-parse%60%20fails%20and%20skips%20all%20ignore%20protection%2C%20but%20%60fnox%20sync%20--local-file%60%20still%20generates%20the%20machine-local%20override.%20A%20later%20%60git%20init%60%20therefore%20leaves%20%60fnox.local.toml%60%20or%20%60.fnox.local.toml%60%20available%20to%20add%20and%20commit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ryo246912%2Fdotfiles&pr=1350&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["docs(fnox): clarify Bitwarden cache work..."](https://github.com/ryo246912/dotfiles/commit/ebc7beff41c360e8be9058d7e38f305d32b3a2fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56459236)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->