### PR TITLE
fix(tmux): resize zoomed panes for active clients

### DIFF
--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -4,6 +4,10 @@ set -g mouse on
 bind -T edit-mode-vi WheelUpPane send-keys -X scroll-up
 bind -T edit-mode-vi WheelDownPane send-keys -X scroll-down
 
+# 複数クライアント接続時も、現在表示中のウィンドウに合わせてサイズを再計算する
+# エージェント用クライアントの小さいサイズに固定され、zoom後も再描画されない問題を防ぐ
+setw -g aggressive-resize on
+
 # スクロール可能な行数を2000行にする
 set -g history-limit 2000
 


### PR DESCRIPTION
## Summary
- enable tmux aggressive window resizing when multiple clients are attached
- prevent agent clients with smaller dimensions from constraining a pane after zooming

## Testing
- `git diff --check`
- tmux config runtime check could not run because tmux is not installed in the container

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resize zoomed panes to the active client in multi-client `tmux` sessions by enabling aggressive resize. Previously the smallest attached client fixed window size and zoomed panes did not redraw; now panes resize and redraw to the active client’s dimensions.

**Rollout**
- Reload the config in existing sessions to apply: run `tmux source-file ~/.tmux.conf` or restart `tmux`.

<sup>Written for commit 94c41ad29157487c20bd4845aeca54553565f03d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryo246912/dotfiles/pull/1353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds tmux aggressive window resizing so windows follow the dimensions of clients actively displaying them, preventing smaller agent clients from constraining panes after zooming.
- Enables `aggressive-resize` globally for tmux windows.
- Documents the intended multi-client and zoom-redraw behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the focused tmux option change matches the stated multi-client resizing behavior and no actionable failure was identified.

The new global window option is valid tmux configuration and directly targets active-client window sizing without changing bindings, persisted state, or security boundaries.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| dot_config/tmux/tmux.conf | Enables tmux aggressive resizing globally; no concrete correctness or configuration issue was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tmux): resize zoomed panes for activ..."](https://github.com/ryo246912/dotfiles/commit/94c41ad29157487c20bd4845aeca54553565f03d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56494207)</sub>

**Context used:**

- Knowledge Base — [Editor and terminal experience](https://app.greptile.com/ryo/-/custom-context/knowledge-base/ryo246912/dotfiles/-/docs/editor-and-terminal-experience.md)
- Knowledge Base — [Terminal and navigation configuration](https://app.greptile.com/ryo/-/custom-context/knowledge-base/ryo246912/dotfiles/-/docs/terminal-and-navigation-configuration.md)

<!-- /greptile_comment -->